### PR TITLE
feat: add patient management UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added the Patient Management frontend with list, create, edit, detail, delete, and API service workflows.
 - Added Swagger/OpenAPI documentation with browser-based API testing for health and patient endpoints.
 - Added the Patient Management API with database model, migration, CRUD endpoints, validation, tests, and API documentation.
 - Prepared GitHub Actions workflows for the Node.js 24 runtime by updating action versions and enabling Node.js 24 compatibility testing.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Docker Compose is the recommended way to run the local SeniorMate stack. It star
 6. Open the local services.
 
    - Frontend: `http://localhost:5173`
+   - Patient management UI: `http://localhost:5173/patients`
    - Backend health: `http://localhost:5001/api/health`
    - Swagger UI: `http://localhost:5001/api/docs`
    - OpenAPI JSON: `http://localhost:5001/api/openapi.json`

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@vitejs/plugin-vue": "5.2.4",
         "vite": "6.4.2",
         "vue": "3.5.16",
+        "vue-router": "4.5.1",
         "vuetify": "3.8.8"
       },
       "devDependencies": {}
@@ -884,6 +885,12 @@
         "@vue/shared": "3.5.16"
       }
     },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
     "node_modules/@vue/reactivity": {
       "version": "3.5.16",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.16.tgz",
@@ -1068,7 +1075,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1178,7 +1184,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -1253,7 +1258,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.16.tgz",
       "integrity": "sha512-rjOV2ecxMd5SiAmof2xzh2WxntRcigkX/He4YFJ6WdRvVUrbt6DxC1Iujh10XLl8xCDRDtGKMeO3D+pRQ1PP9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.16",
         "@vue/compiler-sfc": "3.5.16",
@@ -1268,6 +1272,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/vuetify": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@vitejs/plugin-vue": "5.2.4",
     "vite": "6.4.2",
     "vue": "3.5.16",
+    "vue-router": "4.5.1",
     "vuetify": "3.8.8"
   },
   "devDependencies": {}

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,2 @@
+export const apiBaseUrl =
+  import.meta.env.VITE_API_BASE_URL || "http://localhost:5001/api";

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,107 +1,14 @@
 import "@mdi/font/css/materialdesignicons.css";
 import "vuetify/styles";
 
-import { createApp, onMounted, ref } from "vue";
+import { createApp } from "vue";
 import { createVuetify } from "vuetify";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
 import { aliases, mdi } from "vuetify/iconsets/mdi";
 
