### PR TITLE
Add Patient Management API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added the Patient Management API with database model, migration, CRUD endpoints, validation, tests, and API documentation.
 - Prepared GitHub Actions workflows for the Node.js 24 runtime by updating action versions and enabling Node.js 24 compatibility testing.
 - Added GitHub Actions CI checks for backend linting/tests, frontend builds, and Docker Compose image builds.
 - Added minimal backend pytest coverage for app creation and the `/api/health` endpoint.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -4,6 +4,8 @@ from sqlalchemy import text
 
 from app.config import Config
 from app.extensions import db, migrate
+from app.models import Patient as Patient
+from app.routes.patients import patients_bp
 
 
 def create_app(config_object=Config):
@@ -13,6 +15,7 @@ def create_app(config_object=Config):
 
     db.init_app(app)
     migrate.init_app(app, db)
+    app.register_blueprint(patients_bp)
 
     @app.get("/api/health")
     def health():

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,4 @@
+from app.models.patient import Patient
+
+
+__all__ = ["Patient"]

--- a/backend/app/models/patient.py
+++ b/backend/app/models/patient.py
@@ -1,0 +1,56 @@
+from datetime import UTC, datetime
+
+from sqlalchemy import CheckConstraint
+
+from app.extensions import db
+
+
+class Patient(db.Model):
+    __tablename__ = "patients"
+    __table_args__ = (
+        CheckConstraint("status IN ('active', 'inactive')", name="ck_patients_status"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    first_name = db.Column(db.String(100), nullable=False)
+    last_name = db.Column(db.String(100), nullable=False)
+    date_of_birth = db.Column(db.Date, nullable=True)
+    gender = db.Column(db.String(50), nullable=True)
+    phone = db.Column(db.String(50), nullable=True)
+    email = db.Column(db.String(255), nullable=True)
+    address = db.Column(db.Text, nullable=True)
+    emergency_contact_name = db.Column(db.String(200), nullable=True)
+    emergency_contact_phone = db.Column(db.String(50), nullable=True)
+    diagnosis_summary = db.Column(db.Text, nullable=True)
+    status = db.Column(db.String(20), nullable=False, default="active")
+    created_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "first_name": self.first_name,
+            "last_name": self.last_name,
+            "date_of_birth": self.date_of_birth.isoformat()
+            if self.date_of_birth
+            else None,
+            "gender": self.gender,
+            "phone": self.phone,
+            "email": self.email,
+            "address": self.address,
+            "emergency_contact_name": self.emergency_contact_name,
+            "emergency_contact_phone": self.emergency_contact_phone,
+            "diagnosis_summary": self.diagnosis_summary,
+            "status": self.status,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,0 +1,1 @@
+"""Application route blueprints."""

--- a/backend/app/routes/patients.py
+++ b/backend/app/routes/patients.py
@@ -1,0 +1,140 @@
+from datetime import date
+
+from flask import Blueprint, jsonify, request
+
+from app.extensions import db
+from app.models import Patient
+
+
+patients_bp = Blueprint("patients", __name__, url_prefix="/api/patients")
+
+PATIENT_FIELDS = {
+    "first_name",
+    "last_name",
+    "date_of_birth",
+    "gender",
+    "phone",
+    "email",
+    "address",
+    "emergency_contact_name",
+    "emergency_contact_phone",
+    "diagnosis_summary",
+    "status",
+}
+VALID_STATUSES = {"active", "inactive"}
+
+
+def success_response(data, message, status_code=200):
+    return jsonify({"data": data, "message": message}), status_code
+
+
+def error_response(message, status_code=400, errors=None):
+    payload = {"message": message}
+
+    if errors:
+        payload["errors"] = errors
+
+    return jsonify(payload), status_code
+
+
+def parse_patient_payload(payload, partial=False):
+    if not isinstance(payload, dict):
+        return None, {"request": "JSON body is required."}
+
+    data = {}
+    errors = {}
+
+    for field in PATIENT_FIELDS:
+        if field in payload:
+            data[field] = payload[field]
+
+    for field in ("first_name", "last_name"):
+        value = data.get(field)
+        if not partial or field in data:
+            if not isinstance(value, str) or not value.strip():
+                errors[field] = "This field is required."
+            elif field in data:
+                data[field] = value.strip()
+
+    if "status" not in data and not partial:
+        data["status"] = "active"
+
+    if "status" in data and data["status"] not in VALID_STATUSES:
+        errors["status"] = "Status must be active or inactive."
+
+    if "date_of_birth" in data and data["date_of_birth"]:
+        try:
+            data["date_of_birth"] = date.fromisoformat(data["date_of_birth"])
+        except (TypeError, ValueError):
+            errors["date_of_birth"] = "Use ISO date format YYYY-MM-DD."
+    elif "date_of_birth" in data:
+        data["date_of_birth"] = None
+
+    return data, errors
+
+
+@patients_bp.get("")
+def list_patients():
+    patients = Patient.query.order_by(Patient.id.asc()).all()
+
+    return success_response(
+        [patient.to_dict() for patient in patients],
+        "Patients retrieved successfully",
+    )
+
+
+@patients_bp.get("/<int:patient_id>")
+def get_patient(patient_id):
+    patient = db.session.get(Patient, patient_id)
+
+    if patient is None:
+        return error_response("Patient not found", 404)
+
+    return success_response(patient.to_dict(), "Patient retrieved successfully")
+
+
+@patients_bp.post("")
+def create_patient():
+    data, errors = parse_patient_payload(request.get_json(silent=True))
+
+    if errors:
+        return error_response("Invalid patient data", 400, errors)
+
+    patient = Patient(**data)
+    db.session.add(patient)
+    db.session.commit()
+
+    return success_response(patient.to_dict(), "Patient created successfully", 201)
+
+
+@patients_bp.put("/<int:patient_id>")
+def update_patient(patient_id):
+    patient = db.session.get(Patient, patient_id)
+
+    if patient is None:
+        return error_response("Patient not found", 404)
+
+    data, errors = parse_patient_payload(request.get_json(silent=True), partial=True)
+
+    if errors:
+        return error_response("Invalid patient data", 400, errors)
+
+    for field, value in data.items():
+        setattr(patient, field, value)
+
+    db.session.commit()
+
+    return success_response(patient.to_dict(), "Patient updated successfully")
+
+
+@patients_bp.delete("/<int:patient_id>")
+def delete_patient(patient_id):
+    patient = db.session.get(Patient, patient_id)
+
+    if patient is None:
+        return error_response("Patient not found", 404)
+
+    db.session.delete(patient)
+    db.session.commit()
+
+    return success_response({"id": patient_id}, "Patient deleted successfully")

--- a/backend/migrations/README
+++ b/backend/migrations/README
@@ -1,0 +1,1 @@
+Single-database configuration for Flask-Migrate.

--- a/backend/migrations/alembic.ini
+++ b/backend/migrations/alembic.ini
@@ -1,0 +1,39 @@
+# A generic, single database Alembic configuration.
+
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,0 +1,64 @@
+from logging.config import fileConfig
+
+from flask import current_app
+
+from alembic import context
+
+config = context.config
+
+fileConfig(config.config_file_name)
+target_db = current_app.extensions["migrate"].db
+
+
+def get_engine():
+    try:
+        return target_db.get_engine()
+    except TypeError:
+        return target_db.engine
+
+
+def get_engine_url():
+    return str(get_engine().url).replace("%", "%%")
+
+
+config.set_main_option("sqlalchemy.url", get_engine_url())
+target_metadata = target_db.metadata
+
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    def process_revision_directives(context, revision, directives):
+        if getattr(config.cmd_opts, "autogenerate", False):
+            script = directives[0]
+            if script.upgrade_ops.is_empty():
+                directives[:] = []
+
+    connectable = get_engine()
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            process_revision_directives=process_revision_directives,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/migrations/script.py.mako
+++ b/backend/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/backend/migrations/versions/20260529_0001_create_patients_table.py
+++ b/backend/migrations/versions/20260529_0001_create_patients_table.py
@@ -1,0 +1,44 @@
+"""create patients table
+
+Revision ID: 20260529_0001
+Revises:
+Create Date: 2026-05-29 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260529_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "patients",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("first_name", sa.String(length=100), nullable=False),
+        sa.Column("last_name", sa.String(length=100), nullable=False),
+        sa.Column("date_of_birth", sa.Date(), nullable=True),
+        sa.Column("gender", sa.String(length=50), nullable=True),
+        sa.Column("phone", sa.String(length=50), nullable=True),
+        sa.Column("email", sa.String(length=255), nullable=True),
+        sa.Column("address", sa.Text(), nullable=True),
+        sa.Column("emergency_contact_name", sa.String(length=200), nullable=True),
+        sa.Column("emergency_contact_phone", sa.String(length=50), nullable=True),
+        sa.Column("diagnosis_summary", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "status IN ('active', 'inactive')",
+            name="ck_patients_status",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade():
+    op.drop_table("patients")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+
+from app import create_app
+from app.config import Config
+from app.extensions import db
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite+pysqlite:///:memory:"
+    CORS_ORIGINS = ["http://localhost:5173"]
+
+
+@pytest.fixture()
+def app():
+    app = create_app(TestConfig)
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,28 +1,10 @@
-from app import create_app
-from app.config import Config
-from app.extensions import db
-
-
-class TestConfig(Config):
-    TESTING = True
-    SQLALCHEMY_DATABASE_URI = "sqlite+pysqlite:///:memory:"
-    CORS_ORIGINS = ["http://localhost:5173"]
-
-
-def test_create_app():
-    app = create_app(TestConfig)
-
+def test_create_app(app):
     assert app is not None
     assert app.config["TESTING"] is True
 
 
-def test_health_endpoint_returns_success():
-    app = create_app(TestConfig)
-
-    with app.app_context():
-        db.create_all()
-
-    response = app.test_client().get("/api/health")
+def test_health_endpoint_returns_success(client):
+    response = client.get("/api/health")
 
     assert response.status_code == 200
     assert response.get_json()["status"] == "ok"

--- a/backend/tests/test_patients.py
+++ b/backend/tests/test_patients.py
@@ -1,0 +1,100 @@
+def patient_payload(**overrides):
+    payload = {
+        "first_name": "Maria",
+        "last_name": "Santos",
+        "date_of_birth": "1945-03-12",
+        "gender": "female",
+        "phone": "+1-555-0100",
+        "email": "maria.santos@example.com",
+        "address": "12 Care Lane",
+        "emergency_contact_name": "Ana Santos",
+        "emergency_contact_phone": "+1-555-0199",
+        "diagnosis_summary": "Requires daily mobility support.",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def create_patient(client, **overrides):
+    return client.post("/api/patients", json=patient_payload(**overrides))
+
+
+def test_create_patient(client):
+    response = create_patient(client)
+    body = response.get_json()
+
+    assert response.status_code == 201
+    assert body["message"] == "Patient created successfully"
+    assert body["data"]["id"] is not None
+    assert body["data"]["first_name"] == "Maria"
+    assert body["data"]["status"] == "active"
+
+
+def test_list_patients(client):
+    create_patient(client)
+    create_patient(client, first_name="John", last_name="Rivera")
+
+    response = client.get("/api/patients")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["message"] == "Patients retrieved successfully"
+    assert len(body["data"]) == 2
+
+
+def test_get_patient(client):
+    created = create_patient(client).get_json()["data"]
+
+    response = client.get(f"/api/patients/{created['id']}")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["data"]["id"] == created["id"]
+    assert body["data"]["last_name"] == "Santos"
+
+
+def test_update_patient(client):
+    created = create_patient(client).get_json()["data"]
+
+    response = client.put(
+        f"/api/patients/{created['id']}",
+        json={"phone": "+1-555-0111", "status": "inactive"},
+    )
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["message"] == "Patient updated successfully"
+    assert body["data"]["phone"] == "+1-555-0111"
+    assert body["data"]["status"] == "inactive"
+
+
+def test_delete_patient(client):
+    created = create_patient(client).get_json()["data"]
+
+    response = client.delete(f"/api/patients/{created['id']}")
+
+    assert response.status_code == 200
+    assert response.get_json()["message"] == "Patient deleted successfully"
+    assert client.get(f"/api/patients/{created['id']}").status_code == 404
+
+
+def test_create_patient_requires_first_and_last_name(client):
+    response = client.post("/api/patients", json={"first_name": ""})
+    body = response.get_json()
+
+    assert response.status_code == 400
+    assert body["message"] == "Invalid patient data"
+    assert body["errors"]["first_name"] == "This field is required."
+    assert body["errors"]["last_name"] == "This field is required."
+
+
+def test_create_patient_validates_date_of_birth(client):
+    response = client.post(
+        "/api/patients",
+        json=patient_payload(date_of_birth="12-03-1945"),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["date_of_birth"] == (
+        "Use ISO date format YYYY-MM-DD."
+    )

--- a/docs/architecture/api-design.md
+++ b/docs/architecture/api-design.md
@@ -1,0 +1,199 @@
+# API Design
+
+SeniorMate API responses use JSON and keep successful responses in a consistent envelope:
+
+```json
+{
+  "data": {},
+  "message": "Operation completed successfully"
+}
+```
+
+Validation and not-found responses include a clear message and, when applicable, field-level errors:
+
+```json
+{
+  "message": "Invalid patient data",
+  "errors": {
+    "first_name": "This field is required."
+  }
+}
+```
+
+## Patient API
+
+The Patient API is available under `/api/patients`.
+
+### Patient Fields
+
+- `id`
+- `first_name`
+- `last_name`
+- `date_of_birth`
+- `gender`
+- `phone`
+- `email`
+- `address`
+- `emergency_contact_name`
+- `emergency_contact_phone`
+- `diagnosis_summary`
+- `status`
+- `created_at`
+- `updated_at`
+
+`first_name` and `last_name` are required. `status` defaults to `active` and must be either `active` or `inactive`. `date_of_birth` is optional, but when provided it must use `YYYY-MM-DD`.
+
+### List Patients
+
+`GET /api/patients`
+
+Example response:
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "first_name": "Maria",
+      "last_name": "Santos",
+      "date_of_birth": "1945-03-12",
+      "gender": "female",
+      "phone": "+1-555-0100",
+      "email": "maria.santos@example.com",
+      "address": "12 Care Lane",
+      "emergency_contact_name": "Ana Santos",
+      "emergency_contact_phone": "+1-555-0199",
+      "diagnosis_summary": "Requires daily mobility support.",
+      "status": "active",
+      "created_at": "2026-05-29T10:00:00+00:00",
+      "updated_at": "2026-05-29T10:00:00+00:00"
+    }
+  ],
+  "message": "Patients retrieved successfully"
+}
+```
+
+### Retrieve a Patient
+
+`GET /api/patients/<id>`
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "first_name": "Maria",
+    "last_name": "Santos",
+    "date_of_birth": "1945-03-12",
+    "gender": "female",
+    "phone": "+1-555-0100",
+    "email": "maria.santos@example.com",
+    "address": "12 Care Lane",
+    "emergency_contact_name": "Ana Santos",
+    "emergency_contact_phone": "+1-555-0199",
+    "diagnosis_summary": "Requires daily mobility support.",
+    "status": "active",
+    "created_at": "2026-05-29T10:00:00+00:00",
+    "updated_at": "2026-05-29T10:00:00+00:00"
+  },
+  "message": "Patient retrieved successfully"
+}
+```
+
+### Create a Patient
+
+`POST /api/patients`
+
+Example request:
+
+```json
+{
+  "first_name": "Maria",
+  "last_name": "Santos",
+  "date_of_birth": "1945-03-12",
+  "gender": "female",
+  "phone": "+1-555-0100",
+  "email": "maria.santos@example.com",
+  "address": "12 Care Lane",
+  "emergency_contact_name": "Ana Santos",
+  "emergency_contact_phone": "+1-555-0199",
+  "diagnosis_summary": "Requires daily mobility support."
+}
+```
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "first_name": "Maria",
+    "last_name": "Santos",
+    "date_of_birth": "1945-03-12",
+    "gender": "female",
+    "phone": "+1-555-0100",
+    "email": "maria.santos@example.com",
+    "address": "12 Care Lane",
+    "emergency_contact_name": "Ana Santos",
+    "emergency_contact_phone": "+1-555-0199",
+    "diagnosis_summary": "Requires daily mobility support.",
+    "status": "active",
+    "created_at": "2026-05-29T10:00:00+00:00",
+    "updated_at": "2026-05-29T10:00:00+00:00"
+  },
+  "message": "Patient created successfully"
+}
+```
+
+### Update a Patient
+
+`PUT /api/patients/<id>`
+
+Example request:
+
+```json
+{
+  "phone": "+1-555-0111",
+  "status": "inactive"
+}
+```
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "first_name": "Maria",
+    "last_name": "Santos",
+    "date_of_birth": "1945-03-12",
+    "gender": "female",
+    "phone": "+1-555-0111",
+    "email": "maria.santos@example.com",
+    "address": "12 Care Lane",
+    "emergency_contact_name": "Ana Santos",
+    "emergency_contact_phone": "+1-555-0199",
+    "diagnosis_summary": "Requires daily mobility support.",
+    "status": "inactive",
+    "created_at": "2026-05-29T10:00:00+00:00",
+    "updated_at": "2026-05-29T10:05:00+00:00"
+  },
+  "message": "Patient updated successfully"
+}
+```
+
+### Delete a Patient
+
+`DELETE /api/patients/<id>`
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1
+  },
+  "message": "Patient deleted successfully"
+}
+```


### PR DESCRIPTION
# Summary

- Adds the first SeniorMate domain model, `Patient`, with demographic, contact, emergency contact, diagnosis, status, and timestamp fields.
- Adds Flask-Migrate/Alembic migration scaffolding and a patients table migration.
- Adds Patient CRUD endpoints under `/api/patients` with JSON response envelopes and validation errors.
- Adds backend tests for creating, listing, retrieving, updating, deleting, and validating patients.
- Adds API documentation for patient endpoints and updates `CHANGELOG.md`.

## Related Issue / Task

- Feature: 04-patient-api

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `git checkout main`
- `git pull origin main`
- Deleted stale local `feature/03-node24-github-actions-compatibility` branch after it was merged into `main`.
- `docker-compose exec -T backend pytest`
- `docker-compose exec -T backend ruff check .`
- `docker-compose exec -T backend flask --app run:app db upgrade`
- `curl -fsS http://localhost:5001/api/patients`
- `curl -fsS -X POST http://localhost:5001/api/patients ...`
- `curl -fsS -X DELETE http://localhost:5001/api/patients/1`
- `docker-compose exec -T postgres psql -U seniormate -d seniormate -c '\d patients'`
- `python3 -m compileall -q backend`
- `npm run build`
- `docker-compose config`
- `docker-compose build backend frontend`
- `git diff --check`
- Secret-pattern scan found no real credentials or key material.

## Screenshots

N/A

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.