### PR TITLE
feat: add nurse note API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added the Nurses Progress Note API with patient/visit-linked clinical records, JSON clinical section storage, duplicate visit-note prevention, Swagger documentation, tests, and API documentation.
 - Added the Home Health Aide Note frontend with visit detail integration, grouped checklist form, read-only detail view, edit workflow, and API service functions.
 - Added the Home Health Aide Note API with patient/visit-linked records, JSON checklist storage, duplicate visit-note prevention, Swagger documentation, tests, and API documentation.
 - Added the Visits frontend with list, create, edit, detail, delete, API service workflows, and patient detail integration.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -6,9 +6,11 @@ from sqlalchemy import text
 from app.config import Config
 from app.extensions import db, migrate
 from app.models import AideNote as AideNote
+from app.models import NurseNote as NurseNote
 from app.models import Patient as Patient
 from app.models import Visit as Visit
 from app.routes.aide_notes import aide_notes_bp
+from app.routes.nurse_notes import nurse_notes_bp
 from app.routes.patients import patients_bp
 from app.routes.visits import visits_bp
 from app.swagger import health_spec, swagger_config, swagger_template
@@ -23,6 +25,7 @@ def create_app(config_object=Config):
     db.init_app(app)
     migrate.init_app(app, db)
     app.register_blueprint(aide_notes_bp)
+    app.register_blueprint(nurse_notes_bp)
     app.register_blueprint(patients_bp)
     app.register_blueprint(visits_bp)
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,7 @@
 from app.models.aide_note import AideNote
+from app.models.nurse_note import NurseNote
 from app.models.patient import Patient
 from app.models.visit import Visit
 
 
-__all__ = ["AideNote", "Patient", "Visit"]
+__all__ = ["AideNote", "NurseNote", "Patient", "Visit"]

