### PR TITLE
feat: add visits API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added the Visits API with patient-linked visit records, migration, CRUD endpoints, Swagger documentation, tests, and API documentation.
 - Added the Patient Management frontend with list, create, edit, detail, delete, and API service workflows.
 - Added Swagger/OpenAPI documentation with browser-based API testing for health and patient endpoints.
 - Added the Patient Management API with database model, migration, CRUD endpoints, validation, tests, and API documentation.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -6,7 +6,9 @@ from sqlalchemy import text
 from app.config import Config
 from app.extensions import db, migrate
 from app.models import Patient as Patient
+from app.models import Visit as Visit
 from app.routes.patients import patients_bp
+from app.routes.visits import visits_bp
 from app.swagger import health_spec, swagger_config, swagger_template
 
 
@@ -19,6 +21,7 @@ def create_app(config_object=Config):
     db.init_app(app)
     migrate.init_app(app, db)
     app.register_blueprint(patients_bp)
+    app.register_blueprint(visits_bp)
 
     @app.get("/api/health")
     @swag_from(health_spec)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,5 @@
 from app.models.patient import Patient
+from app.models.visit import Visit
 
 
-__all__ = ["Patient"]
+__all__ = ["Patient", "Visit"]

--- a/backend/app/models/patient.py
+++ b/backend/app/models/patient.py
@@ -34,6 +34,11 @@ class Patient(db.Model):
         default=lambda: datetime.now(UTC),
         onupdate=lambda: datetime.now(UTC),
     )