-const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || "http://localhost:5000/api";
-
-const App = {
-  setup() {
-    const health = ref(null);
-    const loading = ref(true);
-    const error = ref("");
-
-    async function loadHealth() {
-      loading.value = true;
-      error.value = "";
-
-      try {
-        const response = await fetch(`${apiBaseUrl}/health`);
-        const payload = await response.json();
-
-        if (!response.ok) {
-          throw new Error(payload.status || "Backend health check failed");
-        }
-
-        health.value = payload;
-      } catch (err) {
-        error.value = err.message;
-      } finally {
-        loading.value = false;
-      }
-    }
-
-    onMounted(loadHealth);
-
-    return {
-      apiBaseUrl,
-      error,
-      health,
-      loading,
-      loadHealth,
-    };
-  },
-  template: `
-    <v-app>
-      <v-main>
-        <v-container class="py-10" style="max-width: 960px;">
-          <v-row align="center" class="mb-6">
-            <v-col cols="12" md="8">
-              <p class="text-overline mb-2">SeniorMate local development</p>
-              <h1 class="text-h3 font-weight-bold mb-3">Care operations dashboard</h1>
-              <p class="text-body-1 text-medium-emphasis mb-0">
-                Local backend, frontend, PostgreSQL, and MinIO services are wired for development.
-              </p>
-            </v-col>
-            <v-col cols="12" md="4" class="text-md-right">
-              <v-btn color="primary" variant="flat" :loading="loading" @click="loadHealth">
-                Refresh health
-              </v-btn>
-            </v-col>
-          </v-row>
-
-          <v-row>
-            <v-col cols="12" md="4">
-              <v-card variant="tonal">
-                <v-card-title>Backend</v-card-title>
-                <v-card-text>
-                  <div class="text-h5 mb-2">{{ health?.status || "Checking" }}</div>
-                  <div class="text-body-2">{{ apiBaseUrl }}</div>
-                </v-card-text>
-              </v-card>
-            </v-col>
-            <v-col cols="12" md="4">
-              <v-card variant="tonal">
-                <v-card-title>Database</v-card-title>
-                <v-card-text>
-                  <div class="text-h5 mb-2">{{ health?.database || "Checking" }}</div>
-                  <div class="text-body-2">PostgreSQL via Docker Compose</div>
-                </v-card-text>
-              </v-card>
-            </v-col>
-            <v-col cols="12" md="4">
-              <v-card variant="tonal">
-                <v-card-title>Storage</v-card-title>
-                <v-card-text>
-                  <div class="text-h5 mb-2">MinIO</div>
-                  <div class="text-body-2">{{ health?.minio_endpoint || "Configured from environment" }}</div>
-                </v-card-text>
-              </v-card>
-            </v-col>
-          </v-row>
-
-          <v-alert v-if="error" type="error" variant="tonal" class="mt-6">
-            {{ error }}
-          </v-alert>
-        </v-container>
-      </v-main>
-    </v-app>
-  `,
-};
+import App from "./views/App.js";
+import router from "./router.js";
 
 const vuetify = createVuetify({
   components,
@@ -113,4 +20,4 @@ const vuetify = createVuetify({
   },
 });
 
-createApp(App).use(vuetify).mount("#app");
+createApp(App).use(router).use(vuetify).mount("#app");

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -1,0 +1,44 @@
+import { createRouter, createWebHistory } from "vue-router";
+
+import DashboardView from "./views/DashboardView.js";
+import PatientDetailView from "./views/PatientDetailView.js";
+import PatientFormView from "./views/PatientFormView.js";
+import PatientListView from "./views/PatientListView.js";
+
+const routes = [
+  {
+    path: "/",
+    name: "dashboard",
+    component: DashboardView,
+  },
+  {
+    path: "/patients",
+    name: "patients",
+    component: PatientListView,
+  },
+  {
+    path: "/patients/new",
+    name: "patient-create",
+    component: PatientFormView,
+    props: { mode: "create" },
+  },
+  {
+    path: "/patients/:id",
+    name: "patient-detail",
+    component: PatientDetailView,
+    props: true,
+  },
+  {
+    path: "/patients/:id/edit",
+    name: "patient-edit",
+    component: PatientFormView,
+    props: { mode: "edit" },
+  },
+];
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+});
+
+export default router;

--- a/frontend/src/services/patients.js
+++ b/frontend/src/services/patients.js
@@ -1,0 +1,54 @@
+import { apiBaseUrl } from "../config.js";
+
+async function parseResponse(response) {
+  const payload = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const message = payload.message || "The request could not be completed.";
+    const error = new Error(message);
+    error.payload = payload;
+    throw error;
+  }
+
+  return payload;
+}
+
+async function apiRequest(path, options = {}) {
+  const response = await fetch(`${apiBaseUrl}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+    ...options,
+  });
+
+  return parseResponse(response);
+}
+
+export async function listPatients() {
+  return apiRequest("/patients");
+}
+
+export async function getPatient(id) {
+  return apiRequest(`/patients/${id}`);
+}
+
+export async function createPatient(patient) {
+  return apiRequest("/patients", {
+    method: "POST",
+    body: JSON.stringify(patient),
+  });
+}
+
+export async function updatePatient(id, patient) {
+  return apiRequest(`/patients/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(patient),
+  });
+}
+
+export async function deletePatient(id) {
+  return apiRequest(`/patients/${id}`, {
+    method: "DELETE",
+  });
+}

--- a/frontend/src/views/App.js
+++ b/frontend/src/views/App.js
@@ -1,0 +1,42 @@
+import { ref } from "vue";
+
+const navItems = [
+  { title: "Dashboard", icon: "mdi-view-dashboard-outline", to: "/" },
+  { title: "Patients", icon: "mdi-account-heart-outline", to: "/patients" },
+];
+
+export default {
+  setup() {
+    const drawer = ref(true);
+
+    return {
+      drawer,
+      navItems,
+    };
+  },
+  template: `
+    <v-app>
+      <v-navigation-drawer v-model="drawer" width="248">
+        <v-list density="comfortable" nav>
+          <v-list-item
+            v-for="item in navItems"
+            :key="item.to"
+            :prepend-icon="item.icon"
+            :title="item.title"
+            :to="item.to"
+            rounded="0"
+          />
+        </v-list>
+      </v-navigation-drawer>
+
+      <v-app-bar flat border>
+        <v-app-bar-nav-icon @click="drawer = !drawer" />
+        <v-app-bar-title>SeniorMate</v-app-bar-title>
+      </v-app-bar>
+
+      <v-main>
+        <router-view />
+      </v-main>
+    </v-app>
+  `,
+};

