### PR TITLE
feat: add aide note API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added the Home Health Aide Note API with patient/visit-linked records, JSON checklist storage, duplicate visit-note prevention, Swagger documentation, tests, and API documentation.
 - Added the Visits frontend with list, create, edit, detail, delete, API service workflows, and patient detail integration.
 - Added the Visits API with patient-linked visit records, migration, CRUD endpoints, Swagger documentation, tests, and API documentation.
 - Added the Patient Management frontend with list, create, edit, detail, delete, and API service workflows.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -5,8 +5,10 @@ from sqlalchemy import text
 
 from app.config import Config
 from app.extensions import db, migrate
+from app.models import AideNote as AideNote
 from app.models import Patient as Patient
 from app.models import Visit as Visit
+from app.routes.aide_notes import aide_notes_bp
 from app.routes.patients import patients_bp
 from app.routes.visits import visits_bp
 from app.swagger import health_spec, swagger_config, swagger_template
@@ -20,6 +22,7 @@ def create_app(config_object=Config):
 
     db.init_app(app)
     migrate.init_app(app, db)
+    app.register_blueprint(aide_notes_bp)
     app.register_blueprint(patients_bp)
     app.register_blueprint(visits_bp)
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,6 @@
+from app.models.aide_note import AideNote
 from app.models.patient import Patient
 from app.models.visit import Visit
 
 
-__all__ = ["Patient", "Visit"]
+__all__ = ["AideNote", "Patient", "Visit"]