+    visits = db.relationship(
+        "Visit",
+        back_populates="patient",
+        cascade="all, delete-orphan",
+    )
 
     def to_dict(self):
         return {

--- a/backend/app/models/visit.py
+++ b/backend/app/models/visit.py
@@ -1,0 +1,65 @@
+from datetime import UTC, datetime
+
+from sqlalchemy import CheckConstraint
+
+from app.extensions import db
+
+
+class Visit(db.Model):
+    __tablename__ = "visits"
+    __table_args__ = (
+        CheckConstraint("staff_role IN ('aide', 'nurse')", name="ck_visits_staff_role"),
+        CheckConstraint(
+            "status IN ('scheduled', 'completed', 'cancelled')",
+            name="ck_visits_status",
+        ),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    patient_id = db.Column(
+        db.Integer,
+        db.ForeignKey("patients.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    visit_date = db.Column(db.Date, nullable=False)
+    visit_type = db.Column(db.String(100), nullable=False)
+    staff_name = db.Column(db.String(200), nullable=True)
+    staff_role = db.Column(db.String(50), nullable=True)
+    time_in = db.Column(db.Time, nullable=True)
+    time_out = db.Column(db.Time, nullable=True)
+    notes = db.Column(db.Text, nullable=True)
+    status = db.Column(db.String(20), nullable=False, default="scheduled")
+    created_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    patient = db.relationship("Patient", back_populates="visits")
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "patient_id": self.patient_id,
+            "visit_date": self.visit_date.isoformat() if self.visit_date else None,
+            "visit_type": self.visit_type,
+            "staff_name": self.staff_name,
+            "staff_role": self.staff_role,
+            "time_in": self.time_in.isoformat(timespec="minutes")
+            if self.time_in
+            else None,
+            "time_out": self.time_out.isoformat(timespec="minutes")
+            if self.time_out
+            else None,
+            "notes": self.notes,
+            "status": self.status,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/backend/app/routes/visits.py
+++ b/backend/app/routes/visits.py
@@ -1,0 +1,214 @@
+from datetime import date, time
+
+from flasgger import swag_from
+from flask import Blueprint, jsonify, request
+
+from app.extensions import db
+from app.models import Patient, Visit
+from app.swagger import (
+    patient_visits_list_spec,
+    visit_create_spec,
+    visit_delete_spec,
+    visit_get_spec,
+    visit_list_spec,
+    visit_update_spec,
+)
+
+
+visits_bp = Blueprint("visits", __name__, url_prefix="/api")
+
+VISIT_FIELDS = {
+    "patient_id",
+    "visit_date",
+    "visit_type",
+    "staff_name",
+    "staff_role",
+    "time_in",
+    "time_out",
+    "notes",
+    "status",
+}
+VALID_STAFF_ROLES = {"aide", "nurse"}
+VALID_STATUSES = {"scheduled", "completed", "cancelled"}
+
+
+def success_response(data, message, status_code=200):
+    return jsonify({"data": data, "message": message}), status_code
+
+
+def error_response(message, status_code=400, errors=None):
+    payload = {"message": message}
+
+    if errors:
+        payload["errors"] = errors
+
+    return jsonify(payload), status_code
+
+
+def parse_time(value):
+    if value is None or value == "":
+        return None
+
+    if not isinstance(value, str):
+        raise ValueError
+
+    return time.fromisoformat(value)
+
+
+def parse_visit_payload(payload, partial=False):
+    if not isinstance(payload, dict):
+        return None, {"request": "JSON body is required."}
+
+    data = {}
+    errors = {}
+
+    for field in VISIT_FIELDS:
+        if field in payload:
+            data[field] = payload[field]
+
+    if not partial or "patient_id" in data:
+        patient_id = data.get("patient_id")
+        if patient_id in (None, ""):
+            errors["patient_id"] = "This field is required."
+        elif not isinstance(patient_id, int):
+            errors["patient_id"] = "Patient ID must be an integer."
+        elif db.session.get(Patient, patient_id) is None:
+            errors["patient_id"] = "Patient not found."
+
+    if not partial or "visit_date" in data:
+        visit_date = data.get("visit_date")
+        if not visit_date:
+            errors["visit_date"] = "This field is required."
+        else:
+            try:
+                data["visit_date"] = date.fromisoformat(visit_date)
+            except (TypeError, ValueError):
+                errors["visit_date"] = "Use ISO date format YYYY-MM-DD."
+
+    if not partial or "visit_type" in data:
+        visit_type = data.get("visit_type")
+        if not isinstance(visit_type, str) or not visit_type.strip():
+            errors["visit_type"] = "This field is required."
+        else:
+            data["visit_type"] = visit_type.strip()
+
+    for field in ("staff_name", "notes"):
+        if field in data and isinstance(data[field], str):
+            data[field] = data[field].strip() or None
+
+    if "staff_role" in data and data["staff_role"]:
+        if not isinstance(data["staff_role"], str):
+            errors["staff_role"] = "Staff role must be aide or nurse."
+        else:
+            data["staff_role"] = data["staff_role"].strip().lower()
+            if data["staff_role"] not in VALID_STAFF_ROLES:
+                errors["staff_role"] = "Staff role must be aide or nurse."
+    elif "staff_role" in data:
+        data["staff_role"] = None
+
+    for field in ("time_in", "time_out"):
+        if field in data:
+            try:
+                data[field] = parse_time(data[field])
+            except ValueError:
+                errors[field] = "Use 24-hour time format HH:MM."
+
+    if "status" not in data and not partial:
+        data["status"] = "scheduled"
+
+    if "status" in data and data["status"] not in VALID_STATUSES:
+        errors["status"] = "Status must be scheduled, completed, or cancelled."
+
+    return data, errors
+
+
+@visits_bp.get("/visits")
+@swag_from(visit_list_spec)
+def list_visits():
+    visits = Visit.query.order_by(Visit.visit_date.desc(), Visit.id.desc()).all()
+
+    return success_response(
+        [visit.to_dict() for visit in visits],
+        "Visits retrieved successfully",
+    )
+
+
+@visits_bp.get("/visits/<int:visit_id>")
+@swag_from(visit_get_spec)
+def get_visit(visit_id):
+    visit = db.session.get(Visit, visit_id)
+
+    if visit is None:
+        return error_response("Visit not found", 404)
+
+    return success_response(visit.to_dict(), "Visit retrieved successfully")
+
+
+@visits_bp.post("/visits")
+@swag_from(visit_create_spec)
+def create_visit():
+    data, errors = parse_visit_payload(request.get_json(silent=True))
+
+    if errors:
+        return error_response("Invalid visit data", 400, errors)
+
+    visit = Visit(**data)
+    db.session.add(visit)
+    db.session.commit()
+
+    return success_response(visit.to_dict(), "Visit created successfully", 201)
+
+
+@visits_bp.put("/visits/<int:visit_id>")
+@swag_from(visit_update_spec)
+def update_visit(visit_id):
+    visit = db.session.get(Visit, visit_id)
+
+    if visit is None:
+        return error_response("Visit not found", 404)
+
+    data, errors = parse_visit_payload(request.get_json(silent=True), partial=True)
+
+    if errors:
+        return error_response("Invalid visit data", 400, errors)
+
+    for field, value in data.items():
+        setattr(visit, field, value)
+
+    db.session.commit()
+
+    return success_response(visit.to_dict(), "Visit updated successfully")
+
+
+@visits_bp.delete("/visits/<int:visit_id>")
+@swag_from(visit_delete_spec)
+def delete_visit(visit_id):
+    visit = db.session.get(Visit, visit_id)
+
+    if visit is None:
+        return error_response("Visit not found", 404)
+
+    db.session.delete(visit)
+    db.session.commit()
+
+    return success_response({"id": visit_id}, "Visit deleted successfully")
+
+
+@visits_bp.get("/patients/<int:patient_id>/visits")
+@swag_from(patient_visits_list_spec)
+def list_patient_visits(patient_id):
+    patient = db.session.get(Patient, patient_id)
+
+    if patient is None:
+        return error_response("Patient not found", 404)
+
+    visits = (
+        Visit.query.filter_by(patient_id=patient_id)
+        .order_by(Visit.visit_date.desc(), Visit.id.desc())
+        .all()
+    )
+
+    return success_response(
+        [visit.to_dict() for visit in visits],
+        "Patient visits retrieved successfully",
+    )

--- a/backend/app/swagger.py
+++ b/backend/app/swagger.py
@@ -55,6 +55,60 @@ patient_request_properties = {
     if key not in {"id", "created_at", "updated_at"}
 }
 
+visit_properties = {
+    "id": {"type": "integer", "example": 1},
+    "patient_id": {"type": "integer", "example": 1},
+    "visit_date": {
+        "type": "string",
+        "format": "date",
+        "example": "2026-06-01",
+    },
+    "visit_type": {"type": "string", "example": "Home care visit"},
+    "staff_name": {"type": "string", "nullable": True, "example": "Jordan Lee"},
+    "staff_role": {
+        "type": "string",
+        "nullable": True,
+        "enum": ["aide", "nurse"],
+        "example": "aide",
+    },
+    "time_in": {
+        "type": "string",
+        "nullable": True,
+        "example": "09:00",
+    },
+    "time_out": {
+        "type": "string",
+        "nullable": True,
+        "example": "10:30",
+    },
+    "notes": {
+        "type": "string",
+        "nullable": True,
+        "example": "Patient completed morning mobility exercises.",
+    },
+    "status": {
+        "type": "string",
+        "enum": ["scheduled", "completed", "cancelled"],
+        "example": "scheduled",
+    },
+    "created_at": {
+        "type": "string",
+        "format": "date-time",
+        "example": "2026-05-31T10:00:00+00:00",
+    },
+    "updated_at": {
+        "type": "string",
+        "format": "date-time",
+        "example": "2026-05-31T10:00:00+00:00",
+    },
+}
+
+visit_request_properties = {
+    key: value
+    for key, value in visit_properties.items()
+    if key not in {"id", "created_at", "updated_at"}
+}
+
 swagger_config = {
     "headers": [],
     "specs": [
@@ -95,6 +149,19 @@ swagger_template = {
             "type": "object",
             "properties": patient_request_properties,
         },
+        "Visit": {
+            "type": "object",
+            "properties": visit_properties,
+        },
+        "VisitCreate": {
+            "type": "object",
+            "required": ["patient_id", "visit_date", "visit_type"],
+            "properties": visit_request_properties,
+        },
+        "VisitUpdate": {
+            "type": "object",
+            "properties": visit_request_properties,
+        },
         "ErrorResponse": {
             "type": "object",
             "properties": {
@@ -129,6 +196,29 @@ swagger_template = {
                 "message": {
                     "type": "string",
                     "example": "Patients retrieved successfully",
+                },
+            },
+        },
+        "VisitResponse": {
+            "type": "object",
+            "properties": {
+                "data": {"$ref": "#/definitions/Visit"},
+                "message": {
+                    "type": "string",
+                    "example": "Visit retrieved successfully",
+                },
+            },
+        },
+        "VisitListResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/Visit"},
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Visits retrieved successfully",
                 },
             },
         },
@@ -281,6 +371,142 @@ patient_delete_spec = {
         200: {
             "description": "Patient deleted successfully.",
             "schema": {"$ref": "#/definitions/DeleteSuccessResponse"},
+        },
+        404: {
+            "description": "Patient not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+visit_list_spec = {
+    "tags": ["Visits"],
+    "summary": "List visits",
+    "responses": {
+        200: {
+            "description": "Visits retrieved successfully.",
+            "schema": {"$ref": "#/definitions/VisitListResponse"},
+        }
+    },
+}
+
+visit_get_spec = {
+    "tags": ["Visits"],
+    "summary": "Retrieve a visit",
+    "parameters": [
+        {
+            "name": "visit_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Visit retrieved successfully.",
+            "schema": {"$ref": "#/definitions/VisitResponse"},
+        },
+        404: {
+            "description": "Visit not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+visit_create_spec = {
+    "tags": ["Visits"],
+    "summary": "Create a visit",
+    "parameters": [
+        {
+            "name": "body",
+            "in": "body",
+            "required": True,
+            "schema": {"$ref": "#/definitions/VisitCreate"},
+        }
+    ],
+    "responses": {
+        201: {
+            "description": "Visit created successfully.",
+            "schema": {"$ref": "#/definitions/VisitResponse"},
+        },
+        400: {
+            "description": "Invalid visit data.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+visit_update_spec = {
+    "tags": ["Visits"],
+    "summary": "Update a visit",
+    "parameters": [
+        {
+            "name": "visit_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        },
+        {
+            "name": "body",
+            "in": "body",
+            "required": True,
+            "schema": {"$ref": "#/definitions/VisitUpdate"},
+        },
+    ],
+    "responses": {
+        200: {
+            "description": "Visit updated successfully.",
+            "schema": {"$ref": "#/definitions/VisitResponse"},
+        },
+        400: {
+            "description": "Invalid visit data.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+        404: {
+            "description": "Visit not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+visit_delete_spec = {
+    "tags": ["Visits"],
+    "summary": "Delete a visit",
+    "parameters": [
+        {
+            "name": "visit_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Visit deleted successfully.",
+            "schema": {"$ref": "#/definitions/DeleteSuccessResponse"},
+        },
+        404: {
+            "description": "Visit not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+patient_visits_list_spec = {
+    "tags": ["Visits"],
+    "summary": "List visits for a patient",
+    "parameters": [
+        {
+            "name": "patient_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Patient visits retrieved successfully.",
+            "schema": {"$ref": "#/definitions/VisitListResponse"},
         },
         404: {
             "description": "Patient not found.",

--- a/backend/migrations/versions/20260531_0002_create_visits_table.py
+++ b/backend/migrations/versions/20260531_0002_create_visits_table.py
@@ -1,0 +1,49 @@
+"""create visits table
+
+Revision ID: 20260531_0002
+Revises: 20260529_0001
+Create Date: 2026-05-31 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260531_0002"
+down_revision = "20260529_0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "visits",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("patient_id", sa.Integer(), nullable=False),
+        sa.Column("visit_date", sa.Date(), nullable=False),
+        sa.Column("visit_type", sa.String(length=100), nullable=False),
+        sa.Column("staff_name", sa.String(length=200), nullable=True),
+        sa.Column("staff_role", sa.String(length=50), nullable=True),
+        sa.Column("time_in", sa.Time(), nullable=True),
+        sa.Column("time_out", sa.Time(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "staff_role IN ('aide', 'nurse')",
+            name="ck_visits_staff_role",
+        ),
+        sa.CheckConstraint(
+            "status IN ('scheduled', 'completed', 'cancelled')",
+            name="ck_visits_status",
+        ),
+        sa.ForeignKeyConstraint(["patient_id"], ["patients.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_visits_patient_id", "visits", ["patient_id"])
+
+
+def downgrade():
+    op.drop_index("ix_visits_patient_id", table_name="visits")
+    op.drop_table("visits")

--- a/backend/tests/test_openapi.py
+++ b/backend/tests/test_openapi.py
@@ -21,11 +21,17 @@ def test_openapi_json_includes_health_and_patient_endpoints(client):
     assert "/api/health" in paths
     assert "/api/patients" in paths
     assert "/api/patients/{patient_id}" in paths
+    assert "/api/visits" in paths
+    assert "/api/visits/{visit_id}" in paths
+    assert "/api/patients/{patient_id}/visits" in paths
     assert "get" in paths["/api/health"]
     assert {"get", "post"} <= set(paths["/api/patients"].keys())
     assert {"get", "put", "delete"} <= set(
         paths["/api/patients/{patient_id}"].keys()
     )
+    assert {"get", "post"} <= set(paths["/api/visits"].keys())
+    assert {"get", "put", "delete"} <= set(paths["/api/visits/{visit_id}"].keys())
+    assert "get" in paths["/api/patients/{patient_id}/visits"]
 
 
 def test_openapi_json_includes_patient_schemas(client):
@@ -38,3 +44,8 @@ def test_openapi_json_includes_patient_schemas(client):
     assert "ErrorResponse" in definitions
     assert "PatientSuccessResponse" in definitions
     assert "PatientListSuccessResponse" in definitions
+    assert "Visit" in definitions
+    assert "VisitCreate" in definitions
+    assert "VisitUpdate" in definitions
+    assert "VisitResponse" in definitions
+    assert "VisitListResponse" in definitions

--- a/backend/tests/test_visits.py
+++ b/backend/tests/test_visits.py
@@ -1,0 +1,148 @@
+def patient_payload(**overrides):
+    payload = {
+        "first_name": "Maria",
+        "last_name": "Santos",
+        "date_of_birth": "1945-03-12",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def create_patient(client, **overrides):
+    return client.post("/api/patients", json=patient_payload(**overrides)).get_json()[
+        "data"
+    ]
+
+
+def visit_payload(patient_id, **overrides):
+    payload = {
+        "patient_id": patient_id,
+        "visit_date": "2026-06-01",
+        "visit_type": "Home care visit",
+        "staff_name": "Jordan Lee",
+        "staff_role": "aide",
+        "time_in": "09:00",
+        "time_out": "10:30",
+        "notes": "Patient completed morning mobility exercises.",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def create_visit(client, patient_id, **overrides):
+    return client.post("/api/visits", json=visit_payload(patient_id, **overrides))
+
+
+def test_create_visit_for_patient(client):
+    patient = create_patient(client)
+
+    response = create_visit(client, patient["id"])
+    body = response.get_json()
+
+    assert response.status_code == 201
+    assert body["message"] == "Visit created successfully"
+    assert body["data"]["patient_id"] == patient["id"]
+    assert body["data"]["visit_date"] == "2026-06-01"
+    assert body["data"]["visit_type"] == "Home care visit"
+    assert body["data"]["status"] == "scheduled"
+
+
+def test_list_visits(client):
+    patient = create_patient(client)
+    create_visit(client, patient["id"])
+    create_visit(client, patient["id"], visit_date="2026-06-02", staff_role="nurse")
+
+    response = client.get("/api/visits")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["message"] == "Visits retrieved successfully"
+    assert len(body["data"]) == 2
+
+
+def test_list_visits_for_specific_patient(client):
+    patient = create_patient(client)
+    other_patient = create_patient(client, first_name="John", last_name="Rivera")
+    create_visit(client, patient["id"])
+    create_visit(client, other_patient["id"])
+
+    response = client.get(f"/api/patients/{patient['id']}/visits")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["message"] == "Patient visits retrieved successfully"
+    assert len(body["data"]) == 1
+    assert body["data"][0]["patient_id"] == patient["id"]
+
+
+def test_get_visit(client):
+    patient = create_patient(client)
+    created = create_visit(client, patient["id"]).get_json()["data"]
+
+    response = client.get(f"/api/visits/{created['id']}")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["data"]["id"] == created["id"]
+    assert body["data"]["staff_name"] == "Jordan Lee"
+
+
+def test_update_visit(client):
+    patient = create_patient(client)
+    created = create_visit(client, patient["id"]).get_json()["data"]
+
+    response = client.put(
+        f"/api/visits/{created['id']}",
+        json={
+            "staff_role": "nurse",
+            "status": "completed",
+            "notes": "Vitals checked and medication reminder completed.",
+        },
+    )
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["message"] == "Visit updated successfully"
+    assert body["data"]["staff_role"] == "nurse"
+    assert body["data"]["status"] == "completed"
+
+
+def test_delete_visit(client):
+    patient = create_patient(client)
+    created = create_visit(client, patient["id"]).get_json()["data"]
+
+    response = client.delete(f"/api/visits/{created['id']}")
+
+    assert response.status_code == 200
+    assert response.get_json()["message"] == "Visit deleted successfully"
+    assert client.get(f"/api/visits/{created['id']}").status_code == 404
+
+
+def test_create_visit_requires_patient_id_and_visit_date(client):
+    response = client.post("/api/visits", json={"visit_type": "Home care visit"})
+    body = response.get_json()
+
+    assert response.status_code == 400
+    assert body["message"] == "Invalid visit data"
+    assert body["errors"]["patient_id"] == "This field is required."
+    assert body["errors"]["visit_date"] == "This field is required."
+
+
+def test_create_visit_rejects_invalid_patient_id(client):
+    response = client.post("/api/visits", json=visit_payload(999))
+    body = response.get_json()
+
+    assert response.status_code == 400
+    assert body["message"] == "Invalid visit data"
+    assert body["errors"]["patient_id"] == "Patient not found."
+
+
+def test_create_visit_validates_staff_role(client):
+    patient = create_patient(client)
+
+    response = create_visit(client, patient["id"], staff_role="therapist")
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["staff_role"] == (
+        "Staff role must be aide or nurse."
+    )

--- a/docs/architecture/api-design.md
+++ b/docs/architecture/api-design.md
@@ -206,3 +206,198 @@ Example response:
   "message": "Patient deleted successfully"
 }
 ```
+
+## Visit API
+
+The Visit API records caregiver and nursing visits linked to patients.
+
+### Visit Fields
+
+- `id`
+- `patient_id`
+- `visit_date`
+- `visit_type`
+- `staff_name`
+- `staff_role`
+- `time_in`
+- `time_out`
+- `notes`
+- `status`
+- `created_at`
+- `updated_at`
+
+`patient_id`, `visit_date`, and `visit_type` are required. `visit_date` must use `YYYY-MM-DD`. `staff_role` currently supports `aide` and `nurse`. `status` defaults to `scheduled` and must be `scheduled`, `completed`, or `cancelled`.
+
+### List Visits
+
+`GET /api/visits`
+
+Example response:
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "patient_id": 1,
+      "visit_date": "2026-06-01",
+      "visit_type": "Home care visit",
+      "staff_name": "Jordan Lee",
+      "staff_role": "aide",
+      "time_in": "09:00",
+      "time_out": "10:30",
+      "notes": "Patient completed morning mobility exercises.",
+      "status": "scheduled",
+      "created_at": "2026-05-31T10:00:00+00:00",
+      "updated_at": "2026-05-31T10:00:00+00:00"
+    }
+  ],
+  "message": "Visits retrieved successfully"
+}
+```
+
+### List Visits for a Patient
+
+`GET /api/patients/<patient_id>/visits`
+
+Example response:
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "patient_id": 1,
+      "visit_date": "2026-06-01",
+      "visit_type": "Home care visit",
+      "staff_name": "Jordan Lee",
+      "staff_role": "aide",
+      "time_in": "09:00",
+      "time_out": "10:30",
+      "notes": "Patient completed morning mobility exercises.",
+      "status": "scheduled",
+      "created_at": "2026-05-31T10:00:00+00:00",
+      "updated_at": "2026-05-31T10:00:00+00:00"
+    }
+  ],
+  "message": "Patient visits retrieved successfully"
+}
+```
+
+### Retrieve a Visit
+
+`GET /api/visits/<id>`
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "patient_id": 1,
+    "visit_date": "2026-06-01",
+    "visit_type": "Home care visit",
+    "staff_name": "Jordan Lee",
+    "staff_role": "aide",
+    "time_in": "09:00",
+    "time_out": "10:30",
+    "notes": "Patient completed morning mobility exercises.",
+    "status": "scheduled",
+    "created_at": "2026-05-31T10:00:00+00:00",
+    "updated_at": "2026-05-31T10:00:00+00:00"
+  },
+  "message": "Visit retrieved successfully"
+}
+```
+
+### Create a Visit
+
+`POST /api/visits`
+
+Example request:
+
+```json
+{
+  "patient_id": 1,
+  "visit_date": "2026-06-01",
+  "visit_type": "Home care visit",
+  "staff_name": "Jordan Lee",
+  "staff_role": "aide",
+  "time_in": "09:00",
+  "time_out": "10:30",
+  "notes": "Patient completed morning mobility exercises."
+}
+```
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "patient_id": 1,
+    "visit_date": "2026-06-01",
+    "visit_type": "Home care visit",
+    "staff_name": "Jordan Lee",
+    "staff_role": "aide",
+    "time_in": "09:00",
+    "time_out": "10:30",
+    "notes": "Patient completed morning mobility exercises.",
+    "status": "scheduled",
+    "created_at": "2026-05-31T10:00:00+00:00",
+    "updated_at": "2026-05-31T10:00:00+00:00"
+  },
+  "message": "Visit created successfully"
+}
+```
+
+### Update a Visit
+
+`PUT /api/visits/<id>`
+
+Example request:
+
+```json
+{
+  "staff_role": "nurse",
+  "status": "completed",
+  "notes": "Vitals checked and medication reminder completed."
+}
+```
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "patient_id": 1,
+    "visit_date": "2026-06-01",
+    "visit_type": "Home care visit",
+    "staff_name": "Jordan Lee",
+    "staff_role": "nurse",
+    "time_in": "09:00",
+    "time_out": "10:30",
+    "notes": "Vitals checked and medication reminder completed.",
+    "status": "completed",
+    "created_at": "2026-05-31T10:00:00+00:00",
+    "updated_at": "2026-05-31T10:15:00+00:00"
+  },
+  "message": "Visit updated successfully"
+}
+```
+
+### Delete a Visit
+
+`DELETE /api/visits/<id>`
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1
+  },
+  "message": "Visit deleted successfully"
+}
+```


### PR DESCRIPTION
# Summary

- Added a patient-linked Visit model with SQLAlchemy relationships and cascade behavior from Patient to Visits.
- Added Visits CRUD endpoints and `GET /api/patients/{patient_id}/visits` with consistent JSON response envelopes and validation errors.
- Added an Alembic migration for the `visits` table with patient foreign key, status constraints, and staff role constraints.
- Added Swagger/OpenAPI definitions and endpoint specs for the Visit API.
- Added backend tests and updated API design documentation and CHANGELOG.md.

## Related Issue / Task

- Feature: 07-visits-api

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `docker-compose exec -T backend pytest`
- `docker-compose exec -T backend ruff check .`
- `docker-compose exec -T backend flask db upgrade`
- `curl -s http://localhost:5001/api/openapi.json`
- `curl -s http://localhost:5001/api/visits`
- `docker-compose exec -T postgres psql -U seniormate -d seniormate -c "\\dt"`
- `docker-compose config`
- `docker-compose build backend`
- `npm run build`
- `git diff --check`
- Secret-pattern scan with `rg`

## Screenshots

N/A

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.