--- a/frontend/src/views/DashboardView.js
+++ b/frontend/src/views/DashboardView.js
@@ -1,0 +1,93 @@
+import { onMounted, ref } from "vue";
+
+import { apiBaseUrl } from "../config.js";
+
+export default {
+  setup() {
+    const health = ref(null);
+    const loading = ref(true);
+    const error = ref("");
+
+    async function loadHealth() {
+      loading.value = true;
+      error.value = "";
+
+      try {
+        const response = await fetch(`${apiBaseUrl}/health`);
+        const payload = await response.json();
+
+        if (!response.ok) {
+          throw new Error(payload.status || "Backend health check failed");
+        }
+
+        health.value = payload;
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    onMounted(loadHealth);
+
+    return {
+      apiBaseUrl,
+      error,
+      health,
+      loading,
+      loadHealth,
+    };
+  },
+  template: `
+    <v-container class="py-8" style="max-width: 1120px;">
+      <v-row align="center" class="mb-6">
+        <v-col cols="12" md="8">
+          <p class="text-overline mb-2">SeniorMate local development</p>
+          <h1 class="text-h4 font-weight-bold mb-2">Care operations dashboard</h1>
+          <p class="text-body-1 text-medium-emphasis mb-0">
+            Backend, frontend, PostgreSQL, and MinIO status.
+          </p>
+        </v-col>
+        <v-col cols="12" md="4" class="text-md-right">
+          <v-btn color="primary" variant="flat" :loading="loading" @click="loadHealth">
+            Refresh health
+          </v-btn>
+        </v-col>
+      </v-row>
+
+      <v-row>
+        <v-col cols="12" md="4">
+          <v-card variant="tonal">
+            <v-card-title>Backend</v-card-title>
+            <v-card-text>
+              <div class="text-h5 mb-2">{{ health?.status || "Checking" }}</div>
+              <div class="text-body-2">{{ apiBaseUrl }}</div>
+            </v-card-text>
+          </v-card>
+        </v-col>
+        <v-col cols="12" md="4">
+          <v-card variant="tonal">
+            <v-card-title>Database</v-card-title>
+            <v-card-text>
+              <div class="text-h5 mb-2">{{ health?.database || "Checking" }}</div>
+              <div class="text-body-2">PostgreSQL via Docker Compose</div>
+            </v-card-text>
+          </v-card>
+        </v-col>
+        <v-col cols="12" md="4">
+          <v-card variant="tonal">
+            <v-card-title>Storage</v-card-title>
+            <v-card-text>
+              <div class="text-h5 mb-2">MinIO</div>
+              <div class="text-body-2">{{ health?.minio_endpoint || "Configured from environment" }}</div>
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+
+      <v-alert v-if="error" type="error" variant="tonal" class="mt-6">
+        {{ error }}
+      </v-alert>
+    </v-container>
+  `,
+};

--- a/frontend/src/views/PatientDetailView.js
+++ b/frontend/src/views/PatientDetailView.js
@@ -1,0 +1,101 @@
+import { computed, onMounted, ref } from "vue";
+
+import { getPatient } from "../services/patients.js";
+
+export default {
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    const patient = ref(null);
+    const loading = ref(true);
+    const error = ref("");
+
+    const fullName = computed(() =>
+      patient.value ? `${patient.value.first_name} ${patient.value.last_name}` : ""
+    );
+
+    async function loadPatient() {
+      loading.value = true;
+      error.value = "";
+
+      try {
+        const response = await getPatient(props.id);
+        patient.value = response.data;
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    onMounted(loadPatient);
+
+    return {
+      error,
+      fullName,
+      loading,
+      patient,
+    };
+  },
+  template: `
+    <v-container class="py-8" style="max-width: 1120px;">
+      <v-btn variant="text" prepend-icon="mdi-arrow-left" to="/patients" class="mb-4">
+        Patients
+      </v-btn>
+
+      <v-alert v-if="error" type="error" variant="tonal" class="mb-4">
+        {{ error }}
+      </v-alert>
+
+      <v-skeleton-loader v-if="loading" type="heading, paragraph, card" />
+
+      <template v-else-if="patient">
+        <v-row align="center" class="mb-5">
+          <v-col cols="12" md="8">
+            <h1 class="text-h4 font-weight-bold mb-2">{{ fullName }}</h1>
+            <v-chip :color="patient.status === 'active' ? 'success' : 'grey'" size="small">
+              {{ patient.status }}
+            </v-chip>
+          </v-col>
+          <v-col cols="12" md="4" class="text-md-right">
+            <v-btn color="primary" prepend-icon="mdi-pencil-outline" :to="\`/patients/\${patient.id}/edit\`">
+              Edit patient
+            </v-btn>
+          </v-col>
+        </v-row>
+
+        <v-row>
+          <v-col cols="12" md="6">
+            <v-card>
+              <v-card-title>Demographics</v-card-title>
+              <v-list>
+                <v-list-item title="Date of birth" :subtitle="patient.date_of_birth || 'Not provided'" />
+                <v-list-item title="Gender" :subtitle="patient.gender || 'Not provided'" />
+                <v-list-item title="Phone" :subtitle="patient.phone || 'Not provided'" />
+                <v-list-item title="Email" :subtitle="patient.email || 'Not provided'" />
+                <v-list-item title="Address" :subtitle="patient.address || 'Not provided'" />
+              </v-list>
+            </v-card>
+          </v-col>
+
+          <v-col cols="12" md="6">
+            <v-card>
+              <v-card-title>Emergency contact</v-card-title>
+              <v-list>
+                <v-list-item title="Name" :subtitle="patient.emergency_contact_name || 'Not provided'" />
+                <v-list-item title="Phone" :subtitle="patient.emergency_contact_phone || 'Not provided'" />
+              </v-list>
+              <v-divider />
+              <v-card-title>Diagnosis summary</v-card-title>
+              <v-card-text>{{ patient.diagnosis_summary || 'Not provided' }}</v-card-text>
+            </v-card>
+          </v-col>
+        </v-row>
+      </template>
+    </v-container>
+  `,
+};

--- a/frontend/src/views/PatientFormView.js
+++ b/frontend/src/views/PatientFormView.js
@@ -1,0 +1,209 @@
+import { computed, onMounted, ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
+
+import { createPatient, getPatient, updatePatient } from "../services/patients.js";
+
+const emptyForm = {
+  first_name: "",
+  last_name: "",
+  date_of_birth: "",
+  gender: "",
+  phone: "",
+  email: "",
+  address: "",
+  emergency_contact_name: "",
+  emergency_contact_phone: "",
+  diagnosis_summary: "",
+  status: "active",
+};
+
+export default {
+  props: {
+    mode: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    const route = useRoute();
+    const router = useRouter();
+    const form = ref({ ...emptyForm });
+    const errors = ref({});
+    const error = ref("");
+    const loading = ref(false);
+    const saving = ref(false);
+
+    const isEdit = computed(() => props.mode === "edit");
+    const title = computed(() => (isEdit.value ? "Edit patient" : "New patient"));
+
+    function validate() {
+      const nextErrors = {};
+
+      if (!form.value.first_name.trim()) {
+        nextErrors.first_name = "First name is required.";
+      }
+
+      if (!form.value.last_name.trim()) {
+        nextErrors.last_name = "Last name is required.";
+      }
+
+      errors.value = nextErrors;
+      return Object.keys(nextErrors).length === 0;
+    }
+
+    function apiPayload() {
+      const payload = {};
+
+      for (const [key, value] of Object.entries(form.value)) {
+        payload[key] = typeof value === "string" && value === "" ? null : value;
+      }
+
+      payload.first_name = form.value.first_name.trim();
+      payload.last_name = form.value.last_name.trim();
+      payload.status = form.value.status || "active";
+
+      return payload;
+    }
+
+    async function loadPatient() {
+      if (!isEdit.value) return;
+
+      loading.value = true;
+      error.value = "";
+
+      try {
+        const response = await getPatient(route.params.id);
+        form.value = {
+          ...emptyForm,
+          ...response.data,
+          date_of_birth: response.data.date_of_birth || "",
+        };
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    async function submit() {
+      error.value = "";
+
+      if (!validate()) return;
+
+      saving.value = true;
+
+      try {
+        const response = isEdit.value
+          ? await updatePatient(route.params.id, apiPayload())
+          : await createPatient(apiPayload());
+
+        await router.push(`/patients/${response.data.id}`);
+      } catch (err) {
+        error.value = err.message;
+        errors.value = err.payload?.errors || {};
+      } finally {
+        saving.value = false;
+      }
+    }
+
+    onMounted(loadPatient);
+
+    return {
+      error,
+      errors,
+      form,
+      isEdit,
+      loading,
+      saving,
+      submit,
+      title,
+    };
+  },
+  template: `
+    <v-container class="py-8" style="max-width: 960px;">
+      <v-btn variant="text" prepend-icon="mdi-arrow-left" to="/patients" class="mb-4">
+        Patients
+      </v-btn>
+
+      <h1 class="text-h4 font-weight-bold mb-5">{{ title }}</h1>
+
+      <v-alert v-if="error" type="error" variant="tonal" class="mb-4">
+        {{ error }}
+      </v-alert>
+
+      <v-skeleton-loader v-if="loading" type="heading, paragraph, card" />
+
+      <v-form v-else @submit.prevent="submit">
+        <v-card class="mb-5">
+          <v-card-title>Demographics</v-card-title>
+          <v-card-text>
+            <v-row>
+              <v-col cols="12" md="6">
+                <v-text-field
+                  v-model="form.first_name"
+                  label="First name"
+                  :error-messages="errors.first_name"
+                  required
+                />
+              </v-col>
+              <v-col cols="12" md="6">
+                <v-text-field
+                  v-model="form.last_name"
+                  label="Last name"
+                  :error-messages="errors.last_name"
+                  required
+                />
+              </v-col>
+              <v-col cols="12" md="4">
+                <v-text-field v-model="form.date_of_birth" label="Date of birth" type="date" />
+              </v-col>
+              <v-col cols="12" md="4">
+                <v-text-field v-model="form.gender" label="Gender" />
+              </v-col>
+              <v-col cols="12" md="4">
+                <v-select
+                  v-model="form.status"
+                  label="Status"
+                  :items="['active', 'inactive']"
+                />
+              </v-col>
+              <v-col cols="12" md="6">
+                <v-text-field v-model="form.phone" label="Phone" />
+              </v-col>
+              <v-col cols="12" md="6">
+                <v-text-field v-model="form.email" label="Email" type="email" />
+              </v-col>
+              <v-col cols="12">
+                <v-textarea v-model="form.address" label="Address" rows="2" />
+              </v-col>
+            </v-row>
+          </v-card-text>
+        </v-card>
+
+        <v-card class="mb-5">
+          <v-card-title>Emergency and clinical details</v-card-title>
+          <v-card-text>
+            <v-row>
+              <v-col cols="12" md="6">
+                <v-text-field v-model="form.emergency_contact_name" label="Emergency contact name" />
+              </v-col>
+              <v-col cols="12" md="6">
+                <v-text-field v-model="form.emergency_contact_phone" label="Emergency contact phone" />
+              </v-col>
+              <v-col cols="12">
+                <v-textarea v-model="form.diagnosis_summary" label="Diagnosis summary" rows="3" />
+              </v-col>
+            </v-row>
+          </v-card-text>
+        </v-card>
+
+        <div class="d-flex justify-end ga-3">
+          <v-btn variant="text" to="/patients">Cancel</v-btn>
+          <v-btn color="primary" type="submit" :loading="saving">
+            Save patient
+          </v-btn>
+        </div>
+      </v-form>
+    </v-container>
+  `,
+};

--- a/frontend/src/views/PatientListView.js
+++ b/frontend/src/views/PatientListView.js
@@ -1,0 +1,158 @@
+import { computed, onMounted, ref } from "vue";
+
+import { deletePatient, listPatients } from "../services/patients.js";
+
+export default {
+  setup() {
+    const patients = ref([]);
+    const loading = ref(true);
+    const error = ref("");
+    const success = ref("");
+    const deleting = ref(false);
+    const selectedPatient = ref(null);
+    const confirmDelete = ref(false);
+
+    const headers = [
+      { title: "Full name", key: "full_name" },
+      { title: "Date of birth", key: "date_of_birth" },
+      { title: "Gender", key: "gender" },
+      { title: "Phone", key: "phone" },
+      { title: "Status", key: "status" },
+      { title: "Actions", key: "actions", sortable: false },
+    ];
+
+    const rows = computed(() =>
+      patients.value.map((patient) => ({
+        ...patient,
+        full_name: `${patient.first_name} ${patient.last_name}`,
+      }))
+    );
+
+    async function loadPatients() {
+      loading.value = true;
+      error.value = "";
+
+      try {
+        const response = await listPatients();
+        patients.value = response.data;
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    function askDelete(patient) {
+      selectedPatient.value = patient;
+      confirmDelete.value = true;
+    }
+
+    async function removePatient() {
+      if (!selectedPatient.value) return;
+
+      deleting.value = true;
+      error.value = "";
+      success.value = "";
+
+      try {
+        await deletePatient(selectedPatient.value.id);
+        success.value = "Patient deleted successfully.";
+        confirmDelete.value = false;
+        selectedPatient.value = null;
+        await loadPatients();
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        deleting.value = false;
+      }
+    }
+
+    onMounted(loadPatients);
+
+    return {
+      askDelete,
+      confirmDelete,
+      deleting,
+      error,
+      headers,
+      loadPatients,
+      loading,
+      patients,
+      removePatient,
+      rows,
+      selectedPatient,
+      success,
+    };
+  },
+  template: `
+    <v-container class="py-8" style="max-width: 1280px;">
+      <v-row align="center" class="mb-5">
+        <v-col cols="12" md="8">
+          <h1 class="text-h4 font-weight-bold mb-1">Patients</h1>
+          <p class="text-body-2 text-medium-emphasis mb-0">Manage patient demographics and emergency contacts.</p>
+        </v-col>
+        <v-col cols="12" md="4" class="text-md-right">
+          <v-btn color="primary" prepend-icon="mdi-plus" to="/patients/new">
+            New patient
+          </v-btn>
+        </v-col>
+      </v-row>
+
+      <v-alert v-if="error" type="error" variant="tonal" class="mb-4">
+        {{ error }}
+      </v-alert>
+      <v-alert v-if="success" type="success" variant="tonal" class="mb-4">
+        {{ success }}
+      </v-alert>
+
+      <v-card>
+        <v-data-table
+          :headers="headers"
+          :items="rows"
+          :loading="loading"
+          item-value="id"
+        >
+          <template #loading>
+            <v-skeleton-loader type="table-row@5" />
+          </template>
+
+          <template #no-data>
+            <div class="pa-8 text-center">
+              <v-icon icon="mdi-account-heart-outline" size="40" class="mb-3" />
+              <div class="text-h6 mb-2">No patients yet</div>
+              <v-btn color="primary" variant="flat" to="/patients/new">Create patient</v-btn>
+            </div>
+          </template>
+
+          <template #[\`item.status\`]="{ item }">
+            <v-chip :color="item.status === 'active' ? 'success' : 'grey'" size="small">
+              {{ item.status }}
+            </v-chip>
+          </template>
+
+          <template #[\`item.actions\`]="{ item }">
+            <v-btn icon="mdi-eye-outline" variant="text" :to="\`/patients/\${item.id}\`" aria-label="View patient" />
+            <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/patients/\${item.id}/edit\`" aria-label="Edit patient" />
+            <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete patient" @click="askDelete(item)" />
+          </template>
+        </v-data-table>
+      </v-card>
+
+      <v-dialog v-model="confirmDelete" max-width="440">
+        <v-card>
+          <v-card-title>Delete patient</v-card-title>
+          <v-card-text>
+            Delete {{ selectedPatient?.full_name }}?
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn variant="text" @click="confirmDelete = false">Cancel</v-btn>
+            <v-btn color="error" variant="flat" :loading="deleting" @click="removePatient">
+              Delete
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+    </v-container>
+  `,
+};


### PR DESCRIPTION
# Summary

- Added a routed Vuetify frontend shell with Dashboard and Patients navigation.
- Added Patient Management screens for listing, creating, viewing, editing, and deleting patients.
- Added a frontend Patient API service layer and configuration for the existing backend API base URL.
- Updated README local service links and CHANGELOG.md for this feature.

## Related Issue / Task

- Feature: 06-patient-ui

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `npm ci`
- `npm run build`
- `docker-compose config`
- `docker-compose build frontend`
- `docker-compose up -d postgres minio backend frontend`
- `docker-compose exec -T frontend npm install`
- `docker-compose exec -T backend pytest`
- `docker-compose exec -T backend ruff check .`
- `curl -s http://localhost:5001/api/health`
- `curl -s http://localhost:5001/api/patients`
- `curl -s http://localhost:5173/patients`
- Browser manual workflow: empty list, create patient, view detail, edit patient, delete with confirmation, list refresh.
- `git diff --check`
- Secret-pattern scan with `rg`.

## Screenshots

Screenshots captured locally during browser validation:

- Patient list: `/private/tmp/seniormate-patient-list.png`
- Patient form: `/private/tmp/seniormate-patient-form.png`
- Patient detail: `/private/tmp/seniormate-patient-detail.png`

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.