### PR TITLE
Add Swagger API documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added Swagger/OpenAPI documentation with browser-based API testing for health and patient endpoints.
 - Added the Patient Management API with database model, migration, CRUD endpoints, validation, tests, and API documentation.
 - Prepared GitHub Actions workflows for the Node.js 24 runtime by updating action versions and enabling Node.js 24 compatibility testing.
 - Added GitHub Actions CI checks for backend linting/tests, frontend builds, and Docker Compose image builds.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Docker Compose is the recommended way to run the local SeniorMate stack. It star
 
    - Frontend: `http://localhost:5173`
    - Backend health: `http://localhost:5001/api/health`
+   - Swagger UI: `http://localhost:5001/api/docs`
+   - OpenAPI JSON: `http://localhost:5001/api/openapi.json`
    - MinIO console: `http://localhost:9001`
    - PostgreSQL: `localhost:5432`
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,23 +1,27 @@
 from flask import Flask, jsonify
 from flask_cors import CORS
+from flasgger import Swagger, swag_from
 from sqlalchemy import text
 
 from app.config import Config
 from app.extensions import db, migrate
 from app.models import Patient as Patient
 from app.routes.patients import patients_bp
+from app.swagger import health_spec, swagger_config, swagger_template
 
 
 def create_app(config_object=Config):
     app = Flask(__name__)
     app.config.from_object(config_object)
     CORS(app, resources={r"/api/*": {"origins": app.config["CORS_ORIGINS"]}})
+    Swagger(app, config=swagger_config, template=swagger_template)
 
     db.init_app(app)
     migrate.init_app(app, db)
     app.register_blueprint(patients_bp)
 
     @app.get("/api/health")
+    @swag_from(health_spec)
     def health():
         database = "ok"
         status_code = 200

--- a/backend/app/routes/patients.py
+++ b/backend/app/routes/patients.py
@@ -1,9 +1,17 @@
 from datetime import date
 
+from flasgger import swag_from
 from flask import Blueprint, jsonify, request
 
 from app.extensions import db
 from app.models import Patient
+from app.swagger import (
+    patient_create_spec,
+    patient_delete_spec,
+    patient_get_spec,
+    patient_list_spec,
+    patient_update_spec,
+)
 
 
 patients_bp = Blueprint("patients", __name__, url_prefix="/api/patients")
@@ -74,6 +82,7 @@ def parse_patient_payload(payload, partial=False):
 
 
 @patients_bp.get("")
+@swag_from(patient_list_spec)
 def list_patients():
     patients = Patient.query.order_by(Patient.id.asc()).all()
 
@@ -84,6 +93,7 @@ def list_patients():
 
 
 @patients_bp.get("/<int:patient_id>")
+@swag_from(patient_get_spec)
 def get_patient(patient_id):
     patient = db.session.get(Patient, patient_id)
 
@@ -94,6 +104,7 @@ def get_patient(patient_id):
 
 
 @patients_bp.post("")
+@swag_from(patient_create_spec)
 def create_patient():
     data, errors = parse_patient_payload(request.get_json(silent=True))
 
@@ -108,6 +119,7 @@ def create_patient():
 
 
 @patients_bp.put("/<int:patient_id>")
+@swag_from(patient_update_spec)
 def update_patient(patient_id):
     patient = db.session.get(Patient, patient_id)
 
@@ -128,6 +140,7 @@ def update_patient(patient_id):
 
 
 @patients_bp.delete("/<int:patient_id>")
+@swag_from(patient_delete_spec)
 def delete_patient(patient_id):
     patient = db.session.get(Patient, patient_id)
 