--- a/backend/app/models/nurse_note.py
+++ b/backend/app/models/nurse_note.py
@@ -1,0 +1,103 @@
+from datetime import UTC, datetime
+
+from app.extensions import db
+
+
+class NurseNote(db.Model):
+    __tablename__ = "nurse_notes"
+
+    id = db.Column(db.Integer, primary_key=True)
+    patient_id = db.Column(
+        db.Integer,
+        db.ForeignKey("patients.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    visit_id = db.Column(
+        db.Integer,
+        db.ForeignKey("visits.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    diagnosis = db.Column(db.Text, nullable=True)
+    living_arrangements = db.Column(db.JSON, nullable=True)
+    visit_type = db.Column(db.JSON, nullable=True)
+    vital_signs = db.Column(db.JSON, nullable=True)
+    diet = db.Column(db.JSON, nullable=True)
+    pain_assessment = db.Column(db.JSON, nullable=True)
+    sensory = db.Column(db.JSON, nullable=True)
+    neuro = db.Column(db.JSON, nullable=True)
+    respiratory = db.Column(db.JSON, nullable=True)
+    cardiac = db.Column(db.JSON, nullable=True)
+    peripheral_circulation = db.Column(db.JSON, nullable=True)
+    genitourinary = db.Column(db.JSON, nullable=True)
+    gastrointestinal = db.Column(db.JSON, nullable=True)
+    endocrine = db.Column(db.JSON, nullable=True)
+    skin_integrity = db.Column(db.JSON, nullable=True)
+    wound_evaluation = db.Column(db.JSON, nullable=True)
+    mental_status = db.Column(db.JSON, nullable=True)
+    functional_status = db.Column(db.JSON, nullable=True)
+    homebound_status = db.Column(db.JSON, nullable=True)
+    skilled_nursing = db.Column(db.Text, nullable=True)
+    response_to_intervention = db.Column(db.Text, nullable=True)
+    patient_caregiver_understanding = db.Column(db.JSON, nullable=True)
+    md_contact = db.Column(db.JSON, nullable=True)
+    discharge_planning = db.Column(db.Text, nullable=True)
+    patient_feedback = db.Column(db.Text, nullable=True)
+    narrative = db.Column(db.Text, nullable=True)
+    signature_data = db.Column(db.Text, nullable=True)
+    signature_date = db.Column(db.Date, nullable=True)
+    created_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    patient = db.relationship("Patient", back_populates="nurse_notes")
+    visit = db.relationship("Visit", back_populates="nurse_note")
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "patient_id": self.patient_id,
+            "visit_id": self.visit_id,
+            "diagnosis": self.diagnosis,
+            "living_arrangements": self.living_arrangements,
+            "visit_type": self.visit_type,
+            "vital_signs": self.vital_signs,
+            "diet": self.diet,
+            "pain_assessment": self.pain_assessment,
+            "sensory": self.sensory,
+            "neuro": self.neuro,
+            "respiratory": self.respiratory,
+            "cardiac": self.cardiac,
+            "peripheral_circulation": self.peripheral_circulation,
+            "genitourinary": self.genitourinary,
+            "gastrointestinal": self.gastrointestinal,
+            "endocrine": self.endocrine,
+            "skin_integrity": self.skin_integrity,
+            "wound_evaluation": self.wound_evaluation,
+            "mental_status": self.mental_status,
+            "functional_status": self.functional_status,
+            "homebound_status": self.homebound_status,
+            "skilled_nursing": self.skilled_nursing,
+            "response_to_intervention": self.response_to_intervention,
+            "patient_caregiver_understanding": self.patient_caregiver_understanding,
+            "md_contact": self.md_contact,
+            "discharge_planning": self.discharge_planning,
+            "patient_feedback": self.patient_feedback,
+            "narrative": self.narrative,
+            "signature_data": self.signature_data,
+            "signature_date": self.signature_date.isoformat()
+            if self.signature_date
+            else None,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/backend/app/models/patient.py
+++ b/backend/app/models/patient.py
@@ -44,6 +44,11 @@ class Patient(db.Model):
         back_populates="patient",
         cascade="all, delete-orphan",
     )
+    nurse_notes = db.relationship(
+        "NurseNote",
+        back_populates="patient",
+        cascade="all, delete-orphan",
+    )
 
     def to_dict(self):
         return {

--- a/backend/app/models/visit.py
+++ b/backend/app/models/visit.py
@@ -49,6 +49,12 @@ class Visit(db.Model):
         cascade="all, delete-orphan",
         uselist=False,
     )
+    nurse_note = db.relationship(
+        "NurseNote",
+        back_populates="visit",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )
 
     def to_dict(self):
         return {

--- a/backend/app/routes/nurse_notes.py
+++ b/backend/app/routes/nurse_notes.py
@@ -1,0 +1,256 @@
+from datetime import date
+
+from flasgger import swag_from
+from flask import Blueprint, jsonify, request
+
+from app.extensions import db
+from app.models import NurseNote, Patient, Visit
+from app.swagger import (
+    nurse_note_create_spec,
+    nurse_note_delete_spec,
+    nurse_note_get_spec,
+    nurse_note_list_spec,
+    nurse_note_update_spec,
+    patient_nurse_notes_list_spec,
+    visit_nurse_note_get_spec,
+)
+
+
+nurse_notes_bp = Blueprint("nurse_notes", __name__, url_prefix="/api")
+
+JSON_FIELDS = {
+    "living_arrangements",
+    "visit_type",
+    "vital_signs",
+    "diet",
+    "pain_assessment",
+    "sensory",
+    "neuro",
+    "respiratory",
+    "cardiac",
+    "peripheral_circulation",
+    "genitourinary",
+    "gastrointestinal",
+    "endocrine",
+    "skin_integrity",
+    "wound_evaluation",
+    "mental_status",
+    "functional_status",
+    "homebound_status",
+    "patient_caregiver_understanding",
+    "md_contact",
+}
+TEXT_FIELDS = {
+    "diagnosis",
+    "skilled_nursing",
+    "response_to_intervention",
+    "discharge_planning",
+    "patient_feedback",
+    "narrative",
+    "signature_data",
+}
+NURSE_NOTE_FIELDS = {
+    "patient_id",
+    "visit_id",
+    "signature_date",
+    *JSON_FIELDS,
+    *TEXT_FIELDS,
+}
+
+
+def success_response(data, message, status_code=200):
+    return jsonify({"data": data, "message": message}), status_code
+
+
+def error_response(message, status_code=400, errors=None):
+    payload = {"message": message}
+
+    if errors:
+        payload["errors"] = errors
+
+    return jsonify(payload), status_code
+
+
+def parse_nurse_note_payload(payload, partial=False, current_note=None):
+    if not isinstance(payload, dict):
+        return None, {"request": "JSON body is required."}
+
+    data = {}
+    errors = {}
+    patient = None
+    visit = None
+
+    for field in NURSE_NOTE_FIELDS:
+        if field in payload:
+            data[field] = payload[field]
+
+    if not partial or "patient_id" in data:
+        patient_id = data.get("patient_id")
+        if patient_id in (None, ""):
+            errors["patient_id"] = "This field is required."
+        elif not isinstance(patient_id, int):
+            errors["patient_id"] = "Patient ID must be an integer."
+        else:
+            patient = db.session.get(Patient, patient_id)
+            if patient is None:
+                errors["patient_id"] = "Patient not found."
+
+    if partial and "patient_id" not in data and current_note is not None:
+        patient = db.session.get(Patient, current_note.patient_id)
+
+    if not partial or "visit_id" in data:
+        visit_id = data.get("visit_id")
+        if visit_id in (None, ""):
+            errors["visit_id"] = "This field is required."
+        elif not isinstance(visit_id, int):
+            errors["visit_id"] = "Visit ID must be an integer."
+        else:
+            visit = db.session.get(Visit, visit_id)
+            if visit is None:
+                errors["visit_id"] = "Visit not found."
+
+    if partial and "visit_id" not in data and current_note is not None:
+        visit = db.session.get(Visit, current_note.visit_id)
+
+    if patient is not None and visit is not None and visit.patient_id != patient.id:
+        errors["visit_id"] = "Visit does not belong to the selected patient."
+
+    if visit is not None:
+        existing_note = NurseNote.query.filter_by(visit_id=visit.id).first()
+        if existing_note is not None and (
+            current_note is None or existing_note.id != current_note.id
+        ):
+            errors["visit_id"] = "A nurse note already exists for this visit."
+
+    for field in JSON_FIELDS:
+        if field in data and data[field] is not None and not isinstance(
+            data[field],
+            (dict, list),
+        ):
+            errors[field] = "Clinical section data must be a JSON object or array."
+
+    for field in TEXT_FIELDS:
+        if field in data and isinstance(data[field], str):
+            data[field] = data[field].strip() or None
+
+    if "signature_date" in data and data["signature_date"]:
+        try:
+            data["signature_date"] = date.fromisoformat(data["signature_date"])
+        except (TypeError, ValueError):
+            errors["signature_date"] = "Use ISO date format YYYY-MM-DD."
+    elif "signature_date" in data:
+        data["signature_date"] = None
+
+    return data, errors
+
+
+@nurse_notes_bp.get("/nurse-notes")
+@swag_from(nurse_note_list_spec)
+def list_nurse_notes():
+    nurse_notes = NurseNote.query.order_by(NurseNote.id.desc()).all()
+
+    return success_response(
+        [nurse_note.to_dict() for nurse_note in nurse_notes],
+        "Nurse notes retrieved successfully",
+    )
+
+
+@nurse_notes_bp.get("/nurse-notes/<int:nurse_note_id>")
+@swag_from(nurse_note_get_spec)
+def get_nurse_note(nurse_note_id):
+    nurse_note = db.session.get(NurseNote, nurse_note_id)
+
+    if nurse_note is None:
+        return error_response("Nurse note not found", 404)
+
+    return success_response(nurse_note.to_dict(), "Nurse note retrieved successfully")
+
+
+@nurse_notes_bp.post("/nurse-notes")
+@swag_from(nurse_note_create_spec)
+def create_nurse_note():
+    data, errors = parse_nurse_note_payload(request.get_json(silent=True))
+
+    if errors:
+        return error_response("Invalid nurse note data", 400, errors)
+
+    nurse_note = NurseNote(**data)
+    db.session.add(nurse_note)
+    db.session.commit()
+
+    return success_response(nurse_note.to_dict(), "Nurse note created successfully", 201)
+
+
+@nurse_notes_bp.put("/nurse-notes/<int:nurse_note_id>")
+@swag_from(nurse_note_update_spec)
+def update_nurse_note(nurse_note_id):
+    nurse_note = db.session.get(NurseNote, nurse_note_id)
+
+    if nurse_note is None:
+        return error_response("Nurse note not found", 404)
+
+    data, errors = parse_nurse_note_payload(
+        request.get_json(silent=True),
+        partial=True,
+        current_note=nurse_note,
+    )
+
+    if errors:
+        return error_response("Invalid nurse note data", 400, errors)
+
+    for field, value in data.items():
+        setattr(nurse_note, field, value)
+
+    db.session.commit()
+
+    return success_response(nurse_note.to_dict(), "Nurse note updated successfully")
+
+
+@nurse_notes_bp.delete("/nurse-notes/<int:nurse_note_id>")
+@swag_from(nurse_note_delete_spec)
+def delete_nurse_note(nurse_note_id):
+    nurse_note = db.session.get(NurseNote, nurse_note_id)
+
+    if nurse_note is None:
+        return error_response("Nurse note not found", 404)
+
+    db.session.delete(nurse_note)
+    db.session.commit()
+
+    return success_response({"id": nurse_note_id}, "Nurse note deleted successfully")
+
+
+@nurse_notes_bp.get("/patients/<int:patient_id>/nurse-notes")
+@swag_from(patient_nurse_notes_list_spec)
+def list_patient_nurse_notes(patient_id):
+    patient = db.session.get(Patient, patient_id)
+
+    if patient is None:
+        return error_response("Patient not found", 404)
+
+    nurse_notes = (
+        NurseNote.query.filter_by(patient_id=patient_id)
+        .order_by(NurseNote.id.desc())
+        .all()
+    )
+
+    return success_response(
+        [nurse_note.to_dict() for nurse_note in nurse_notes],
+        "Patient nurse notes retrieved successfully",
+    )
+
+
+@nurse_notes_bp.get("/visits/<int:visit_id>/nurse-note")
+@swag_from(visit_nurse_note_get_spec)
+def get_visit_nurse_note(visit_id):
+    visit = db.session.get(Visit, visit_id)
+
+    if visit is None:
+        return error_response("Visit not found", 404)
+
+    nurse_note = NurseNote.query.filter_by(visit_id=visit_id).first()
+
+    if nurse_note is None:
+        return error_response("Nurse note not found", 404)
+
+    return success_response(nurse_note.to_dict(), "Visit nurse note retrieved successfully")

--- a/backend/app/swagger.py
+++ b/backend/app/swagger.py
@@ -164,6 +164,92 @@ aide_note_request_properties = {
     if key not in {"id", "created_at", "updated_at"}
 }
 
+clinical_section_schema = {
+    "type": "object",
+    "nullable": True,
+    "additionalProperties": True,
+    "example": {"findings": ["within normal limits"], "comments": "Stable"},
+}
+
+nurse_note_properties = {
+    "id": {"type": "integer", "example": 1},
+    "patient_id": {"type": "integer", "example": 1},
+    "visit_id": {"type": "integer", "example": 1},
+    "diagnosis": {"type": "string", "nullable": True, "example": "Hypertension"},
+    "living_arrangements": clinical_section_schema,
+    "visit_type": clinical_section_schema,
+    "vital_signs": clinical_section_schema,
+    "diet": clinical_section_schema,
+    "pain_assessment": clinical_section_schema,
+    "sensory": clinical_section_schema,
+    "neuro": clinical_section_schema,
+    "respiratory": clinical_section_schema,
+    "cardiac": clinical_section_schema,
+    "peripheral_circulation": clinical_section_schema,
+    "genitourinary": clinical_section_schema,
+    "gastrointestinal": clinical_section_schema,
+    "endocrine": clinical_section_schema,
+    "skin_integrity": clinical_section_schema,
+    "wound_evaluation": clinical_section_schema,
+    "mental_status": clinical_section_schema,
+    "functional_status": clinical_section_schema,
+    "homebound_status": clinical_section_schema,
+    "skilled_nursing": {
+        "type": "string",
+        "nullable": True,
+        "example": "Medication reconciliation completed.",
+    },
+    "response_to_intervention": {
+        "type": "string",
+        "nullable": True,
+        "example": "Patient verbalized improvement after education.",
+    },
+    "patient_caregiver_understanding": clinical_section_schema,
+    "md_contact": clinical_section_schema,
+    "discharge_planning": {
+        "type": "string",
+        "nullable": True,
+        "example": "Continue current plan of care.",
+    },
+    "patient_feedback": {
+        "type": "string",
+        "nullable": True,
+        "example": "Patient reports feeling safer at home.",
+    },
+    "narrative": {
+        "type": "string",
+        "nullable": True,
+        "example": "Skilled nursing visit completed without incident.",
+    },
+    "signature_data": {
+        "type": "string",
+        "nullable": True,
+        "example": "data:image/png;base64,...",
+    },
+    "signature_date": {
+        "type": "string",
+        "format": "date",
+        "nullable": True,
+        "example": "2026-06-01",
+    },
+    "created_at": {
+        "type": "string",
+        "format": "date-time",
+        "example": "2026-05-31T10:00:00+00:00",
+    },
+    "updated_at": {
+        "type": "string",
+        "format": "date-time",
+        "example": "2026-05-31T10:00:00+00:00",
+    },
+}
+
+nurse_note_request_properties = {
+    key: value
+    for key, value in nurse_note_properties.items()
+    if key not in {"id", "created_at", "updated_at"}
+}
+
 swagger_config = {
     "headers": [],
     "specs": [
@@ -229,6 +315,19 @@ swagger_template = {
         "AideNoteUpdate": {
             "type": "object",
             "properties": aide_note_request_properties,
+        },
+        "NurseNote": {
+            "type": "object",
+            "properties": nurse_note_properties,
+        },
+        "NurseNoteCreate": {
+            "type": "object",
+            "required": ["patient_id", "visit_id"],
+            "properties": nurse_note_request_properties,
+        },
+        "NurseNoteUpdate": {
+            "type": "object",
+            "properties": nurse_note_request_properties,
         },
         "ErrorResponse": {
             "type": "object",
@@ -310,6 +409,29 @@ swagger_template = {
                 "message": {
                     "type": "string",
                     "example": "Aide notes retrieved successfully",
+                },
+            },
+        },
+        "NurseNoteResponse": {
+            "type": "object",
+            "properties": {
+                "data": {"$ref": "#/definitions/NurseNote"},
+                "message": {
+                    "type": "string",
+                    "example": "Nurse note retrieved successfully",
+                },
+            },
+        },
+        "NurseNoteListResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/NurseNote"},
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Nurse notes retrieved successfully",
                 },
             },
         },
@@ -760,6 +882,165 @@ visit_aide_note_get_spec = {
         },
         404: {
             "description": "Visit or aide note not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+nurse_note_list_spec = {
+    "tags": ["Nurse Notes"],
+    "summary": "List nurse notes",
+    "responses": {
+        200: {
+            "description": "Nurse notes retrieved successfully.",
+            "schema": {"$ref": "#/definitions/NurseNoteListResponse"},
+        }
+    },
+}
+
+nurse_note_get_spec = {
+    "tags": ["Nurse Notes"],
+    "summary": "Retrieve a nurse note",
+    "parameters": [
+        {
+            "name": "nurse_note_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Nurse note retrieved successfully.",
+            "schema": {"$ref": "#/definitions/NurseNoteResponse"},
+        },
+        404: {
+            "description": "Nurse note not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+nurse_note_create_spec = {
+    "tags": ["Nurse Notes"],
+    "summary": "Create a nurse note",
+    "parameters": [
+        {
+            "name": "body",
+            "in": "body",
+            "required": True,
+            "schema": {"$ref": "#/definitions/NurseNoteCreate"},
+        }
+    ],
+    "responses": {
+        201: {
+            "description": "Nurse note created successfully.",
+            "schema": {"$ref": "#/definitions/NurseNoteResponse"},
+        },
+        400: {
+            "description": "Invalid nurse note data.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+nurse_note_update_spec = {
+    "tags": ["Nurse Notes"],
+    "summary": "Update a nurse note",
+    "parameters": [
+        {
+            "name": "nurse_note_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        },
+        {
+            "name": "body",
+            "in": "body",
+            "required": True,
+            "schema": {"$ref": "#/definitions/NurseNoteUpdate"},
+        },
+    ],
+    "responses": {
+        200: {
+            "description": "Nurse note updated successfully.",
+            "schema": {"$ref": "#/definitions/NurseNoteResponse"},
+        },
+        400: {
+            "description": "Invalid nurse note data.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+        404: {
+            "description": "Nurse note not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+nurse_note_delete_spec = {
+    "tags": ["Nurse Notes"],
+    "summary": "Delete a nurse note",
+    "parameters": [
+        {
+            "name": "nurse_note_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Nurse note deleted successfully.",
+            "schema": {"$ref": "#/definitions/DeleteSuccessResponse"},
+        },
+        404: {
+            "description": "Nurse note not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+patient_nurse_notes_list_spec = {
+    "tags": ["Nurse Notes"],
+    "summary": "List nurse notes for a patient",
+    "parameters": [
+        {
+            "name": "patient_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Patient nurse notes retrieved successfully.",
+            "schema": {"$ref": "#/definitions/NurseNoteListResponse"},
+        },
+        404: {
+            "description": "Patient not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+visit_nurse_note_get_spec = {
+    "tags": ["Nurse Notes"],
+    "summary": "Retrieve the nurse note for a visit",
+    "parameters": [
+        {
+            "name": "visit_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Visit nurse note retrieved successfully.",
+            "schema": {"$ref": "#/definitions/NurseNoteResponse"},
+        },
+        404: {
+            "description": "Visit or nurse note not found.",
             "schema": {"$ref": "#/definitions/ErrorResponse"},
         },
     },

--- a/backend/migrations/versions/20260531_0004_create_nurse_notes_table.py
+++ b/backend/migrations/versions/20260531_0004_create_nurse_notes_table.py
@@ -1,0 +1,66 @@
+"""create nurse notes table
+
+Revision ID: 20260531_0004
+Revises: 20260531_0003
+Create Date: 2026-05-31 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260531_0004"
+down_revision = "20260531_0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "nurse_notes",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("patient_id", sa.Integer(), nullable=False),
+        sa.Column("visit_id", sa.Integer(), nullable=False),
+        sa.Column("diagnosis", sa.Text(), nullable=True),
+        sa.Column("living_arrangements", sa.JSON(), nullable=True),
+        sa.Column("visit_type", sa.JSON(), nullable=True),
+        sa.Column("vital_signs", sa.JSON(), nullable=True),
+        sa.Column("diet", sa.JSON(), nullable=True),
+        sa.Column("pain_assessment", sa.JSON(), nullable=True),
+        sa.Column("sensory", sa.JSON(), nullable=True),
+        sa.Column("neuro", sa.JSON(), nullable=True),
+        sa.Column("respiratory", sa.JSON(), nullable=True),
+        sa.Column("cardiac", sa.JSON(), nullable=True),
+        sa.Column("peripheral_circulation", sa.JSON(), nullable=True),
+        sa.Column("genitourinary", sa.JSON(), nullable=True),
+        sa.Column("gastrointestinal", sa.JSON(), nullable=True),
+        sa.Column("endocrine", sa.JSON(), nullable=True),
+        sa.Column("skin_integrity", sa.JSON(), nullable=True),
+        sa.Column("wound_evaluation", sa.JSON(), nullable=True),
+        sa.Column("mental_status", sa.JSON(), nullable=True),
+        sa.Column("functional_status", sa.JSON(), nullable=True),
+        sa.Column("homebound_status", sa.JSON(), nullable=True),
+        sa.Column("skilled_nursing", sa.Text(), nullable=True),
+        sa.Column("response_to_intervention", sa.Text(), nullable=True),
+        sa.Column("patient_caregiver_understanding", sa.JSON(), nullable=True),
+        sa.Column("md_contact", sa.JSON(), nullable=True),
+        sa.Column("discharge_planning", sa.Text(), nullable=True),
+        sa.Column("patient_feedback", sa.Text(), nullable=True),
+        sa.Column("narrative", sa.Text(), nullable=True),
+        sa.Column("signature_data", sa.Text(), nullable=True),
+        sa.Column("signature_date", sa.Date(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["patient_id"], ["patients.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["visit_id"], ["visits.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("visit_id", name="uq_nurse_notes_visit_id"),
+    )
+    op.create_index("ix_nurse_notes_patient_id", "nurse_notes", ["patient_id"])
+    op.create_index("ix_nurse_notes_visit_id", "nurse_notes", ["visit_id"], unique=True)
+
+
+def downgrade():
+    op.drop_index("ix_nurse_notes_visit_id", table_name="nurse_notes")
+    op.drop_index("ix_nurse_notes_patient_id", table_name="nurse_notes")
+    op.drop_table("nurse_notes")

--- a/backend/tests/test_nurse_notes.py
+++ b/backend/tests/test_nurse_notes.py
@@ -1,0 +1,228 @@
+def patient_payload(**overrides):
+    payload = {
+        "first_name": "Maria",
+        "last_name": "Santos",
+        "date_of_birth": "1945-03-12",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def create_patient(client, **overrides):
+    return client.post("/api/patients", json=patient_payload(**overrides)).get_json()[
+        "data"
+    ]
+
+
+def visit_payload(patient_id, **overrides):
+    payload = {
+        "patient_id": patient_id,
+        "visit_date": "2026-06-01",
+        "visit_type": "Skilled nursing visit",
+        "staff_name": "Jordan Lee",
+        "staff_role": "nurse",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def create_visit(client, patient_id, **overrides):
+    return client.post("/api/visits", json=visit_payload(patient_id, **overrides)).get_json()[
+        "data"
+    ]
+
+
+def nurse_note_payload(patient_id, visit_id, **overrides):
+    payload = {
+        "patient_id": patient_id,
+        "visit_id": visit_id,
+        "diagnosis": "Hypertension",
+        "living_arrangements": {"status": "lives with caregiver"},
+        "visit_type": {"type": "routine skilled nursing"},
+        "vital_signs": {"blood_pressure": "120/80", "pulse": 72},
+        "diet": {"ordered": "low sodium"},
+        "pain_assessment": {"pain_level": 2},
+        "sensory": {"vision": "glasses"},
+        "neuro": {"orientation": "oriented x3"},
+        "respiratory": {"lungs": "clear"},
+        "cardiac": {"rhythm": "regular"},
+        "peripheral_circulation": {"edema": "none"},
+        "genitourinary": {"voiding": "normal"},
+        "gastrointestinal": {"bowel_sounds": "present"},
+        "endocrine": {"blood_glucose": 110},
+        "skin_integrity": {"intact": True},
+        "wound_evaluation": {"wounds": []},
+        "mental_status": {"mood": "calm"},
+        "functional_status": {"ambulation": "walker"},
+        "homebound_status": {"reason": "requires assistance to leave home"},
+        "skilled_nursing": "Medication reconciliation completed.",
+        "response_to_intervention": "Patient verbalized understanding.",
+        "patient_caregiver_understanding": {"understood": True},
+        "md_contact": {"contacted": False},
+        "discharge_planning": "Continue plan of care.",
+        "patient_feedback": "Patient reports feeling stable.",
+        "narrative": "Skilled nursing visit completed without incident.",
+        "signature_data": "data:image/png;base64,placeholder",
+        "signature_date": "2026-06-01",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def create_nurse_note(client, patient_id, visit_id, **overrides):
+    return client.post(
+        "/api/nurse-notes",
+        json=nurse_note_payload(patient_id, visit_id, **overrides),
+    )
+
+
+def test_create_nurse_note(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+
+    response = create_nurse_note(client, patient["id"], visit["id"])
+    body = response.get_json()
+
+    assert response.status_code == 201
+    assert body["message"] == "Nurse note created successfully"
+    assert body["data"]["patient_id"] == patient["id"]
+    assert body["data"]["visit_id"] == visit["id"]
+    assert body["data"]["diagnosis"] == "Hypertension"
+    assert body["data"]["vital_signs"]["blood_pressure"] == "120/80"
+
+
+def test_list_nurse_notes(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    create_nurse_note(client, patient["id"], visit["id"])
+
+    response = client.get("/api/nurse-notes")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["message"] == "Nurse notes retrieved successfully"
+    assert len(body["data"]) == 1
+
+
+def test_get_nurse_note(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    created = create_nurse_note(client, patient["id"], visit["id"]).get_json()["data"]
+
+    response = client.get(f"/api/nurse-notes/{created['id']}")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["data"]["id"] == created["id"]
+    assert body["data"]["diagnosis"] == "Hypertension"
+
+
+def test_update_nurse_note(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    created = create_nurse_note(client, patient["id"], visit["id"]).get_json()["data"]
+
+    response = client.put(
+        f"/api/nurse-notes/{created['id']}",
+        json={
+            "diagnosis": "Hypertension and diabetes",
+            "narrative": "Updated after nursing review.",
+        },
+    )
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["message"] == "Nurse note updated successfully"
+    assert body["data"]["diagnosis"] == "Hypertension and diabetes"
+
+
+def test_delete_nurse_note(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    created = create_nurse_note(client, patient["id"], visit["id"]).get_json()["data"]
+
+    response = client.delete(f"/api/nurse-notes/{created['id']}")
+
+    assert response.status_code == 200
+    assert response.get_json()["message"] == "Nurse note deleted successfully"
+    assert client.get(f"/api/nurse-notes/{created['id']}").status_code == 404
+
+
+def test_list_nurse_notes_for_patient(client):
+    patient = create_patient(client)
+    other_patient = create_patient(client, first_name="John", last_name="Rivera")
+    visit = create_visit(client, patient["id"])
+    other_visit = create_visit(client, other_patient["id"])
+    create_nurse_note(client, patient["id"], visit["id"])
+    create_nurse_note(client, other_patient["id"], other_visit["id"])
+
+    response = client.get(f"/api/patients/{patient['id']}/nurse-notes")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["message"] == "Patient nurse notes retrieved successfully"
+    assert len(body["data"]) == 1
+    assert body["data"][0]["patient_id"] == patient["id"]
+
+
+def test_get_nurse_note_by_visit(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    created = create_nurse_note(client, patient["id"], visit["id"]).get_json()["data"]
+
+    response = client.get(f"/api/visits/{visit['id']}/nurse-note")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["message"] == "Visit nurse note retrieved successfully"
+    assert body["data"]["id"] == created["id"]
+
+
+def test_create_nurse_note_requires_patient_id(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    payload = nurse_note_payload(patient["id"], visit["id"])
+    payload["patient_id"] = None
+
+    response = client.post("/api/nurse-notes", json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["patient_id"] == "This field is required."
+
+
+def test_create_nurse_note_requires_visit_id(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    payload = nurse_note_payload(patient["id"], visit["id"])
+    payload["visit_id"] = None
+
+    response = client.post("/api/nurse-notes", json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["visit_id"] == "This field is required."
+
+
+def test_create_nurse_note_rejects_visit_for_different_patient(client):
+    patient = create_patient(client)
+    other_patient = create_patient(client, first_name="John", last_name="Rivera")
+    visit = create_visit(client, other_patient["id"])
+
+    response = create_nurse_note(client, patient["id"], visit["id"])
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["visit_id"] == (
+        "Visit does not belong to the selected patient."
+    )
+
+
+def test_create_nurse_note_rejects_duplicate_visit_note(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    create_nurse_note(client, patient["id"], visit["id"])
+
+    response = create_nurse_note(client, patient["id"], visit["id"])
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["visit_id"] == (
+        "A nurse note already exists for this visit."
+    )

--- a/backend/tests/test_openapi.py
+++ b/backend/tests/test_openapi.py
@@ -28,6 +28,10 @@ def test_openapi_json_includes_health_and_patient_endpoints(client):
     assert "/api/aide-notes/{aide_note_id}" in paths
     assert "/api/patients/{patient_id}/aide-notes" in paths
     assert "/api/visits/{visit_id}/aide-note" in paths
+    assert "/api/nurse-notes" in paths
+    assert "/api/nurse-notes/{nurse_note_id}" in paths
+    assert "/api/patients/{patient_id}/nurse-notes" in paths
+    assert "/api/visits/{visit_id}/nurse-note" in paths
     assert "get" in paths["/api/health"]
     assert {"get", "post"} <= set(paths["/api/patients"].keys())
     assert {"get", "put", "delete"} <= set(
@@ -42,6 +46,12 @@ def test_openapi_json_includes_health_and_patient_endpoints(client):
     )
     assert "get" in paths["/api/patients/{patient_id}/aide-notes"]
     assert "get" in paths["/api/visits/{visit_id}/aide-note"]
+    assert {"get", "post"} <= set(paths["/api/nurse-notes"].keys())
+    assert {"get", "put", "delete"} <= set(
+        paths["/api/nurse-notes/{nurse_note_id}"].keys()
+    )
+    assert "get" in paths["/api/patients/{patient_id}/nurse-notes"]
+    assert "get" in paths["/api/visits/{visit_id}/nurse-note"]
 
 
 def test_openapi_json_includes_patient_schemas(client):
@@ -64,3 +74,8 @@ def test_openapi_json_includes_patient_schemas(client):
     assert "AideNoteUpdate" in definitions
     assert "AideNoteResponse" in definitions
     assert "AideNoteListResponse" in definitions
+    assert "NurseNote" in definitions
+    assert "NurseNoteCreate" in definitions
+    assert "NurseNoteUpdate" in definitions
+    assert "NurseNoteResponse" in definitions
+    assert "NurseNoteListResponse" in definitions

--- a/docs/architecture/api-design.md
+++ b/docs/architecture/api-design.md
@@ -731,3 +731,328 @@ Example response:
   "message": "Aide note deleted successfully"
 }
 ```
+
+## Nurse Note API
+
+The Nurse Note API records clinical nurses progress notes linked to both a patient and a visit. Large clinical assessment sections are stored as JSON for flexibility while the clinical form evolves.
+
+### Nurse Note Fields
+
+- `id`
+- `patient_id`
+- `visit_id`
+- `diagnosis`
+- `living_arrangements`
+- `visit_type`
+- `vital_signs`
+- `diet`
+- `pain_assessment`
+- `sensory`
+- `neuro`
+- `respiratory`
+- `cardiac`
+- `peripheral_circulation`
+- `genitourinary`
+- `gastrointestinal`
+- `endocrine`
+- `skin_integrity`
+- `wound_evaluation`
+- `mental_status`
+- `functional_status`
+- `homebound_status`
+- `skilled_nursing`
+- `response_to_intervention`
+- `patient_caregiver_understanding`
+- `md_contact`
+- `discharge_planning`
+- `patient_feedback`
+- `narrative`
+- `signature_data`
+- `signature_date`
+- `created_at`
+- `updated_at`
+
+`patient_id` and `visit_id` are required. The visit must exist and belong to the selected patient. A visit can have only one nurse note.
+
+### List Nurse Notes
+
+`GET /api/nurse-notes`
+
+Example response:
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "patient_id": 1,
+      "visit_id": 1,
+      "diagnosis": "Hypertension",
+      "living_arrangements": {
+        "status": "lives with caregiver"
+      },
+      "visit_type": {
+        "type": "routine skilled nursing"
+      },
+      "vital_signs": {
+        "blood_pressure": "120/80",
+        "pulse": 72
+      },
+      "diet": {
+        "ordered": "low sodium"
+      },
+      "pain_assessment": {
+        "pain_level": 2
+      },
+      "sensory": {
+        "vision": "glasses"
+      },
+      "neuro": {
+        "orientation": "oriented x3"
+      },
+      "respiratory": {
+        "lungs": "clear"
+      },
+      "cardiac": {
+        "rhythm": "regular"
+      },
+      "peripheral_circulation": {
+        "edema": "none"
+      },
+      "genitourinary": {
+        "voiding": "normal"
+      },
+      "gastrointestinal": {
+        "bowel_sounds": "present"
+      },
+      "endocrine": {
+        "blood_glucose": 110
+      },
+      "skin_integrity": {
+        "intact": true
+      },
+      "wound_evaluation": {
+        "wounds": []
+      },
+      "mental_status": {
+        "mood": "calm"
+      },
+      "functional_status": {
+        "ambulation": "walker"
+      },
+      "homebound_status": {
+        "reason": "requires assistance to leave home"
+      },
+      "skilled_nursing": "Medication reconciliation completed.",
+      "response_to_intervention": "Patient verbalized understanding.",
+      "patient_caregiver_understanding": {
+        "understood": true
+      },
+      "md_contact": {
+        "contacted": false
+      },
+      "discharge_planning": "Continue plan of care.",
+      "patient_feedback": "Patient reports feeling stable.",
+      "narrative": "Skilled nursing visit completed without incident.",
+      "signature_data": "data:image/png;base64,...",
+      "signature_date": "2026-06-01",
+      "created_at": "2026-05-31T10:00:00+00:00",
+      "updated_at": "2026-05-31T10:00:00+00:00"
+    }
+  ],
+  "message": "Nurse notes retrieved successfully"
+}
+```
+
+### List Nurse Notes for a Patient
+
+`GET /api/patients/<patient_id>/nurse-notes`
+
+Example response:
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "patient_id": 1,
+      "visit_id": 1,
+      "diagnosis": "Hypertension",
+      "vital_signs": {
+        "blood_pressure": "120/80"
+      },
+      "skilled_nursing": "Medication reconciliation completed.",
+      "narrative": "Skilled nursing visit completed without incident.",
+      "created_at": "2026-05-31T10:00:00+00:00",
+      "updated_at": "2026-05-31T10:00:00+00:00"
+    }
+  ],
+  "message": "Patient nurse notes retrieved successfully"
+}
+```
+
+### Retrieve a Nurse Note
+
+`GET /api/nurse-notes/<id>`
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "patient_id": 1,
+    "visit_id": 1,
+    "diagnosis": "Hypertension",
+    "vital_signs": {
+      "blood_pressure": "120/80",
+      "pulse": 72
+    },
+    "skilled_nursing": "Medication reconciliation completed.",
+    "narrative": "Skilled nursing visit completed without incident.",
+    "signature_date": "2026-06-01",
+    "created_at": "2026-05-31T10:00:00+00:00",
+    "updated_at": "2026-05-31T10:00:00+00:00"
+  },
+  "message": "Nurse note retrieved successfully"
+}
+```
+
+### Retrieve a Nurse Note for a Visit
+
+`GET /api/visits/<visit_id>/nurse-note`
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "patient_id": 1,
+    "visit_id": 1,
+    "diagnosis": "Hypertension",
+    "vital_signs": {
+      "blood_pressure": "120/80"
+    },
+    "narrative": "Skilled nursing visit completed without incident.",
+    "created_at": "2026-05-31T10:00:00+00:00",
+    "updated_at": "2026-05-31T10:00:00+00:00"
+  },
+  "message": "Visit nurse note retrieved successfully"
+}
+```
+
+### Create a Nurse Note
+
+`POST /api/nurse-notes`
+
+Example request:
+
+```json
+{
+  "patient_id": 1,
+  "visit_id": 1,
+  "diagnosis": "Hypertension",
+  "vital_signs": {
+    "blood_pressure": "120/80",
+    "pulse": 72
+  },
+  "pain_assessment": {
+    "pain_level": 2
+  },
+  "skilled_nursing": "Medication reconciliation completed.",
+  "response_to_intervention": "Patient verbalized understanding.",
+  "patient_caregiver_understanding": {
+    "understood": true
+  },
+  "md_contact": {
+    "contacted": false
+  },
+  "discharge_planning": "Continue plan of care.",
+  "patient_feedback": "Patient reports feeling stable.",
+  "narrative": "Skilled nursing visit completed without incident.",
+  "signature_data": "data:image/png;base64,...",
+  "signature_date": "2026-06-01"
+}
+```
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "patient_id": 1,
+    "visit_id": 1,
+    "diagnosis": "Hypertension",
+    "vital_signs": {
+      "blood_pressure": "120/80",
+      "pulse": 72
+    },
+    "pain_assessment": {
+      "pain_level": 2
+    },
+    "skilled_nursing": "Medication reconciliation completed.",
+    "response_to_intervention": "Patient verbalized understanding.",
+    "patient_caregiver_understanding": {
+      "understood": true
+    },
+    "md_contact": {
+      "contacted": false
+    },
+    "discharge_planning": "Continue plan of care.",
+    "patient_feedback": "Patient reports feeling stable.",
+    "narrative": "Skilled nursing visit completed without incident.",
+    "signature_data": "data:image/png;base64,...",
+    "signature_date": "2026-06-01",
+    "created_at": "2026-05-31T10:00:00+00:00",
+    "updated_at": "2026-05-31T10:00:00+00:00"
+  },
+  "message": "Nurse note created successfully"
+}
+```
+
+### Update a Nurse Note
+
+`PUT /api/nurse-notes/<id>`
+
+Example request:
+
+```json
+{
+  "diagnosis": "Hypertension and diabetes",
+  "narrative": "Updated after nursing review."
+}
+```
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "patient_id": 1,
+    "visit_id": 1,
+    "diagnosis": "Hypertension and diabetes",
+    "narrative": "Updated after nursing review.",
+    "created_at": "2026-05-31T10:00:00+00:00",
+    "updated_at": "2026-05-31T10:10:00+00:00"
+  },
+  "message": "Nurse note updated successfully"
+}
+```
+
+### Delete a Nurse Note
+
+`DELETE /api/nurse-notes/<id>`
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1
+  },
+  "message": "Nurse note deleted successfully"
+}
+```


### PR DESCRIPTION
# Summary

- Added a NurseNote model linked to patients and visits, with large clinical assessment sections stored as JSON and one nurse note per visit.
- Added Nurse Note CRUD endpoints plus patient-to-nurse-notes and visit-to-nurse-note endpoints.
- Added validation for required patient and visit fields, patient/visit existence, visit ownership, duplicate visit notes, optional signature dates, and JSON clinical section formats.
- Added an Alembic migration for the `nurse_notes` table with patient/visit foreign keys and a unique visit constraint.
- Added Swagger/OpenAPI schemas and endpoint specs, backend tests, API documentation, and CHANGELOG.md entry.

## Related Issue / Task

- Feature: 11-nurse-note-api

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `docker-compose exec -T backend pytest`
- `docker-compose exec -T backend ruff check .`
- `docker-compose exec -T backend flask db upgrade`
- `curl -s http://localhost:5001/api/nurse-notes`
- `curl -s http://localhost:5001/api/openapi.json | rg 'nurse-notes|NurseNote'`
- `docker-compose build backend`
- `npm run build`
- `git diff --check`
- Secret-pattern scan with `rg`

## Screenshots

N/A

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.