--- a/backend/app/models/aide_note.py
+++ b/backend/app/models/aide_note.py
@@ -1,0 +1,77 @@
+from datetime import UTC, datetime
+
+from app.extensions import db
+
+
+class AideNote(db.Model):
+    __tablename__ = "aide_notes"
+
+    id = db.Column(db.Integer, primary_key=True)
+    patient_id = db.Column(
+        db.Integer,
+        db.ForeignKey("patients.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    visit_id = db.Column(
+        db.Integer,
+        db.ForeignKey("visits.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    personal_care = db.Column(db.JSON, nullable=True)
+    nutrition = db.Column(db.JSON, nullable=True)
+    mental_status = db.Column(db.JSON, nullable=True)
+    elimination = db.Column(db.JSON, nullable=True)
+    activity = db.Column(db.JSON, nullable=True)
+    assistive_devices = db.Column(db.JSON, nullable=True)
+    housekeeping = db.Column(db.JSON, nullable=True)
+    additional_notes = db.Column(db.Text, nullable=True)
+    aide_name = db.Column(db.String(200), nullable=False)
+    signature_data = db.Column(db.Text, nullable=True)
+    signature_date = db.Column(db.Date, nullable=True)
+    time_in = db.Column(db.Time, nullable=True)
+    time_out = db.Column(db.Time, nullable=True)
+    created_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    patient = db.relationship("Patient", back_populates="aide_notes")
+    visit = db.relationship("Visit", back_populates="aide_note")
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "patient_id": self.patient_id,
+            "visit_id": self.visit_id,
+            "personal_care": self.personal_care,
+            "nutrition": self.nutrition,
+            "mental_status": self.mental_status,
+            "elimination": self.elimination,
+            "activity": self.activity,
+            "assistive_devices": self.assistive_devices,
+            "housekeeping": self.housekeeping,
+            "additional_notes": self.additional_notes,
+            "aide_name": self.aide_name,
+            "signature_data": self.signature_data,
+            "signature_date": self.signature_date.isoformat()
+            if self.signature_date
+            else None,
+            "time_in": self.time_in.isoformat(timespec="minutes")
+            if self.time_in
+            else None,
+            "time_out": self.time_out.isoformat(timespec="minutes")
+            if self.time_out
+            else None,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/backend/app/models/patient.py
+++ b/backend/app/models/patient.py
@@ -39,6 +39,11 @@ class Patient(db.Model):
         back_populates="patient",
         cascade="all, delete-orphan",
     )
+    aide_notes = db.relationship(
+        "AideNote",
+        back_populates="patient",
+        cascade="all, delete-orphan",
+    )
 
     def to_dict(self):
         return {

--- a/backend/app/models/visit.py
+++ b/backend/app/models/visit.py
@@ -43,6 +43,12 @@ class Visit(db.Model):
     )
 
     patient = db.relationship("Patient", back_populates="visits")
+    aide_note = db.relationship(
+        "AideNote",
+        back_populates="visit",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )
 
     def to_dict(self):
         return {

--- a/backend/app/routes/aide_notes.py
+++ b/backend/app/routes/aide_notes.py
@@ -1,0 +1,260 @@
+from datetime import date, time
+
+from flasgger import swag_from
+from flask import Blueprint, jsonify, request
+
+from app.extensions import db
+from app.models import AideNote, Patient, Visit
+from app.swagger import (
+    aide_note_create_spec,
+    aide_note_delete_spec,
+    aide_note_get_spec,
+    aide_note_list_spec,
+    aide_note_update_spec,
+    patient_aide_notes_list_spec,
+    visit_aide_note_get_spec,
+)
+
+
+aide_notes_bp = Blueprint("aide_notes", __name__, url_prefix="/api")
+
+JSON_FIELDS = {
+    "personal_care",
+    "nutrition",
+    "mental_status",
+    "elimination",
+    "activity",
+    "assistive_devices",
+    "housekeeping",
+}
+AIDE_NOTE_FIELDS = {
+    "patient_id",
+    "visit_id",
+    "additional_notes",
+    "aide_name",
+    "signature_data",
+    "signature_date",
+    "time_in",
+    "time_out",
+    *JSON_FIELDS,
+}
+
+
+def success_response(data, message, status_code=200):
+    return jsonify({"data": data, "message": message}), status_code
+
+
+def error_response(message, status_code=400, errors=None):
+    payload = {"message": message}
+
+    if errors:
+        payload["errors"] = errors
+
+    return jsonify(payload), status_code
+
+
+def parse_time(value):
+    if value is None or value == "":
+        return None
+
+    if not isinstance(value, str):
+        raise ValueError
+
+    return time.fromisoformat(value)
+
+
+def parse_aide_note_payload(payload, partial=False, current_note=None):
+    if not isinstance(payload, dict):
+        return None, {"request": "JSON body is required."}
+
+    data = {}
+    errors = {}
+    patient = None
+    visit = None
+
+    for field in AIDE_NOTE_FIELDS:
+        if field in payload:
+            data[field] = payload[field]
+
+    if not partial or "patient_id" in data:
+        patient_id = data.get("patient_id")
+        if patient_id in (None, ""):
+            errors["patient_id"] = "This field is required."
+        elif not isinstance(patient_id, int):
+            errors["patient_id"] = "Patient ID must be an integer."
+        else:
+            patient = db.session.get(Patient, patient_id)
+            if patient is None:
+                errors["patient_id"] = "Patient not found."
+
+    if partial and "patient_id" not in data and current_note is not None:
+        patient = db.session.get(Patient, current_note.patient_id)
+
+    if not partial or "visit_id" in data:
+        visit_id = data.get("visit_id")
+        if visit_id in (None, ""):
+            errors["visit_id"] = "This field is required."
+        elif not isinstance(visit_id, int):
+            errors["visit_id"] = "Visit ID must be an integer."
+        else:
+            visit = db.session.get(Visit, visit_id)
+            if visit is None:
+                errors["visit_id"] = "Visit not found."
+
+    if partial and "visit_id" not in data and current_note is not None:
+        visit = db.session.get(Visit, current_note.visit_id)
+
+    if patient is not None and visit is not None and visit.patient_id != patient.id:
+        errors["visit_id"] = "Visit does not belong to the selected patient."
+
+    if visit is not None:
+        existing_note = AideNote.query.filter_by(visit_id=visit.id).first()
+        if existing_note is not None and (
+            current_note is None or existing_note.id != current_note.id
+        ):
+            errors["visit_id"] = "An aide note already exists for this visit."
+
+    if not partial or "aide_name" in data:
+        aide_name = data.get("aide_name")
+        if not isinstance(aide_name, str) or not aide_name.strip():
+            errors["aide_name"] = "This field is required."
+        else:
+            data["aide_name"] = aide_name.strip()
+
+    for field in JSON_FIELDS:
+        if field in data and data[field] is not None and not isinstance(
+            data[field],
+            (dict, list),
+        ):
+            errors[field] = "Checklist data must be a JSON object or array."
+
+    for field in ("additional_notes", "signature_data"):
+        if field in data and isinstance(data[field], str):
+            data[field] = data[field].strip() or None
+
+    if "signature_date" in data and data["signature_date"]:
+        try:
+            data["signature_date"] = date.fromisoformat(data["signature_date"])
+        except (TypeError, ValueError):
+            errors["signature_date"] = "Use ISO date format YYYY-MM-DD."
+    elif "signature_date" in data:
+        data["signature_date"] = None
+
+    for field in ("time_in", "time_out"):
+        if field in data:
+            try:
+                data[field] = parse_time(data[field])
+            except ValueError:
+                errors[field] = "Use 24-hour time format HH:MM."
+
+    return data, errors
+
+
+@aide_notes_bp.get("/aide-notes")
+@swag_from(aide_note_list_spec)
+def list_aide_notes():
+    aide_notes = AideNote.query.order_by(AideNote.id.desc()).all()
+
+    return success_response(
+        [aide_note.to_dict() for aide_note in aide_notes],
+        "Aide notes retrieved successfully",
+    )
+
+
+@aide_notes_bp.get("/aide-notes/<int:aide_note_id>")
+@swag_from(aide_note_get_spec)
+def get_aide_note(aide_note_id):
+    aide_note = db.session.get(AideNote, aide_note_id)
+
+    if aide_note is None:
+        return error_response("Aide note not found", 404)
+
+    return success_response(aide_note.to_dict(), "Aide note retrieved successfully")
+
+
+@aide_notes_bp.post("/aide-notes")
+@swag_from(aide_note_create_spec)
+def create_aide_note():
+    data, errors = parse_aide_note_payload(request.get_json(silent=True))
+
+    if errors:
+        return error_response("Invalid aide note data", 400, errors)
+
+    aide_note = AideNote(**data)
+    db.session.add(aide_note)
+    db.session.commit()
+
+    return success_response(aide_note.to_dict(), "Aide note created successfully", 201)
+
+
+@aide_notes_bp.put("/aide-notes/<int:aide_note_id>")
+@swag_from(aide_note_update_spec)
+def update_aide_note(aide_note_id):
+    aide_note = db.session.get(AideNote, aide_note_id)
+
+    if aide_note is None:
+        return error_response("Aide note not found", 404)
+
+    data, errors = parse_aide_note_payload(
+        request.get_json(silent=True),
+        partial=True,
+        current_note=aide_note,
+    )
+
+    if errors:
+        return error_response("Invalid aide note data", 400, errors)
+
+    for field, value in data.items():
+        setattr(aide_note, field, value)
+
+    db.session.commit()
+
+    return success_response(aide_note.to_dict(), "Aide note updated successfully")
+
+
+@aide_notes_bp.delete("/aide-notes/<int:aide_note_id>")
+@swag_from(aide_note_delete_spec)
+def delete_aide_note(aide_note_id):
+    aide_note = db.session.get(AideNote, aide_note_id)
+
+    if aide_note is None:
+        return error_response("Aide note not found", 404)
+
+    db.session.delete(aide_note)
+    db.session.commit()
+
+    return success_response({"id": aide_note_id}, "Aide note deleted successfully")
+
+
+@aide_notes_bp.get("/patients/<int:patient_id>/aide-notes")
+@swag_from(patient_aide_notes_list_spec)
+def list_patient_aide_notes(patient_id):
+    patient = db.session.get(Patient, patient_id)
+
+    if patient is None:
+        return error_response("Patient not found", 404)
+
+    aide_notes = (
+        AideNote.query.filter_by(patient_id=patient_id).order_by(AideNote.id.desc()).all()
+    )
+
+    return success_response(
+        [aide_note.to_dict() for aide_note in aide_notes],
+        "Patient aide notes retrieved successfully",
+    )
+
+
+@aide_notes_bp.get("/visits/<int:visit_id>/aide-note")
+@swag_from(visit_aide_note_get_spec)
+def get_visit_aide_note(visit_id):
+    visit = db.session.get(Visit, visit_id)
+
+    if visit is None:
+        return error_response("Visit not found", 404)
+
+    aide_note = AideNote.query.filter_by(visit_id=visit_id).first()
+
+    if aide_note is None:
+        return error_response("Aide note not found", 404)
+
+    return success_response(aide_note.to_dict(), "Visit aide note retrieved successfully")

--- a/backend/app/swagger.py
+++ b/backend/app/swagger.py
@@ -109,6 +109,61 @@ visit_request_properties = {
     if key not in {"id", "created_at", "updated_at"}
 }
 
+checklist_schema = {
+    "type": "object",
+    "nullable": True,
+    "additionalProperties": True,
+    "example": {"completed": ["bath", "oral_care"], "declined": []},
+}
+
+aide_note_properties = {
+    "id": {"type": "integer", "example": 1},
+    "patient_id": {"type": "integer", "example": 1},
+    "visit_id": {"type": "integer", "example": 1},
+    "personal_care": checklist_schema,
+    "nutrition": checklist_schema,
+    "mental_status": checklist_schema,
+    "elimination": checklist_schema,
+    "activity": checklist_schema,
+    "assistive_devices": checklist_schema,
+    "housekeeping": checklist_schema,
+    "additional_notes": {
+        "type": "string",
+        "nullable": True,
+        "example": "Patient tolerated care well.",
+    },
+    "aide_name": {"type": "string", "example": "Alex Morgan"},
+    "signature_data": {
+        "type": "string",
+        "nullable": True,
+        "example": "data:image/png;base64,...",
+    },
+    "signature_date": {
+        "type": "string",
+        "format": "date",
+        "nullable": True,
+        "example": "2026-06-01",
+    },
+    "time_in": {"type": "string", "nullable": True, "example": "09:00"},
+    "time_out": {"type": "string", "nullable": True, "example": "10:30"},
+    "created_at": {
+        "type": "string",
+        "format": "date-time",
+        "example": "2026-05-31T10:00:00+00:00",
+    },
+    "updated_at": {
+        "type": "string",
+        "format": "date-time",
+        "example": "2026-05-31T10:00:00+00:00",
+    },
+}
+
+aide_note_request_properties = {
+    key: value
+    for key, value in aide_note_properties.items()
+    if key not in {"id", "created_at", "updated_at"}
+}
+
 swagger_config = {
     "headers": [],
     "specs": [
@@ -161,6 +216,19 @@ swagger_template = {
         "VisitUpdate": {
             "type": "object",
             "properties": visit_request_properties,
+        },
+        "AideNote": {
+            "type": "object",
+            "properties": aide_note_properties,
+        },
+        "AideNoteCreate": {
+            "type": "object",
+            "required": ["patient_id", "visit_id", "aide_name"],
+            "properties": aide_note_request_properties,
+        },
+        "AideNoteUpdate": {
+            "type": "object",
+            "properties": aide_note_request_properties,
         },
         "ErrorResponse": {
             "type": "object",
@@ -219,6 +287,29 @@ swagger_template = {
                 "message": {
                     "type": "string",
                     "example": "Visits retrieved successfully",
+                },
+            },
+        },
+        "AideNoteResponse": {
+            "type": "object",
+            "properties": {
+                "data": {"$ref": "#/definitions/AideNote"},
+                "message": {
+                    "type": "string",
+                    "example": "Aide note retrieved successfully",
+                },
+            },
+        },
+        "AideNoteListResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/AideNote"},
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Aide notes retrieved successfully",
                 },
             },
         },
@@ -510,6 +601,165 @@ patient_visits_list_spec = {
         },
         404: {
             "description": "Patient not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+aide_note_list_spec = {
+    "tags": ["Aide Notes"],
+    "summary": "List aide notes",
+    "responses": {
+        200: {
+            "description": "Aide notes retrieved successfully.",
+            "schema": {"$ref": "#/definitions/AideNoteListResponse"},
+        }
+    },
+}
+
+aide_note_get_spec = {
+    "tags": ["Aide Notes"],
+    "summary": "Retrieve an aide note",
+    "parameters": [
+        {
+            "name": "aide_note_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Aide note retrieved successfully.",
+            "schema": {"$ref": "#/definitions/AideNoteResponse"},
+        },
+        404: {
+            "description": "Aide note not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+aide_note_create_spec = {
+    "tags": ["Aide Notes"],
+    "summary": "Create an aide note",
+    "parameters": [
+        {
+            "name": "body",
+            "in": "body",
+            "required": True,
+            "schema": {"$ref": "#/definitions/AideNoteCreate"},
+        }
+    ],
+    "responses": {
+        201: {
+            "description": "Aide note created successfully.",
+            "schema": {"$ref": "#/definitions/AideNoteResponse"},
+        },
+        400: {
+            "description": "Invalid aide note data.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+aide_note_update_spec = {
+    "tags": ["Aide Notes"],
+    "summary": "Update an aide note",
+    "parameters": [
+        {
+            "name": "aide_note_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        },
+        {
+            "name": "body",
+            "in": "body",
+            "required": True,
+            "schema": {"$ref": "#/definitions/AideNoteUpdate"},
+        },
+    ],
+    "responses": {
+        200: {
+            "description": "Aide note updated successfully.",
+            "schema": {"$ref": "#/definitions/AideNoteResponse"},
+        },
+        400: {
+            "description": "Invalid aide note data.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+        404: {
+            "description": "Aide note not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+aide_note_delete_spec = {
+    "tags": ["Aide Notes"],
+    "summary": "Delete an aide note",
+    "parameters": [
+        {
+            "name": "aide_note_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Aide note deleted successfully.",
+            "schema": {"$ref": "#/definitions/DeleteSuccessResponse"},
+        },
+        404: {
+            "description": "Aide note not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+patient_aide_notes_list_spec = {
+    "tags": ["Aide Notes"],
+    "summary": "List aide notes for a patient",
+    "parameters": [
+        {
+            "name": "patient_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Patient aide notes retrieved successfully.",
+            "schema": {"$ref": "#/definitions/AideNoteListResponse"},
+        },
+        404: {
+            "description": "Patient not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+visit_aide_note_get_spec = {
+    "tags": ["Aide Notes"],
+    "summary": "Retrieve the aide note for a visit",
+    "parameters": [
+        {
+            "name": "visit_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Visit aide note retrieved successfully.",
+            "schema": {"$ref": "#/definitions/AideNoteResponse"},
+        },
+        404: {
+            "description": "Visit or aide note not found.",
             "schema": {"$ref": "#/definitions/ErrorResponse"},
         },
     },

--- a/backend/migrations/versions/20260531_0003_create_aide_notes_table.py
+++ b/backend/migrations/versions/20260531_0003_create_aide_notes_table.py
@@ -1,0 +1,51 @@
+"""create aide notes table
+
+Revision ID: 20260531_0003
+Revises: 20260531_0002
+Create Date: 2026-05-31 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260531_0003"
+down_revision = "20260531_0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "aide_notes",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("patient_id", sa.Integer(), nullable=False),
+        sa.Column("visit_id", sa.Integer(), nullable=False),
+        sa.Column("personal_care", sa.JSON(), nullable=True),
+        sa.Column("nutrition", sa.JSON(), nullable=True),
+        sa.Column("mental_status", sa.JSON(), nullable=True),
+        sa.Column("elimination", sa.JSON(), nullable=True),
+        sa.Column("activity", sa.JSON(), nullable=True),
+        sa.Column("assistive_devices", sa.JSON(), nullable=True),
+        sa.Column("housekeeping", sa.JSON(), nullable=True),
+        sa.Column("additional_notes", sa.Text(), nullable=True),
+        sa.Column("aide_name", sa.String(length=200), nullable=False),
+        sa.Column("signature_data", sa.Text(), nullable=True),
+        sa.Column("signature_date", sa.Date(), nullable=True),
+        sa.Column("time_in", sa.Time(), nullable=True),
+        sa.Column("time_out", sa.Time(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["patient_id"], ["patients.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["visit_id"], ["visits.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("visit_id", name="uq_aide_notes_visit_id"),
+    )
+    op.create_index("ix_aide_notes_patient_id", "aide_notes", ["patient_id"])
+    op.create_index("ix_aide_notes_visit_id", "aide_notes", ["visit_id"], unique=True)
+
+
+def downgrade():
+    op.drop_index("ix_aide_notes_visit_id", table_name="aide_notes")
+    op.drop_index("ix_aide_notes_patient_id", table_name="aide_notes")
+    op.drop_table("aide_notes")

--- a/backend/tests/test_aide_notes.py
+++ b/backend/tests/test_aide_notes.py
@@ -1,0 +1,229 @@
+def patient_payload(**overrides):
+    payload = {
+        "first_name": "Maria",
+        "last_name": "Santos",
+        "date_of_birth": "1945-03-12",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def create_patient(client, **overrides):
+    return client.post("/api/patients", json=patient_payload(**overrides)).get_json()[
+        "data"
+    ]
+
+
+def visit_payload(patient_id, **overrides):
+    payload = {
+        "patient_id": patient_id,
+        "visit_date": "2026-06-01",
+        "visit_type": "Home care visit",
+        "staff_name": "Jordan Lee",
+        "staff_role": "aide",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def create_visit(client, patient_id, **overrides):
+    return client.post("/api/visits", json=visit_payload(patient_id, **overrides)).get_json()[
+        "data"
+    ]
+
+
+def aide_note_payload(patient_id, visit_id, **overrides):
+    payload = {
+        "patient_id": patient_id,
+        "visit_id": visit_id,
+        "personal_care": {"completed": ["bath", "oral_care"]},
+        "nutrition": {"meal_percentage": 75, "fluids_offered": True},
+        "mental_status": {"observed": ["alert", "oriented"]},
+        "elimination": {"voided": True},
+        "activity": {"ambulated": True},
+        "assistive_devices": {"walker": True},
+        "housekeeping": {"completed": ["laundry"]},
+        "additional_notes": "Patient tolerated care well.",
+        "aide_name": "Alex Morgan",
+        "signature_data": "data:image/png;base64,placeholder",
+        "signature_date": "2026-06-01",
+        "time_in": "09:00",
+        "time_out": "10:30",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def create_aide_note(client, patient_id, visit_id, **overrides):
+    return client.post(
+        "/api/aide-notes",
+        json=aide_note_payload(patient_id, visit_id, **overrides),
+    )
+
+
+def test_create_aide_note(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+
+    response = create_aide_note(client, patient["id"], visit["id"])
+    body = response.get_json()
+
+    assert response.status_code == 201
+    assert body["message"] == "Aide note created successfully"
+    assert body["data"]["patient_id"] == patient["id"]
+    assert body["data"]["visit_id"] == visit["id"]
+    assert body["data"]["aide_name"] == "Alex Morgan"
+    assert body["data"]["nutrition"]["meal_percentage"] == 75
+
+
+def test_list_aide_notes(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    create_aide_note(client, patient["id"], visit["id"])
+
+    response = client.get("/api/aide-notes")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["message"] == "Aide notes retrieved successfully"
+    assert len(body["data"]) == 1
+
+
+def test_get_aide_note(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    created = create_aide_note(client, patient["id"], visit["id"]).get_json()["data"]
+
+    response = client.get(f"/api/aide-notes/{created['id']}")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["data"]["id"] == created["id"]
+    assert body["data"]["personal_care"]["completed"] == ["bath", "oral_care"]
+
+
+def test_update_aide_note(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    created = create_aide_note(client, patient["id"], visit["id"]).get_json()["data"]
+
+    response = client.put(
+        f"/api/aide-notes/{created['id']}",
+        json={
+            "aide_name": "Taylor Reed",
+            "additional_notes": "Updated after supervisor review.",
+        },
+    )
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["message"] == "Aide note updated successfully"
+    assert body["data"]["aide_name"] == "Taylor Reed"
+
+
+def test_delete_aide_note(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    created = create_aide_note(client, patient["id"], visit["id"]).get_json()["data"]
+
+    response = client.delete(f"/api/aide-notes/{created['id']}")
+
+    assert response.status_code == 200
+    assert response.get_json()["message"] == "Aide note deleted successfully"
+    assert client.get(f"/api/aide-notes/{created['id']}").status_code == 404
+
+
+def test_list_aide_notes_for_patient(client):
+    patient = create_patient(client)
+    other_patient = create_patient(client, first_name="John", last_name="Rivera")
+    visit = create_visit(client, patient["id"])
+    other_visit = create_visit(client, other_patient["id"])
+    create_aide_note(client, patient["id"], visit["id"])
+    create_aide_note(client, other_patient["id"], other_visit["id"])
+
+    response = client.get(f"/api/patients/{patient['id']}/aide-notes")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["message"] == "Patient aide notes retrieved successfully"
+    assert len(body["data"]) == 1
+    assert body["data"][0]["patient_id"] == patient["id"]
+
+
+def test_get_aide_note_by_visit(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    created = create_aide_note(client, patient["id"], visit["id"]).get_json()["data"]
+
+    response = client.get(f"/api/visits/{visit['id']}/aide-note")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["message"] == "Visit aide note retrieved successfully"
+    assert body["data"]["id"] == created["id"]
+
+
+def test_create_aide_note_requires_patient_id(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    payload = aide_note_payload(patient["id"], visit["id"])
+    payload["patient_id"] = None
+
+    response = client.post(
+        "/api/aide-notes",
+        json=payload,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["patient_id"] == "This field is required."
+
+
+def test_create_aide_note_requires_visit_id(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    payload = aide_note_payload(patient["id"], visit["id"])
+    payload["visit_id"] = None
+
+    response = client.post(
+        "/api/aide-notes",
+        json=payload,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["visit_id"] == "This field is required."
+
+
+def test_create_aide_note_requires_aide_name(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+
+    response = create_aide_note(client, patient["id"], visit["id"], aide_name="")
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["aide_name"] == "This field is required."
+
+
+def test_create_aide_note_rejects_visit_for_different_patient(client):
+    patient = create_patient(client)
+    other_patient = create_patient(client, first_name="John", last_name="Rivera")
+    visit = create_visit(client, other_patient["id"])
+
+    response = create_aide_note(client, patient["id"], visit["id"])
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["visit_id"] == (
+        "Visit does not belong to the selected patient."
+    )
+
+
+def test_create_aide_note_rejects_duplicate_visit_note(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    create_aide_note(client, patient["id"], visit["id"])
+
+    response = create_aide_note(client, patient["id"], visit["id"])
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["visit_id"] == (
+        "An aide note already exists for this visit."
+    )

--- a/backend/tests/test_openapi.py
+++ b/backend/tests/test_openapi.py
@@ -24,6 +24,10 @@ def test_openapi_json_includes_health_and_patient_endpoints(client):
     assert "/api/visits" in paths
     assert "/api/visits/{visit_id}" in paths
     assert "/api/patients/{patient_id}/visits" in paths
+    assert "/api/aide-notes" in paths
+    assert "/api/aide-notes/{aide_note_id}" in paths
+    assert "/api/patients/{patient_id}/aide-notes" in paths
+    assert "/api/visits/{visit_id}/aide-note" in paths
     assert "get" in paths["/api/health"]
     assert {"get", "post"} <= set(paths["/api/patients"].keys())
     assert {"get", "put", "delete"} <= set(
@@ -32,6 +36,12 @@ def test_openapi_json_includes_health_and_patient_endpoints(client):
     assert {"get", "post"} <= set(paths["/api/visits"].keys())
     assert {"get", "put", "delete"} <= set(paths["/api/visits/{visit_id}"].keys())
     assert "get" in paths["/api/patients/{patient_id}/visits"]
+    assert {"get", "post"} <= set(paths["/api/aide-notes"].keys())
+    assert {"get", "put", "delete"} <= set(
+        paths["/api/aide-notes/{aide_note_id}"].keys()
+    )
+    assert "get" in paths["/api/patients/{patient_id}/aide-notes"]
+    assert "get" in paths["/api/visits/{visit_id}/aide-note"]
 
 
 def test_openapi_json_includes_patient_schemas(client):
@@ -49,3 +59,8 @@ def test_openapi_json_includes_patient_schemas(client):
     assert "VisitUpdate" in definitions
     assert "VisitResponse" in definitions
     assert "VisitListResponse" in definitions
+    assert "AideNote" in definitions
+    assert "AideNoteCreate" in definitions
+    assert "AideNoteUpdate" in definitions
+    assert "AideNoteResponse" in definitions
+    assert "AideNoteListResponse" in definitions

--- a/docs/architecture/api-design.md
+++ b/docs/architecture/api-design.md
@@ -401,3 +401,333 @@ Example response:
   "message": "Visit deleted successfully"
 }
 ```
+
+## Aide Note API
+
+The Aide Note API records Home Health Aide visit documentation linked to both a patient and a visit. Checklist sections are stored as JSON for flexibility while the final form structure continues to evolve.
+
+### Aide Note Fields
+
+- `id`
+- `patient_id`
+- `visit_id`
+- `personal_care`
+- `nutrition`
+- `mental_status`
+- `elimination`
+- `activity`
+- `assistive_devices`
+- `housekeeping`
+- `additional_notes`
+- `aide_name`
+- `signature_data`
+- `signature_date`
+- `time_in`
+- `time_out`
+- `created_at`
+- `updated_at`
+
+`patient_id`, `visit_id`, and `aide_name` are required. `signature_date` is optional, but when provided it must use `YYYY-MM-DD`. The visit must exist and belong to the selected patient. A visit can have only one aide note.
+
+### List Aide Notes
+
+`GET /api/aide-notes`
+
+Example response:
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "patient_id": 1,
+      "visit_id": 1,
+      "personal_care": {
+        "completed": ["bath", "oral_care"]
+      },
+      "nutrition": {
+        "meal_percentage": 75,
+        "fluids_offered": true
+      },
+      "mental_status": {
+        "observed": ["alert", "oriented"]
+      },
+      "elimination": {
+        "voided": true
+      },
+      "activity": {
+        "ambulated": true
+      },
+      "assistive_devices": {
+        "walker": true
+      },
+      "housekeeping": {
+        "completed": ["laundry"]
+      },
+      "additional_notes": "Patient tolerated care well.",
+      "aide_name": "Alex Morgan",
+      "signature_data": "data:image/png;base64,...",
+      "signature_date": "2026-06-01",
+      "time_in": "09:00",
+      "time_out": "10:30",
+      "created_at": "2026-05-31T10:00:00+00:00",
+      "updated_at": "2026-05-31T10:00:00+00:00"
+    }
+  ],
+  "message": "Aide notes retrieved successfully"
+}
+```
+
+### List Aide Notes for a Patient
+
+`GET /api/patients/<patient_id>/aide-notes`
+
+Example response:
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "patient_id": 1,
+      "visit_id": 1,
+      "personal_care": {
+        "completed": ["bath", "oral_care"]
+      },
+      "nutrition": {
+        "meal_percentage": 75
+      },
+      "mental_status": null,
+      "elimination": null,
+      "activity": null,
+      "assistive_devices": null,
+      "housekeeping": null,
+      "additional_notes": "Patient tolerated care well.",
+      "aide_name": "Alex Morgan",
+      "signature_data": null,
+      "signature_date": "2026-06-01",
+      "time_in": "09:00",
+      "time_out": "10:30",
+      "created_at": "2026-05-31T10:00:00+00:00",
+      "updated_at": "2026-05-31T10:00:00+00:00"
+    }
+  ],
+  "message": "Patient aide notes retrieved successfully"
+}
+```
+
+### Retrieve an Aide Note
+
+`GET /api/aide-notes/<id>`
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "patient_id": 1,
+    "visit_id": 1,
+    "personal_care": {
+      "completed": ["bath", "oral_care"]
+    },
+    "nutrition": {
+      "meal_percentage": 75
+    },
+    "mental_status": null,
+    "elimination": null,
+    "activity": null,
+    "assistive_devices": null,
+    "housekeeping": null,
+    "additional_notes": "Patient tolerated care well.",
+    "aide_name": "Alex Morgan",
+    "signature_data": null,
+    "signature_date": "2026-06-01",
+    "time_in": "09:00",
+    "time_out": "10:30",
+    "created_at": "2026-05-31T10:00:00+00:00",
+    "updated_at": "2026-05-31T10:00:00+00:00"
+  },
+  "message": "Aide note retrieved successfully"
+}
+```
+
+### Retrieve an Aide Note for a Visit
+
+`GET /api/visits/<visit_id>/aide-note`
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "patient_id": 1,
+    "visit_id": 1,
+    "personal_care": {
+      "completed": ["bath", "oral_care"]
+    },
+    "nutrition": {
+      "meal_percentage": 75
+    },
+    "mental_status": null,
+    "elimination": null,
+    "activity": null,
+    "assistive_devices": null,
+    "housekeeping": null,
+    "additional_notes": "Patient tolerated care well.",
+    "aide_name": "Alex Morgan",
+    "signature_data": null,
+    "signature_date": "2026-06-01",
+    "time_in": "09:00",
+    "time_out": "10:30",
+    "created_at": "2026-05-31T10:00:00+00:00",
+    "updated_at": "2026-05-31T10:00:00+00:00"
+  },
+  "message": "Visit aide note retrieved successfully"
+}
+```
+
+### Create an Aide Note
+
+`POST /api/aide-notes`
+
+Example request:
+
+```json
+{
+  "patient_id": 1,
+  "visit_id": 1,
+  "personal_care": {
+    "completed": ["bath", "oral_care"]
+  },
+  "nutrition": {
+    "meal_percentage": 75,
+    "fluids_offered": true
+  },
+  "mental_status": {
+    "observed": ["alert", "oriented"]
+  },
+  "elimination": {
+    "voided": true
+  },
+  "activity": {
+    "ambulated": true
+  },
+  "assistive_devices": {
+    "walker": true
+  },
+  "housekeeping": {
+    "completed": ["laundry"]
+  },
+  "additional_notes": "Patient tolerated care well.",
+  "aide_name": "Alex Morgan",
+  "signature_data": "data:image/png;base64,...",
+  "signature_date": "2026-06-01",
+  "time_in": "09:00",
+  "time_out": "10:30"
+}
+```
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "patient_id": 1,
+    "visit_id": 1,
+    "personal_care": {
+      "completed": ["bath", "oral_care"]
+    },
+    "nutrition": {
+      "meal_percentage": 75,
+      "fluids_offered": true
+    },
+    "mental_status": {
+      "observed": ["alert", "oriented"]
+    },
+    "elimination": {
+      "voided": true
+    },
+    "activity": {
+      "ambulated": true
+    },
+    "assistive_devices": {
+      "walker": true
+    },
+    "housekeeping": {
+      "completed": ["laundry"]
+    },
+    "additional_notes": "Patient tolerated care well.",
+    "aide_name": "Alex Morgan",
+    "signature_data": "data:image/png;base64,...",
+    "signature_date": "2026-06-01",
+    "time_in": "09:00",
+    "time_out": "10:30",
+    "created_at": "2026-05-31T10:00:00+00:00",
+    "updated_at": "2026-05-31T10:00:00+00:00"
+  },
+  "message": "Aide note created successfully"
+}
+```
+
+### Update an Aide Note
+
+`PUT /api/aide-notes/<id>`
+
+Example request:
+
+```json
+{
+  "aide_name": "Taylor Reed",
+  "additional_notes": "Updated after supervisor review."
+}
+```
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "patient_id": 1,
+    "visit_id": 1,
+    "personal_care": {
+      "completed": ["bath", "oral_care"]
+    },
+    "nutrition": {
+      "meal_percentage": 75
+    },
+    "mental_status": null,
+    "elimination": null,
+    "activity": null,
+    "assistive_devices": null,
+    "housekeeping": null,
+    "additional_notes": "Updated after supervisor review.",
+    "aide_name": "Taylor Reed",
+    "signature_data": null,
+    "signature_date": "2026-06-01",
+    "time_in": "09:00",
+    "time_out": "10:30",
+    "created_at": "2026-05-31T10:00:00+00:00",
+    "updated_at": "2026-05-31T10:10:00+00:00"
+  },
+  "message": "Aide note updated successfully"
+}
+```
+
+### Delete an Aide Note
+
+`DELETE /api/aide-notes/<id>`
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1
+  },
+  "message": "Aide note deleted successfully"
+}
+```


### PR DESCRIPTION
# Summary

- Added an AideNote model linked to patients and visits, with JSON checklist storage and one aide note per visit.
- Added Aide Note CRUD endpoints plus patient-to-aide-notes and visit-to-aide-note endpoints.
- Added validation for required patient, visit, and aide name fields; patient/visit existence; visit ownership; duplicate visit notes; optional signature dates; and time/checklist formats.
- Added an Alembic migration for the `aide_notes` table with patient/visit foreign keys and a unique visit constraint.
- Added Swagger/OpenAPI schemas and endpoint specs, backend tests, API documentation, and CHANGELOG.md entry.

## Related Issue / Task

- Feature: 09-aide-note-api

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `docker-compose exec -T backend pytest`
- `docker-compose exec -T backend ruff check .`
- `docker-compose exec -T backend flask db upgrade`
- `curl -s http://localhost:5001/api/aide-notes`
- `curl -s http://localhost:5001/api/openapi.json | rg 'aide-notes|AideNote'`
- `docker-compose build backend`
- `npm run build`
- `git diff --check`
- Secret-pattern scan with `rg`

## Screenshots

N/A

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.