--- a/backend/app/swagger.py
+++ b/backend/app/swagger.py
@@ -1,0 +1,290 @@
+patient_properties = {
+    "id": {"type": "integer", "example": 1},
+    "first_name": {"type": "string", "example": "Maria"},
+    "last_name": {"type": "string", "example": "Santos"},
+    "date_of_birth": {
+        "type": "string",
+        "format": "date",
+        "nullable": True,
+        "example": "1945-03-12",
+    },
+    "gender": {"type": "string", "nullable": True, "example": "female"},
+    "phone": {"type": "string", "nullable": True, "example": "+1-555-0100"},
+    "email": {
+        "type": "string",
+        "format": "email",
+        "nullable": True,
+        "example": "maria.santos@example.com",
+    },
+    "address": {"type": "string", "nullable": True, "example": "12 Care Lane"},
+    "emergency_contact_name": {
+        "type": "string",
+        "nullable": True,
+        "example": "Ana Santos",
+    },
+    "emergency_contact_phone": {
+        "type": "string",
+        "nullable": True,
+        "example": "+1-555-0199",
+    },
+    "diagnosis_summary": {
+        "type": "string",
+        "nullable": True,
+        "example": "Requires daily mobility support.",
+    },
+    "status": {
+        "type": "string",
+        "enum": ["active", "inactive"],
+        "example": "active",
+    },
+    "created_at": {
+        "type": "string",
+        "format": "date-time",
+        "example": "2026-05-29T10:00:00+00:00",
+    },
+    "updated_at": {
+        "type": "string",
+        "format": "date-time",
+        "example": "2026-05-29T10:00:00+00:00",
+    },
+}
+
+patient_request_properties = {
+    key: value
+    for key, value in patient_properties.items()
+    if key not in {"id", "created_at", "updated_at"}
+}
+
+swagger_config = {
+    "headers": [],
+    "specs": [
+        {
+            "endpoint": "openapi",
+            "route": "/api/openapi.json",
+            "rule_filter": lambda rule: True,
+            "model_filter": lambda tag: True,
+        }
+    ],
+    "static_url_path": "/flasgger_static",
+    "swagger_ui": True,
+    "specs_route": "/api/docs",
+}
+
+swagger_template = {
+    "swagger": "2.0",
+    "info": {
+        "title": "SeniorMate API",
+        "description": "Interactive API documentation for SeniorMate.",
+        "version": "0.1.0",
+    },
+    "basePath": "/",
+    "schemes": ["http"],
+    "consumes": ["application/json"],
+    "produces": ["application/json"],
+    "definitions": {
+        "Patient": {
+            "type": "object",
+            "properties": patient_properties,
+        },
+        "PatientCreate": {
+            "type": "object",
+            "required": ["first_name", "last_name"],
+            "properties": patient_request_properties,
+        },
+        "PatientUpdate": {
+            "type": "object",
+            "properties": patient_request_properties,
+        },
+        "ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Invalid patient data",
+                },
+                "errors": {
+                    "type": "object",
+                    "additionalProperties": {"type": "string"},
+                    "example": {"first_name": "This field is required."},
+                },
+            },
+        },
+        "PatientSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "data": {"$ref": "#/definitions/Patient"},
+                "message": {
+                    "type": "string",
+                    "example": "Patient retrieved successfully",
+                },
+            },
+        },
+        "PatientListSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/Patient"},
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Patients retrieved successfully",
+                },
+            },
+        },
+        "DeleteSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "properties": {"id": {"type": "integer", "example": 1}},
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Patient deleted successfully",
+                },
+            },
+        },
+    },
+}
+
+health_spec = {
+    "tags": ["Health"],
+    "summary": "Check backend and database health",
+    "responses": {
+        200: {
+            "description": "Backend and database are available.",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "service": {
+                        "type": "string",
+                        "example": "seniormate-backend",
+                    },
+                    "status": {"type": "string", "example": "ok"},
+                    "database": {"type": "string", "example": "ok"},
+                    "minio_endpoint": {
+                        "type": "string",
+                        "example": "http://minio:9000",
+                    },
+                },
+            },
+        },
+        503: {
+            "description": "Backend is reachable but a dependency is unavailable.",
+        },
+    },
+}
+
+patient_list_spec = {
+    "tags": ["Patients"],
+    "summary": "List patients",
+    "responses": {
+        200: {
+            "description": "Patients retrieved successfully.",
+            "schema": {"$ref": "#/definitions/PatientListSuccessResponse"},
+        }
+    },
+}
+
+patient_get_spec = {
+    "tags": ["Patients"],
+    "summary": "Retrieve a patient",
+    "parameters": [
+        {
+            "name": "patient_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Patient retrieved successfully.",
+            "schema": {"$ref": "#/definitions/PatientSuccessResponse"},
+        },
+        404: {
+            "description": "Patient not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+patient_create_spec = {
+    "tags": ["Patients"],
+    "summary": "Create a patient",
+    "parameters": [
+        {
+            "name": "body",
+            "in": "body",
+            "required": True,
+            "schema": {"$ref": "#/definitions/PatientCreate"},
+        }
+    ],
+    "responses": {
+        201: {
+            "description": "Patient created successfully.",
+            "schema": {"$ref": "#/definitions/PatientSuccessResponse"},
+        },
+        400: {
+            "description": "Invalid patient data.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+patient_update_spec = {
+    "tags": ["Patients"],
+    "summary": "Update a patient",
+    "parameters": [
+        {
+            "name": "patient_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        },
+        {
+            "name": "body",
+            "in": "body",
+            "required": True,
+            "schema": {"$ref": "#/definitions/PatientUpdate"},
+        },
+    ],
+    "responses": {
+        200: {
+            "description": "Patient updated successfully.",
+            "schema": {"$ref": "#/definitions/PatientSuccessResponse"},
+        },
+        400: {
+            "description": "Invalid patient data.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+        404: {
+            "description": "Patient not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+patient_delete_spec = {
+    "tags": ["Patients"],
+    "summary": "Delete a patient",
+    "parameters": [
+        {
+            "name": "patient_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Patient deleted successfully.",
+            "schema": {"$ref": "#/definitions/DeleteSuccessResponse"},
+        },
+        404: {
+            "description": "Patient not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,5 +2,6 @@ Flask==3.1.1
 Flask-Cors==6.0.0
 Flask-Migrate==4.1.0
 Flask-SQLAlchemy==3.1.1
+flasgger==0.9.7b2
 gunicorn==23.0.0
 psycopg[binary]==3.2.9

--- a/backend/tests/test_openapi.py
+++ b/backend/tests/test_openapi.py
@@ -1,0 +1,40 @@
+def test_swagger_ui_is_reachable(client):
+    response = client.get("/api/docs")
+
+    assert response.status_code == 200
+    assert b"swagger-ui" in response.data
+
+
+def test_openapi_json_is_reachable(client):
+    response = client.get("/api/openapi.json")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["info"]["title"] == "SeniorMate API"
+    assert body["swagger"] == "2.0"
+
+
+def test_openapi_json_includes_health_and_patient_endpoints(client):
+    response = client.get("/api/openapi.json")
+    paths = response.get_json()["paths"]
+
+    assert "/api/health" in paths
+    assert "/api/patients" in paths
+    assert "/api/patients/{patient_id}" in paths
+    assert "get" in paths["/api/health"]
+    assert {"get", "post"} <= set(paths["/api/patients"].keys())
+    assert {"get", "put", "delete"} <= set(
+        paths["/api/patients/{patient_id}"].keys()
+    )
+
+
+def test_openapi_json_includes_patient_schemas(client):
+    response = client.get("/api/openapi.json")
+    definitions = response.get_json()["definitions"]
+
+    assert "Patient" in definitions
+    assert "PatientCreate" in definitions
+    assert "PatientUpdate" in definitions
+    assert "ErrorResponse" in definitions
+    assert "PatientSuccessResponse" in definitions
+    assert "PatientListSuccessResponse" in definitions

--- a/docs/architecture/api-design.md
+++ b/docs/architecture/api-design.md
@@ -20,6 +20,15 @@ Validation and not-found responses include a clear message and, when applicable,
 }
 ```
 
+## Interactive API Documentation
+
+SeniorMate exposes browser-based Swagger documentation for local API testing:
+
+- Swagger UI: `http://localhost:5001/api/docs`
+- OpenAPI JSON: `http://localhost:5001/api/openapi.json`
+
+Start the local stack with Docker Compose, then open the Swagger UI in a browser to inspect and test the health and patient endpoints.
+
 ## Patient API
 
 The Patient API is available under `/api/patients`.


### PR DESCRIPTION
# Summary

- Adds Flasgger-based Swagger/OpenAPI documentation to the Flask backend.
- Exposes Swagger UI at `/api/docs` and the JSON specification at `/api/openapi.json`.
- Documents the existing health endpoint and all Patient CRUD endpoints.
- Adds reusable schemas for Patient, PatientCreate, PatientUpdate, error responses, and patient success response envelopes.
- Updates README, API architecture docs, and `CHANGELOG.md`.

Flasgger was chosen because it fits the current plain Flask blueprint structure with minimal code changes, provides embedded Swagger UI, and lets us document existing routes without converting the API to a new resource framework.

## Related Issue / Task

- Feature: 05-api-documentation-swagger

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [x] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `git checkout main`
- `git pull origin main`
- Deleted stale local `feature/04-patient-api` branch after it was merged into `main`.
- `docker-compose build backend`
- `docker-compose up -d backend`
- `docker-compose exec -T backend pytest`
- `docker-compose exec -T backend ruff check .`
- `python3 -m compileall -q backend`
- `git diff --check`
- `npm run build`
- `docker-compose config`
- `curl -I http://localhost:5001/api/docs`
- `curl -fsS http://localhost:5001/api/openapi.json ...`
- Browser smoke test for `http://localhost:5001/api/docs` confirmed SeniorMate API, Health, and Patients sections render.
- `docker-compose build backend frontend`
- Secret-pattern scan found no real credentials or key material.

## Screenshots

N/A

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.