### PR TITLE
feat: add visits management UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added the Visits frontend with list, create, edit, detail, delete, API service workflows, and patient detail integration.
 - Added the Visits API with patient-linked visit records, migration, CRUD endpoints, Swagger documentation, tests, and API documentation.
 - Added the Patient Management frontend with list, create, edit, detail, delete, and API service workflows.
 - Added Swagger/OpenAPI documentation with browser-based API testing for health and patient endpoints.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Docker Compose is the recommended way to run the local SeniorMate stack. It star
 
    - Frontend: `http://localhost:5173`
    - Patient management UI: `http://localhost:5173/patients`
+   - Visits UI: `http://localhost:5173/visits`
    - Backend health: `http://localhost:5001/api/health`
    - Swagger UI: `http://localhost:5001/api/docs`
    - OpenAPI JSON: `http://localhost:5001/api/openapi.json`

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -4,6 +4,9 @@ import DashboardView from "./views/DashboardView.js";
 import PatientDetailView from "./views/PatientDetailView.js";
 import PatientFormView from "./views/PatientFormView.js";
 import PatientListView from "./views/PatientListView.js";
+import VisitDetailView from "./views/VisitDetailView.js";
+import VisitFormView from "./views/VisitFormView.js";
+import VisitListView from "./views/VisitListView.js";
 
 const routes = [
   {
@@ -32,6 +35,29 @@ const routes = [
     path: "/patients/:id/edit",
     name: "patient-edit",
     component: PatientFormView,
+    props: { mode: "edit" },
+  },
+  {
+    path: "/visits",
+    name: "visits",
+    component: VisitListView,
+  },
+  {
+    path: "/visits/new",
+    name: "visit-create",
+    component: VisitFormView,
+    props: { mode: "create" },
+  },
+  {
+    path: "/visits/:id",
+    name: "visit-detail",
+    component: VisitDetailView,
+    props: true,
+  },
+  {
+    path: "/visits/:id/edit",
+    name: "visit-edit",
+    component: VisitFormView,
     props: { mode: "edit" },
   },
 ];

--- a/frontend/src/services/http.js
+++ b/frontend/src/services/http.js
@@ -1,0 +1,26 @@
+import { apiBaseUrl } from "../config.js";
+
+export async function parseResponse(response) {
+  const payload = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const message = payload.message || "The request could not be completed.";
+    const error = new Error(message);
+    error.payload = payload;
+    throw error;
+  }
+
+  return payload;
+}
+
+export async function apiRequest(path, options = {}) {
+  const response = await fetch(`${apiBaseUrl}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+    ...options,
+  });
+
+  return parseResponse(response);
+}

--- a/frontend/src/services/patients.js
+++ b/frontend/src/services/patients.js
@@ -1,29 +1,4 @@
-import { apiBaseUrl } from "../config.js";
-
-async function parseResponse(response) {
-  const payload = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const message = payload.message || "The request could not be completed.";
-    const error = new Error(message);
-    error.payload = payload;
-    throw error;
-  }
-
-  return payload;
-}
-
-async function apiRequest(path, options = {}) {
-  const response = await fetch(`${apiBaseUrl}${path}`, {
-    headers: {
-      "Content-Type": "application/json",
-      ...(options.headers || {}),
-    },
-    ...options,
-  });
-
-  return parseResponse(response);
-}
+import { apiRequest } from "./http.js";
 
 export async function listPatients() {
   return apiRequest("/patients");

--- a/frontend/src/services/visits.js
+++ b/frontend/src/services/visits.js
@@ -1,0 +1,33 @@
+import { apiRequest } from "./http.js";
+
+export async function listVisits() {
+  return apiRequest("/visits");
+}
+
+export async function getVisit(id) {
+  return apiRequest(`/visits/${id}`);
+}
+
+export async function createVisit(visit) {
+  return apiRequest("/visits", {
+    method: "POST",
+    body: JSON.stringify(visit),
+  });
+}
+
+export async function updateVisit(id, visit) {
+  return apiRequest(`/visits/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(visit),
+  });
+}
+
+export async function deleteVisit(id) {
+  return apiRequest(`/visits/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export async function listPatientVisits(patientId) {
+  return apiRequest(`/patients/${patientId}/visits`);
+}

--- a/frontend/src/views/App.js
+++ b/frontend/src/views/App.js
@@ -3,6 +3,7 @@ import { ref } from "vue";
 const navItems = [
   { title: "Dashboard", icon: "mdi-view-dashboard-outline", to: "/" },
   { title: "Patients", icon: "mdi-account-heart-outline", to: "/patients" },
+  { title: "Visits", icon: "mdi-calendar-clock-outline", to: "/visits" },
 ];
 
 export default {

--- a/frontend/src/views/PatientDetailView.js
+++ b/frontend/src/views/PatientDetailView.js
@@ -1,6 +1,7 @@
 import { computed, onMounted, ref } from "vue";
 
 import { getPatient } from "../services/patients.js";
+import { deleteVisit, listPatientVisits } from "../services/visits.js";
 
 export default {
   props: {
@@ -11,8 +12,22 @@ export default {
   },
   setup(props) {
     const patient = ref(null);
+    const visits = ref([]);
     const loading = ref(true);
     const error = ref("");
+    const success = ref("");
+    const deleting = ref(false);
+    const selectedVisit = ref(null);
+    const confirmDelete = ref(false);
+
+    const visitHeaders = [
+      { title: "Visit date", key: "visit_date" },
+      { title: "Visit type", key: "visit_type" },
+      { title: "Staff name", key: "staff_name" },
+      { title: "Staff role", key: "staff_role" },
+      { title: "Status", key: "status" },
+      { title: "Actions", key: "actions", sortable: false },
+    ];
 
     const fullName = computed(() =>
       patient.value ? `${patient.value.first_name} ${patient.value.last_name}` : ""
@@ -23,8 +38,12 @@ export default {
       error.value = "";
 
       try {
-        const response = await getPatient(props.id);
-        patient.value = response.data;
+        const [patientResponse, visitResponse] = await Promise.all([
+          getPatient(props.id),
+          listPatientVisits(props.id),
+        ]);
+        patient.value = patientResponse.data;
+        visits.value = visitResponse.data;
       } catch (err) {
         error.value = err.message;
       } finally {
@@ -32,13 +51,46 @@ export default {
       }
     }
 
+    function askDelete(visit) {
+      selectedVisit.value = visit;
+      confirmDelete.value = true;
+    }
+
+    async function removeVisit() {
+      if (!selectedVisit.value) return;
+
+      deleting.value = true;
+      error.value = "";
+      success.value = "";
+
+      try {
+        await deleteVisit(selectedVisit.value.id);
+        success.value = "Visit deleted successfully.";
+        confirmDelete.value = false;
+        selectedVisit.value = null;
+        await loadPatient();
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        deleting.value = false;
+      }
+    }
+
     onMounted(loadPatient);
 
     return {
       error,
+      askDelete,
+      confirmDelete,
+      deleting,
       fullName,
       loading,
       patient,
+      removeVisit,
+      selectedVisit,
+      success,
+      visitHeaders,
+      visits,
     };
   },
   template: `
@@ -49,6 +101,9 @@ export default {
 
       <v-alert v-if="error" type="error" variant="tonal" class="mb-4">
         {{ error }}
+      </v-alert>
+      <v-alert v-if="success" type="success" variant="tonal" class="mb-4">
+        {{ success }}
       </v-alert>
 
       <v-skeleton-loader v-if="loading" type="heading, paragraph, card" />
@@ -62,13 +117,16 @@ export default {
             </v-chip>
           </v-col>
           <v-col cols="12" md="4" class="text-md-right">
-            <v-btn color="primary" prepend-icon="mdi-pencil-outline" :to="\`/patients/\${patient.id}/edit\`">
+            <v-btn color="primary" prepend-icon="mdi-calendar-plus-outline" :to="\`/visits/new?patient_id=\${patient.id}\`" class="mr-2">
+              New visit
+            </v-btn>
+            <v-btn color="primary" variant="tonal" prepend-icon="mdi-pencil-outline" :to="\`/patients/\${patient.id}/edit\`">
               Edit patient
             </v-btn>
           </v-col>
         </v-row>
 
-        <v-row>
+        <v-row class="mb-5">
           <v-col cols="12" md="6">
             <v-card>
               <v-card-title>Demographics</v-card-title>
@@ -95,7 +153,52 @@ export default {
             </v-card>
           </v-col>
         </v-row>
+
+        <v-card>
+          <v-card-title>Visits</v-card-title>
+          <v-data-table
+            :headers="visitHeaders"
+            :items="visits"
+            item-value="id"
+          >
+            <template #no-data>
+              <div class="pa-8 text-center">
+                <v-icon icon="mdi-calendar-clock-outline" size="40" class="mb-3" />
+                <div class="text-h6 mb-2">No visits yet</div>
+                <v-btn color="primary" variant="flat" :to="\`/visits/new?patient_id=\${patient.id}\`">Create visit</v-btn>
+              </div>
+            </template>
+
+            <template #[\`item.status\`]="{ item }">
+              <v-chip :color="item.status === 'completed' ? 'success' : item.status === 'cancelled' ? 'grey' : 'primary'" size="small">
+                {{ item.status }}
+              </v-chip>
+            </template>
+
+            <template #[\`item.actions\`]="{ item }">
+              <v-btn icon="mdi-eye-outline" variant="text" :to="\`/visits/\${item.id}\`" aria-label="View visit" />
+              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/visits/\${item.id}/edit\`" aria-label="Edit visit" />
+              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete visit" @click="askDelete(item)" />
+            </template>
+          </v-data-table>
+        </v-card>
       </template>
+
+      <v-dialog v-model="confirmDelete" max-width="440">
+        <v-card>
+          <v-card-title>Delete visit</v-card-title>
+          <v-card-text>
+            Delete {{ selectedVisit?.visit_type }} from {{ selectedVisit?.visit_date }}?
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn variant="text" @click="confirmDelete = false">Cancel</v-btn>
+            <v-btn color="error" variant="flat" :loading="deleting" @click="removeVisit">
+              Delete
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
     </v-container>
   `,
 };

--- a/frontend/src/views/VisitDetailView.js
+++ b/frontend/src/views/VisitDetailView.js
@@ -1,0 +1,117 @@
+import { computed, onMounted, ref } from "vue";
+
+import { listPatients } from "../services/patients.js";
+import { getVisit } from "../services/visits.js";
+
+export default {
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    const visit = ref(null);
+    const patients = ref([]);
+    const loading = ref(true);
+    const error = ref("");
+
+    const patient = computed(() =>
+      patients.value.find((candidate) => candidate.id === visit.value?.patient_id)
+    );
+    const patientName = computed(() =>
+      patient.value
+        ? `${patient.value.first_name} ${patient.value.last_name}`
+        : visit.value
+          ? `Patient #${visit.value.patient_id}`
+          : ""
+    );
+
+    async function loadVisit() {
+      loading.value = true;
+      error.value = "";
+
+      try {
+        const [visitResponse, patientResponse] = await Promise.all([
+          getVisit(props.id),
+          listPatients(),
+        ]);
+        visit.value = visitResponse.data;
+        patients.value = patientResponse.data;
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    onMounted(loadVisit);
+
+    return {
+      error,
+      loading,
+      patient,
+      patientName,
+      visit,
+    };
+  },
+  template: `
+    <v-container class="py-8" style="max-width: 1120px;">
+      <v-btn variant="text" prepend-icon="mdi-arrow-left" to="/visits" class="mb-4">
+        Visits
+      </v-btn>
+
+      <v-alert v-if="error" type="error" variant="tonal" class="mb-4">
+        {{ error }}
+      </v-alert>
+
+      <v-skeleton-loader v-if="loading" type="heading, paragraph, card" />
+
+      <template v-else-if="visit">
+        <v-row align="center" class="mb-5">
+          <v-col cols="12" md="8">
+            <h1 class="text-h4 font-weight-bold mb-2">{{ visit.visit_type }}</h1>
+            <div class="text-body-1 text-medium-emphasis mb-2">{{ visit.visit_date }} · {{ patientName }}</div>
+            <v-chip :color="visit.status === 'completed' ? 'success' : visit.status === 'cancelled' ? 'grey' : 'primary'" size="small">
+              {{ visit.status }}
+            </v-chip>
+          </v-col>
+          <v-col cols="12" md="4" class="text-md-right">
+            <v-btn color="primary" prepend-icon="mdi-pencil-outline" :to="\`/visits/\${visit.id}/edit\`">
+              Edit visit
+            </v-btn>
+          </v-col>
+        </v-row>
+
+        <v-row>
+          <v-col cols="12" md="6">
+            <v-card>
+              <v-card-title>Visit metadata</v-card-title>
+              <v-list>
+                <v-list-item title="Patient" :subtitle="patientName" :to="\`/patients/\${visit.patient_id}\`" />
+                <v-list-item title="Visit date" :subtitle="visit.visit_date || 'Not provided'" />
+                <v-list-item title="Visit type" :subtitle="visit.visit_type || 'Not provided'" />
+                <v-list-item title="Status" :subtitle="visit.status || 'Not provided'" />
+              </v-list>
+            </v-card>
+          </v-col>
+
+          <v-col cols="12" md="6">
+            <v-card>
+              <v-card-title>Staff details</v-card-title>
+              <v-list>
+                <v-list-item title="Staff name" :subtitle="visit.staff_name || 'Not provided'" />
+                <v-list-item title="Staff role" :subtitle="visit.staff_role || 'Not provided'" />
+                <v-list-item title="Time in" :subtitle="visit.time_in || 'Not provided'" />
+                <v-list-item title="Time out" :subtitle="visit.time_out || 'Not provided'" />
+              </v-list>
+              <v-divider />
+              <v-card-title>Notes</v-card-title>
+              <v-card-text>{{ visit.notes || 'Not provided' }}</v-card-text>
+            </v-card>
+          </v-col>
+        </v-row>
+      </template>
+    </v-container>
+  `,
+};

--- a/frontend/src/views/VisitFormView.js
+++ b/frontend/src/views/VisitFormView.js
@@ -1,0 +1,237 @@
+import { computed, onMounted, ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
+
+import { listPatients } from "../services/patients.js";
+import { createVisit, getVisit, updateVisit } from "../services/visits.js";
+
+const emptyForm = {
+  patient_id: null,
+  visit_date: "",
+  visit_type: "",
+  staff_name: "",
+  staff_role: "aide",
+  time_in: "",
+  time_out: "",
+  status: "scheduled",
+  notes: "",
+};
+
+export default {
+  props: {
+    mode: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    const route = useRoute();
+    const router = useRouter();
+    const form = ref({ ...emptyForm });
+    const patients = ref([]);
+    const errors = ref({});
+    const error = ref("");
+    const loading = ref(false);
+    const saving = ref(false);
+
+    const isEdit = computed(() => props.mode === "edit");
+    const title = computed(() => (isEdit.value ? "Edit visit" : "New visit"));
+    const patientOptions = computed(() =>
+      patients.value.map((patient) => ({
+        title: `${patient.first_name} ${patient.last_name}`,
+        value: patient.id,
+      }))
+    );
+
+    function validate() {
+      const nextErrors = {};
+
+      if (!form.value.patient_id) {
+        nextErrors.patient_id = "Patient is required.";
+      }
+
+      if (!form.value.visit_date) {
+        nextErrors.visit_date = "Visit date is required.";
+      }
+
+      if (!form.value.visit_type.trim()) {
+        nextErrors.visit_type = "Visit type is required.";
+      }
+
+      errors.value = nextErrors;
+      return Object.keys(nextErrors).length === 0;
+    }
+
+    function apiPayload() {
+      const payload = {};
+
+      for (const [key, value] of Object.entries(form.value)) {
+        payload[key] = typeof value === "string" && value === "" ? null : value;
+      }
+
+      payload.patient_id = Number(form.value.patient_id);
+      payload.visit_date = form.value.visit_date;
+      payload.visit_type = form.value.visit_type.trim();
+      payload.staff_role = form.value.staff_role || null;
+      payload.status = form.value.status || "scheduled";
+
+      return payload;
+    }
+
+    async function loadForm() {
+      loading.value = true;
+      error.value = "";
+
+      try {
+        const patientResponse = await listPatients();
+        patients.value = patientResponse.data;
+
+        if (isEdit.value) {
+          const visitResponse = await getVisit(route.params.id);
+          form.value = {
+            ...emptyForm,
+            ...visitResponse.data,
+            visit_date: visitResponse.data.visit_date || "",
+            time_in: visitResponse.data.time_in || "",
+            time_out: visitResponse.data.time_out || "",
+          };
+        } else if (route.query.patient_id) {
+          form.value.patient_id = Number(route.query.patient_id);
+        }
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    async function submit() {
+      error.value = "";
+
+      if (!validate()) return;
+
+      saving.value = true;
+
+      try {
+        const response = isEdit.value
+          ? await updateVisit(route.params.id, apiPayload())
+          : await createVisit(apiPayload());
+
+        await router.push(`/visits/${response.data.id}`);
+      } catch (err) {
+        error.value = err.message;
+        errors.value = err.payload?.errors || {};
+      } finally {
+        saving.value = false;
+      }
+    }
+
+    onMounted(loadForm);
+
+    return {
+      error,
+      errors,
+      form,
+      loading,
+      patientOptions,
+      saving,
+      submit,
+      title,
+    };
+  },
+  template: `
+    <v-container class="py-8" style="max-width: 960px;">
+      <v-btn variant="text" prepend-icon="mdi-arrow-left" to="/visits" class="mb-4">
+        Visits
+      </v-btn>
+
+      <h1 class="text-h4 font-weight-bold mb-5">{{ title }}</h1>
+
+      <v-alert v-if="error" type="error" variant="tonal" class="mb-4">
+        {{ error }}
+      </v-alert>
+
+      <v-skeleton-loader v-if="loading" type="heading, paragraph, card" />
+
+      <v-form v-else @submit.prevent="submit">
+        <v-card class="mb-5">
+          <v-card-title>Visit details</v-card-title>
+          <v-card-text>
+            <v-row>
+              <v-col cols="12" md="6">
+                <v-select
+                  v-model="form.patient_id"
+                  label="Patient"
+                  :items="patientOptions"
+                  item-title="title"
+                  item-value="value"
+                  :error-messages="errors.patient_id"
+                  required
+                />
+              </v-col>
+              <v-col cols="12" md="6">
+                <v-text-field
+                  v-model="form.visit_date"
+                  label="Visit date"
+                  type="date"
+                  :error-messages="errors.visit_date"
+                  required
+                />
+              </v-col>
+              <v-col cols="12" md="6">
+                <v-text-field
+                  v-model="form.visit_type"
+                  label="Visit type"
+                  :error-messages="errors.visit_type"
+                  required
+                />
+              </v-col>
+              <v-col cols="12" md="6">
+                <v-select
+                  v-model="form.status"
+                  label="Status"
+                  :items="['scheduled', 'completed', 'cancelled']"
+                  :error-messages="errors.status"
+                />
+              </v-col>
+            </v-row>
+          </v-card-text>
+        </v-card>
+
+        <v-card class="mb-5">
+          <v-card-title>Staff and time</v-card-title>
+          <v-card-text>
+            <v-row>
+              <v-col cols="12" md="6">
+                <v-text-field v-model="form.staff_name" label="Staff name" />
+              </v-col>
+              <v-col cols="12" md="6">
+                <v-select
+                  v-model="form.staff_role"
+                  label="Staff role"
+                  :items="['aide', 'nurse']"
+                  :error-messages="errors.staff_role"
+                />
+              </v-col>
+              <v-col cols="12" md="6">
+                <v-text-field v-model="form.time_in" label="Time in" type="time" :error-messages="errors.time_in" />
+              </v-col>
+              <v-col cols="12" md="6">
+                <v-text-field v-model="form.time_out" label="Time out" type="time" :error-messages="errors.time_out" />
+              </v-col>
+              <v-col cols="12">
+                <v-textarea v-model="form.notes" label="Notes" rows="4" />
+              </v-col>
+            </v-row>
+          </v-card-text>
+        </v-card>
+
+        <div class="d-flex justify-end ga-3">
+          <v-btn variant="text" to="/visits">Cancel</v-btn>
+          <v-btn color="primary" type="submit" :loading="saving">
+            Save visit
+          </v-btn>
+        </div>
+      </v-form>
+    </v-container>
+  `,
+};

--- a/frontend/src/views/VisitListView.js
+++ b/frontend/src/views/VisitListView.js
@@ -1,0 +1,178 @@
+import { computed, onMounted, ref } from "vue";
+
+import { listPatients } from "../services/patients.js";
+import { deleteVisit, listVisits } from "../services/visits.js";
+
+export default {
+  setup() {
+    const visits = ref([]);
+    const patients = ref([]);
+    const loading = ref(true);
+    const error = ref("");
+    const success = ref("");
+    const deleting = ref(false);
+    const selectedVisit = ref(null);
+    const confirmDelete = ref(false);
+
+    const headers = [
+      { title: "Patient", key: "patient_name" },
+      { title: "Visit date", key: "visit_date" },
+      { title: "Visit type", key: "visit_type" },
+      { title: "Staff name", key: "staff_name" },
+      { title: "Staff role", key: "staff_role" },
+      { title: "Time in", key: "time_in" },
+      { title: "Time out", key: "time_out" },
+      { title: "Status", key: "status" },
+      { title: "Actions", key: "actions", sortable: false },
+    ];
+
+    const patientNames = computed(() =>
+      Object.fromEntries(
+        patients.value.map((patient) => [
+          patient.id,
+          `${patient.first_name} ${patient.last_name}`,
+        ])
+      )
+    );
+
+    const rows = computed(() =>
+      visits.value.map((visit) => ({
+        ...visit,
+        patient_name: patientNames.value[visit.patient_id] || `Patient #${visit.patient_id}`,
+      }))
+    );
+
+    async function loadVisits() {
+      loading.value = true;
+      error.value = "";
+
+      try {
+        const [visitResponse, patientResponse] = await Promise.all([
+          listVisits(),
+          listPatients(),
+        ]);
+        visits.value = visitResponse.data;
+        patients.value = patientResponse.data;
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    function askDelete(visit) {
+      selectedVisit.value = visit;
+      confirmDelete.value = true;
+    }
+
+    async function removeVisit() {
+      if (!selectedVisit.value) return;
+
+      deleting.value = true;
+      error.value = "";
+      success.value = "";
+
+      try {
+        await deleteVisit(selectedVisit.value.id);
+        success.value = "Visit deleted successfully.";
+        confirmDelete.value = false;
+        selectedVisit.value = null;
+        await loadVisits();
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        deleting.value = false;
+      }
+    }
+
+    onMounted(loadVisits);
+
+    return {
+      askDelete,
+      confirmDelete,
+      deleting,
+      error,
+      headers,
+      loading,
+      removeVisit,
+      rows,
+      selectedVisit,
+      success,
+    };
+  },
+  template: `
+    <v-container class="py-8" style="max-width: 1440px;">
+      <v-row align="center" class="mb-5">
+        <v-col cols="12" md="8">
+          <h1 class="text-h4 font-weight-bold mb-1">Visits</h1>
+          <p class="text-body-2 text-medium-emphasis mb-0">Track caregiver and nursing visits for active patients.</p>
+        </v-col>
+        <v-col cols="12" md="4" class="text-md-right">
+          <v-btn color="primary" prepend-icon="mdi-plus" to="/visits/new">
+            New visit
+          </v-btn>
+        </v-col>
+      </v-row>
+
+      <v-alert v-if="error" type="error" variant="tonal" class="mb-4">
+        {{ error }}
+      </v-alert>
+      <v-alert v-if="success" type="success" variant="tonal" class="mb-4">
+        {{ success }}
+      </v-alert>
+
+      <v-card>
+        <v-data-table
+          :headers="headers"
+          :items="rows"
+          :loading="loading"
+          item-value="id"
+        >
+          <template #loading>
+            <v-skeleton-loader type="table-row@5" />
+          </template>
+
+          <template #no-data>
+            <div class="pa-8 text-center">
+              <v-icon icon="mdi-calendar-clock-outline" size="40" class="mb-3" />
+              <div class="text-h6 mb-2">No visits yet</div>
+              <v-btn color="primary" variant="flat" to="/visits/new">Create visit</v-btn>
+            </div>
+          </template>
+
+          <template #[\`item.patient_name\`]="{ item }">
+            <router-link :to="\`/patients/\${item.patient_id}\`">{{ item.patient_name }}</router-link>
+          </template>
+
+          <template #[\`item.status\`]="{ item }">
+            <v-chip :color="item.status === 'completed' ? 'success' : item.status === 'cancelled' ? 'grey' : 'primary'" size="small">
+              {{ item.status }}
+            </v-chip>
+          </template>
+
+          <template #[\`item.actions\`]="{ item }">
+            <v-btn icon="mdi-eye-outline" variant="text" :to="\`/visits/\${item.id}\`" aria-label="View visit" />
+            <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/visits/\${item.id}/edit\`" aria-label="Edit visit" />
+            <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete visit" @click="askDelete(item)" />
+          </template>
+        </v-data-table>
+      </v-card>
+
+      <v-dialog v-model="confirmDelete" max-width="440">
+        <v-card>
+          <v-card-title>Delete visit</v-card-title>
+          <v-card-text>
+            Delete {{ selectedVisit?.visit_type }} for {{ selectedVisit?.patient_name }}?
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn variant="text" @click="confirmDelete = false">Cancel</v-btn>
+            <v-btn color="error" variant="flat" :loading="deleting" @click="removeVisit">
+              Delete
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+    </v-container>
+  `,
+};


### PR DESCRIPTION
# Summary

- Added Visits navigation, routes, list page, create/edit form, and detail page.
- Added Visits API service functions and shared frontend HTTP helper.
- Connected Visits UI to the existing Visits API with loading, empty, error, delete-confirmation, and success states.
- Integrated patient detail pages with linked visits and a preselected create-visit action.
- Updated README local UI links and CHANGELOG.md.

## Related Issue / Task

- Feature: 08-visits-ui

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `npm ci`
- `npm run build`
- `docker-compose config`
- `docker-compose up -d postgres minio backend frontend`
- `docker-compose exec -T backend pytest`
- `docker-compose exec -T backend ruff check .`
- `docker-compose exec -T backend flask db upgrade`
- `curl -s http://localhost:5001/api/visits`
- `curl -s http://localhost:5173/visits`
- `docker-compose build frontend`
- Browser manual workflow: patient detail linked visits, create visit with preselected patient, visit detail, edit visit, visits list, delete confirmation, and refreshed empty state.
- `git diff --check`
- Secret-pattern scan with `rg`.

## Screenshots

Screenshots captured locally during browser validation:

- Visit form: `/private/tmp/seniormate-visit-form.png`
- Visit detail: `/private/tmp/seniormate-visit-detail.png`
- Visits list: `/private/tmp/seniormate-visits-list.png`
- Patient detail with linked visits: `/private/tmp/seniormate-visits-patient-detail-linked.png`

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.