### PR TITLE
Add CI checks

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -2,20 +2,18 @@ name: Backend CI
 
 on:
   pull_request:
-    paths:
-      - "backend/**"
-      - ".github/workflows/backend-ci.yml"
   push:
     branches:
       - main
-    paths:
-      - "backend/**"
-      - ".github/workflows/backend-ci.yml"
 
 jobs:
   backend-checks:
-    name: Backend checks
+    name: Backend lint and tests
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: backend
 
     steps:
       - name: Check out repository
@@ -24,14 +22,19 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
 
-      - name: Validate backend scaffold
+      - name: Install backend dependencies
         run: |
-          python -m compileall backend
-          if [ -s backend/requirements.txt ]; then
-            python -m pip install --upgrade pip
-            python -m pip install -r backend/requirements.txt
-          else
-            echo "backend/requirements.txt is empty; dependency install skipped."
-          fi
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run backend lint
+        run: ruff check .
+
+      - name: Run backend tests
+        run: pytest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,33 +2,21 @@ name: Docker Build
 
 on:
   pull_request:
-    paths:
-      - "backend/Dockerfile"
-      - "frontend/Dockerfile"
-      - "docker-compose.yml"
-      - ".github/workflows/docker-build.yml"
   push:
     branches:
       - main
-    paths:
-      - "backend/Dockerfile"
-      - "frontend/Dockerfile"
-      - "docker-compose.yml"
-      - ".github/workflows/docker-build.yml"
 
 jobs:
   docker-validation:
-    name: Docker validation
+    name: Docker Compose build
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Validate Docker scaffold
-        run: |
-          if [ -s docker-compose.yml ]; then
-            docker compose config
-          else
-            echo "docker-compose.yml is empty; Docker Compose validation skipped."
-          fi
+      - name: Validate Docker Compose configuration
+        run: docker compose config
+
+      - name: Build application images
+        run: docker compose build backend frontend

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -2,20 +2,18 @@ name: Frontend CI
 
 on:
   pull_request:
-    paths:
-      - "frontend/**"
-      - ".github/workflows/frontend-ci.yml"
   push:
     branches:
       - main
-    paths:
-      - "frontend/**"
-      - ".github/workflows/frontend-ci.yml"
 
 jobs:
   frontend-checks:
-    name: Frontend checks
+    name: Frontend build
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
 
     steps:
       - name: Check out repository
@@ -25,12 +23,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
 
-      - name: Validate frontend scaffold
+      - name: Install frontend dependencies
         run: |
-          if [ -s frontend/package.json ]; then
-            npm --prefix frontend install
-            npm --prefix frontend run build --if-present
+          if [ -f package-lock.json ]; then
+            npm ci
           else
-            echo "frontend/package.json is empty; npm checks skipped."
+            npm install
           fi
+
+      - name: Build frontend
+        run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added GitHub Actions CI checks for backend linting/tests, frontend builds, and Docker Compose image builds.
+- Added minimal backend pytest coverage for app creation and the `/api/health` endpoint.
 - Added a runnable Docker Compose local development stack for Flask, Vue/Vite, PostgreSQL, MinIO, and a future Keycloak profile.
 - Added a Flask backend app with environment-based configuration, SQLAlchemy, Flask-Migrate, PostgreSQL support, CORS, and `/api/health`.
 - Added a Vue/Vite dashboard that reads the backend API base URL from environment configuration.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ Docker Compose is the recommended way to run the local SeniorMate stack. It star
 
 Keycloak is included as an optional Compose profile for future authentication work. It is not required for local development yet.
 
+## CI Checks
+
+GitHub Actions runs basic checks on pull requests and pushes to `main`:
+
+- Backend CI installs Python dependencies, runs Ruff, and executes pytest.
+- Frontend CI installs Node dependencies from the lockfile and runs the Vite build.
+- Docker Build validates the Compose file and builds the backend and frontend images without pushing them.
+
 ## Development Workflow
 
 - Start new work from an up-to-date `main` branch.

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,29 @@
+from app import create_app
+from app.config import Config
+from app.extensions import db
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite+pysqlite:///:memory:"
+    CORS_ORIGINS = ["http://localhost:5173"]
+
+
+def test_create_app():
+    app = create_app(TestConfig)
+
+    assert app is not None
+    assert app.config["TESTING"] is True
+
+
+def test_health_endpoint_returns_success():
+    app = create_app(TestConfig)
+
+    with app.app_context():
+        db.create_all()
+
+    response = app.test_client().get("/api/health")
+
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "ok"
+    assert response.get_json()["database"] == "ok"

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -129,3 +129,13 @@ The main app remains usable without login for now.
 - Run the relevant frontend checks.
 - Run Docker validation when service definitions change.
 - Update `CHANGELOG.md` for notable changes.
+
+## CI Checks
+
+Pull requests and pushes to `main` run GitHub Actions checks for:
+
+- Backend linting and pytest coverage.
+- Frontend dependency installation and production build.
+- Docker Compose configuration and backend/frontend image builds.
+
+The workflows do not require private secrets and do not push Docker images.


### PR DESCRIPTION
# Summary

- Updates Backend CI to install Python dependencies, cache pip packages, run Ruff, and run pytest.
- Updates Frontend CI to install Node dependencies with `npm ci` when the lockfile exists and run the Vite build.
- Updates Docker Build CI to validate Docker Compose and build backend/frontend images without pushing them.
- Adds minimal backend pytest coverage for app creation and `/api/health`.
- Documents the PR CI checks and updates the changelog.

## Related Issue / Task

- Feature: 02-ci-checks

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [x] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `git checkout main`
- `git pull origin main`
- Deleted stale local `feature/01-local-development-setup` branch after it was merged into `main`.
- `docker-compose config`
- `python3 -m compileall -q backend`
- `npm ci`
- `npm run build`
- `docker-compose exec -T backend ruff check .`
- `docker-compose exec -T backend pytest`
- `docker-compose build backend frontend`
- `git diff --check`
- Secret-pattern scan found no real credentials or key material.

## Screenshots

N/A

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.