### PR TITLE
feat: add care operations dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added the dashboard API and frontend dashboard with patient, visit, care-note, chart, and recent visit activity summaries.
 - Added the Nurses Progress Note frontend with visit detail integration, grouped clinical form, read-only detail view, edit workflow, and API service functions.
 - Added the Nurses Progress Note API with patient/visit-linked clinical records, JSON clinical section storage, duplicate visit-note prevention, Swagger documentation, tests, and API documentation.
 - Added the Home Health Aide Note frontend with visit detail integration, grouped checklist form, read-only detail view, edit workflow, and API service functions.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Docker Compose is the recommended way to run the local SeniorMate stack. It star
 6. Open the local services.
 
    - Frontend: `http://localhost:5173`
+   - Dashboard: `http://localhost:5173`
    - Patient management UI: `http://localhost:5173/patients`
    - Visits UI: `http://localhost:5173/visits`
    - Aide Notes UI: `http://localhost:5173/aide-notes`

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -10,6 +10,7 @@ from app.models import NurseNote as NurseNote
 from app.models import Patient as Patient
 from app.models import Visit as Visit
 from app.routes.aide_notes import aide_notes_bp
+from app.routes.dashboard import dashboard_bp
 from app.routes.nurse_notes import nurse_notes_bp
 from app.routes.patients import patients_bp
 from app.routes.visits import visits_bp
@@ -25,6 +26,7 @@ def create_app(config_object=Config):
     db.init_app(app)
     migrate.init_app(app, db)
     app.register_blueprint(aide_notes_bp)
+    app.register_blueprint(dashboard_bp)
     app.register_blueprint(nurse_notes_bp)
     app.register_blueprint(patients_bp)
     app.register_blueprint(visits_bp)

--- a/backend/app/routes/dashboard.py
+++ b/backend/app/routes/dashboard.py
@@ -1,0 +1,101 @@
+from datetime import UTC, date, datetime
+
+from flasgger import swag_from
+from flask import Blueprint
+from sqlalchemy import func
+
+from app.extensions import db
+from app.models import AideNote, NurseNote, Patient, Visit
+from app.swagger import dashboard_stats_spec
+
+
+dashboard_bp = Blueprint("dashboard", __name__, url_prefix="/api")
+
+
+def success_response(data, message, status_code=200):
+    return {"data": data, "message": message}, status_code
+
+
+def month_bounds(today=None):
+    current = today or datetime.now(UTC).date()
+    start = date(current.year, current.month, 1)
+
+    if current.month == 12:
+        end = date(current.year + 1, 1, 1)
+    else:
+        end = date(current.year, current.month + 1, 1)
+
+    return start, end
+
+
+def start_of_day(day):
+    return datetime.combine(day, datetime.min.time(), tzinfo=UTC)
+
+
+def grouped_counts(model, field, default_label="Not specified"):
+    rows = (
+        db.session.query(field, func.count(model.id))
+        .group_by(field)
+        .order_by(func.count(model.id).desc(), field.asc())
+        .all()
+    )
+
+    return [
+        {
+            "label": label or default_label,
+            "count": count,
+        }
+        for label, count in rows
+    ]
+
+
+def recent_visit_payload(visit):
+    patient_name = None
+
+    if visit.patient:
+        patient_name = f"{visit.patient.first_name} {visit.patient.last_name}"
+
+    return {
+        "id": visit.id,
+        "patient_name": patient_name,
+        "visit_date": visit.visit_date.isoformat() if visit.visit_date else None,
+        "visit_type": visit.visit_type,
+        "staff_role": visit.staff_role,
+        "status": visit.status,
+    }
+
+
+@dashboard_bp.get("/dashboard/stats")
+@swag_from(dashboard_stats_spec)
+def get_dashboard_stats():
+    start_of_month, start_of_next_month = month_bounds()
+
+    recent_visits = (
+        Visit.query.order_by(Visit.visit_date.desc(), Visit.id.desc()).limit(5).all()
+    )
+
+    data = {
+        "total_patients": Patient.query.count(),
+        "active_patients": Patient.query.filter_by(status="active").count(),
+        "inactive_patients": Patient.query.filter_by(status="inactive").count(),
+        "total_visits": Visit.query.count(),
+        "visits_this_month": Visit.query.filter(
+            Visit.visit_date >= start_of_month,
+            Visit.visit_date < start_of_next_month,
+        ).count(),
+        "aide_notes_this_month": AideNote.query.filter(
+            AideNote.created_at >= start_of_day(start_of_month),
+            AideNote.created_at < start_of_day(start_of_next_month),
+        ).count(),
+        "nurse_notes_this_month": NurseNote.query.filter(
+            NurseNote.created_at >= start_of_day(start_of_month),
+            NurseNote.created_at < start_of_day(start_of_next_month),
+        ).count(),
+        "patients_by_status": grouped_counts(Patient, Patient.status),
+        "patients_by_gender": grouped_counts(Patient, Patient.gender),
+        "visits_by_type": grouped_counts(Visit, Visit.visit_type),
+        "visits_by_status": grouped_counts(Visit, Visit.status),
+        "recent_visits": [recent_visit_payload(visit) for visit in recent_visits],
+    }
+
+    return success_response(data, "Dashboard stats retrieved successfully")

--- a/backend/app/swagger.py
+++ b/backend/app/swagger.py
@@ -250,6 +250,54 @@ nurse_note_request_properties = {
     if key not in {"id", "created_at", "updated_at"}
 }
 
+dashboard_group_item_properties = {
+    "label": {"type": "string", "example": "active"},
+    "count": {"type": "integer", "example": 4},
+}
+
+dashboard_recent_visit_properties = {
+    "id": {"type": "integer", "example": 1},
+    "patient_name": {"type": "string", "nullable": True, "example": "Maria Santos"},
+    "visit_date": {"type": "string", "format": "date", "example": "2026-06-01"},
+    "visit_type": {"type": "string", "example": "Skilled nursing visit"},
+    "staff_role": {
+        "type": "string",
+        "nullable": True,
+        "example": "nurse",
+    },
+    "status": {"type": "string", "example": "completed"},
+}
+
+dashboard_stats_properties = {
+    "total_patients": {"type": "integer", "example": 12},
+    "active_patients": {"type": "integer", "example": 10},
+    "inactive_patients": {"type": "integer", "example": 2},
+    "total_visits": {"type": "integer", "example": 24},
+    "visits_this_month": {"type": "integer", "example": 8},
+    "aide_notes_this_month": {"type": "integer", "example": 5},
+    "nurse_notes_this_month": {"type": "integer", "example": 3},
+    "patients_by_status": {
+        "type": "array",
+        "items": {"$ref": "#/definitions/DashboardGroupItem"},
+    },
+    "patients_by_gender": {
+        "type": "array",
+        "items": {"$ref": "#/definitions/DashboardGroupItem"},
+    },
+    "visits_by_type": {
+        "type": "array",
+        "items": {"$ref": "#/definitions/DashboardGroupItem"},
+    },
+    "visits_by_status": {
+        "type": "array",
+        "items": {"$ref": "#/definitions/DashboardGroupItem"},
+    },
+    "recent_visits": {
+        "type": "array",
+        "items": {"$ref": "#/definitions/DashboardRecentVisit"},
+    },
+}
+
 swagger_config = {
     "headers": [],
     "specs": [
@@ -328,6 +376,28 @@ swagger_template = {
         "NurseNoteUpdate": {
             "type": "object",
             "properties": nurse_note_request_properties,
+        },
+        "DashboardGroupItem": {
+            "type": "object",
+            "properties": dashboard_group_item_properties,
+        },
+        "DashboardRecentVisit": {
+            "type": "object",
+            "properties": dashboard_recent_visit_properties,
+        },
+        "DashboardStats": {
+            "type": "object",
+            "properties": dashboard_stats_properties,
+        },
+        "DashboardStatsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {"$ref": "#/definitions/DashboardStats"},
+                "message": {
+                    "type": "string",
+                    "example": "Dashboard stats retrieved successfully",
+                },
+            },
         },
         "ErrorResponse": {
             "type": "object",
@@ -476,6 +546,17 @@ health_spec = {
         503: {
             "description": "Backend is reachable but a dependency is unavailable.",
         },
+    },
+}
+
+dashboard_stats_spec = {
+    "tags": ["Dashboard"],
+    "summary": "Retrieve dashboard statistics",
+    "responses": {
+        200: {
+            "description": "Dashboard stats retrieved successfully.",
+            "schema": {"$ref": "#/definitions/DashboardStatsResponse"},
+        }
     },
 }
 

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -1,0 +1,168 @@
+from datetime import UTC, date, datetime
+
+
+def current_month_date(day=1):
+    today = datetime.now(UTC).date()
+    return date(today.year, today.month, day).isoformat()
+
+
+def prior_month_date():
+    today = datetime.now(UTC).date()
+
+    if today.month == 1:
+        return date(today.year - 1, 12, 15).isoformat()
+
+    return date(today.year, today.month - 1, 15).isoformat()
+
+
+def patient_payload(**overrides):
+    payload = {
+        "first_name": "Maria",
+        "last_name": "Santos",
+        "gender": "female",
+        "status": "active",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def create_patient(client, **overrides):
+    return client.post("/api/patients", json=patient_payload(**overrides)).get_json()[
+        "data"
+    ]
+
+
+def visit_payload(patient_id, **overrides):
+    payload = {
+        "patient_id": patient_id,
+        "visit_date": current_month_date(),
+        "visit_type": "Skilled nursing visit",
+        "staff_name": "Jordan Lee",
+        "staff_role": "nurse",
+        "status": "completed",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def create_visit(client, patient_id, **overrides):
+    return client.post("/api/visits", json=visit_payload(patient_id, **overrides)).get_json()[
+        "data"
+    ]
+
+
+def create_aide_note(client, patient_id, visit_id):
+    return client.post(
+        "/api/aide-notes",
+        json={
+            "patient_id": patient_id,
+            "visit_id": visit_id,
+            "aide_name": "Alex Morgan",
+            "time_in": "09:00",
+            "time_out": "10:00",
+        },
+    ).get_json()["data"]
+
+
+def create_nurse_note(client, patient_id, visit_id):
+    return client.post(
+        "/api/nurse-notes",
+        json={
+            "patient_id": patient_id,
+            "visit_id": visit_id,
+            "diagnosis": "Hypertension",
+        },
+    ).get_json()["data"]
+
+
+def test_dashboard_stats_endpoint_returns_expected_keys(client):
+    response = client.get("/api/dashboard/stats")
+    body = response.get_json()
+
+    expected_keys = {
+        "total_patients",
+        "active_patients",
+        "inactive_patients",
+        "total_visits",
+        "visits_this_month",
+        "aide_notes_this_month",
+        "nurse_notes_this_month",
+        "patients_by_status",
+        "patients_by_gender",
+        "visits_by_type",
+        "visits_by_status",
+        "recent_visits",
+    }
+
+    assert response.status_code == 200
+    assert body["message"] == "Dashboard stats retrieved successfully"
+    assert expected_keys <= set(body["data"].keys())
+
+
+def test_dashboard_stats_counts_are_correct(client):
+    active_patient = create_patient(client)
+    inactive_patient = create_patient(
+        client,
+        first_name="John",
+        last_name="Rivera",
+        gender="male",
+        status="inactive",
+    )
+
+    current_visit = create_visit(client, active_patient["id"])
+    create_visit(
+        client,
+        inactive_patient["id"],
+        visit_date=prior_month_date(),
+        visit_type="Home health aide visit",
+        staff_role="aide",
+        status="scheduled",
+    )
+    aide_visit = create_visit(
+        client,
+        active_patient["id"],
+        visit_date=current_month_date(2),
+        visit_type="Home health aide visit",
+        staff_role="aide",
+    )
+    nurse_visit = create_visit(
+        client,
+        active_patient["id"],
+        visit_date=current_month_date(3),
+    )
+    create_aide_note(client, active_patient["id"], aide_visit["id"])
+    create_nurse_note(client, active_patient["id"], nurse_visit["id"])
+
+    response = client.get("/api/dashboard/stats")
+    data = response.get_json()["data"]
+
+    assert response.status_code == 200
+    assert data["total_patients"] == 2
+    assert data["active_patients"] == 1
+    assert data["inactive_patients"] == 1
+    assert data["total_visits"] == 4
+    assert data["visits_this_month"] == 3
+    assert data["aide_notes_this_month"] == 1
+    assert data["nurse_notes_this_month"] == 1
+    assert {"label": "active", "count": 1} in data["patients_by_status"]
+    assert {"label": "inactive", "count": 1} in data["patients_by_status"]
+    assert {"label": "female", "count": 1} in data["patients_by_gender"]
+    assert {"label": "male", "count": 1} in data["patients_by_gender"]
+    assert {"label": "Skilled nursing visit", "count": 2} in data["visits_by_type"]
+    assert {"label": "completed", "count": 3} in data["visits_by_status"]
+    assert data["recent_visits"][0]["id"] == nurse_visit["id"]
+    assert data["recent_visits"][0]["patient_name"] == "Maria Santos"
+    assert current_visit["id"] in [visit["id"] for visit in data["recent_visits"]]
+
+
+def test_dashboard_recent_visits_are_returned_in_expected_order(client):
+    patient = create_patient(client)
+    first = create_visit(client, patient["id"], visit_date=current_month_date(1))
+    second = create_visit(client, patient["id"], visit_date=current_month_date(2))
+    third = create_visit(client, patient["id"], visit_date=current_month_date(3))
+
+    response = client.get("/api/dashboard/stats")
+    recent_ids = [visit["id"] for visit in response.get_json()["data"]["recent_visits"]]
+
+    assert response.status_code == 200
+    assert recent_ids[:3] == [third["id"], second["id"], first["id"]]

--- a/backend/tests/test_openapi.py
+++ b/backend/tests/test_openapi.py
@@ -19,6 +19,7 @@ def test_openapi_json_includes_health_and_patient_endpoints(client):
     paths = response.get_json()["paths"]
 
     assert "/api/health" in paths
+    assert "/api/dashboard/stats" in paths
     assert "/api/patients" in paths
     assert "/api/patients/{patient_id}" in paths
     assert "/api/visits" in paths
@@ -33,6 +34,7 @@ def test_openapi_json_includes_health_and_patient_endpoints(client):
     assert "/api/patients/{patient_id}/nurse-notes" in paths
     assert "/api/visits/{visit_id}/nurse-note" in paths
     assert "get" in paths["/api/health"]
+    assert "get" in paths["/api/dashboard/stats"]
     assert {"get", "post"} <= set(paths["/api/patients"].keys())
     assert {"get", "put", "delete"} <= set(
         paths["/api/patients/{patient_id}"].keys()
@@ -79,3 +81,7 @@ def test_openapi_json_includes_patient_schemas(client):
     assert "NurseNoteUpdate" in definitions
     assert "NurseNoteResponse" in definitions
     assert "NurseNoteListResponse" in definitions
+    assert "DashboardGroupItem" in definitions
+    assert "DashboardRecentVisit" in definitions
+    assert "DashboardStats" in definitions
+    assert "DashboardStatsResponse" in definitions

--- a/docs/architecture/api-design.md
+++ b/docs/architecture/api-design.md
@@ -29,6 +29,90 @@ SeniorMate exposes browser-based Swagger documentation for local API testing:
 
 Start the local stack with Docker Compose, then open the Swagger UI in a browser to inspect and test the health and patient endpoints.
 
+## Dashboard API
+
+The Dashboard API summarizes patient, visit, and care-note activity for the frontend dashboard.
+
+### Dashboard Fields
+
+- `total_patients`
+- `active_patients`
+- `inactive_patients`
+- `total_visits`
+- `visits_this_month`
+- `aide_notes_this_month`
+- `nurse_notes_this_month`
+- `patients_by_status`
+- `patients_by_gender`
+- `visits_by_type`
+- `visits_by_status`
+- `recent_visits`
+
+Grouped chart fields are returned as arrays of `{ "label": "...", "count": 1 }`. The frontend renders these groups with lightweight Vuetify progress bars instead of adding a charting dependency.
+
+### Retrieve Dashboard Stats
+
+`GET /api/dashboard/stats`
+
+Example response:
+
+```json
+{
+  "data": {
+    "total_patients": 2,
+    "active_patients": 1,
+    "inactive_patients": 1,
+    "total_visits": 4,
+    "visits_this_month": 3,
+    "aide_notes_this_month": 1,
+    "nurse_notes_this_month": 1,
+    "patients_by_status": [
+      {
+        "label": "active",
+        "count": 1
+      },
+      {
+        "label": "inactive",
+        "count": 1
+      }
+    ],
+    "patients_by_gender": [
+      {
+        "label": "female",
+        "count": 1
+      },
+      {
+        "label": "male",
+        "count": 1
+      }
+    ],
+    "visits_by_type": [
+      {
+        "label": "Skilled nursing visit",
+        "count": 2
+      }
+    ],
+    "visits_by_status": [
+      {
+        "label": "completed",
+        "count": 3
+      }
+    ],
+    "recent_visits": [
+      {
+        "id": 4,
+        "patient_name": "Maria Santos",
+        "visit_date": "2026-06-03",
+        "visit_type": "Skilled nursing visit",
+        "staff_role": "nurse",
+        "status": "completed"
+      }
+    ]
+  },
+  "message": "Dashboard stats retrieved successfully"
+}
+```
+
 ## Patient API
 
 The Patient API is available under `/api/patients`.

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -46,6 +46,7 @@ docker compose down -v
 ## Local URLs
 
 - Frontend: `http://localhost:5173`
+- Dashboard: `http://localhost:5173`
 - Patient management UI: `http://localhost:5173/patients`
 - Visits UI: `http://localhost:5173/visits`
 - Aide Notes UI: `http://localhost:5173/aide-notes`

--- a/frontend/src/services/dashboard.js
+++ b/frontend/src/services/dashboard.js
@@ -1,0 +1,5 @@
+import { apiRequest } from "./http.js";
+
+export async function getDashboardStats() {
+  return apiRequest("/dashboard/stats");
+}

--- a/frontend/src/views/DashboardView.js
+++ b/frontend/src/views/DashboardView.js
@@ -1,26 +1,100 @@
-import { onMounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 
-import { apiBaseUrl } from "../config.js";
+import { getDashboardStats } from "../services/dashboard.js";
 
 export default {
   setup() {
-    const health = ref(null);
+    const stats = ref(null);
     const loading = ref(true);
     const error = ref("");
 
-    async function loadHealth() {
+    const cards = computed(() => [
+      {
+        title: "Total Patients",
+        value: stats.value?.total_patients ?? 0,
+        icon: "mdi-account-heart-outline",
+        color: "primary",
+      },
+      {
+        title: "Active Patients",
+        value: stats.value?.active_patients ?? 0,
+        icon: "mdi-account-check-outline",
+        color: "success",
+      },
+      {
+        title: "Visits This Month",
+        value: stats.value?.visits_this_month ?? 0,
+        icon: "mdi-calendar-clock-outline",
+        color: "secondary",
+      },
+      {
+        title: "Aide Notes This Month",
+        value: stats.value?.aide_notes_this_month ?? 0,
+        icon: "mdi-clipboard-check-outline",
+        color: "teal",
+      },
+      {
+        title: "Nurse Notes This Month",
+        value: stats.value?.nurse_notes_this_month ?? 0,
+        icon: "mdi-clipboard-pulse-outline",
+        color: "indigo",
+      },
+    ]);
+    const chartSections = computed(() => [
+      {
+        title: "Patients by Status",
+        items: stats.value?.patients_by_status || [],
+        color: "primary",
+      },
+      {
+        title: "Patients by Gender",
+        items: stats.value?.patients_by_gender || [],
+        color: "success",
+      },
+      {
+        title: "Visits by Type",
+        items: stats.value?.visits_by_type || [],
+        color: "secondary",
+      },
+      {
+        title: "Visits by Status",
+        items: stats.value?.visits_by_status || [],
+        color: "teal",
+      },
+    ]);
+    const recentVisitHeaders = [
+      { title: "Patient", key: "patient_name" },
+      { title: "Visit date", key: "visit_date" },
+      { title: "Visit type", key: "visit_type" },
+      { title: "Staff role", key: "staff_role" },
+      { title: "Status", key: "status" },
+      { title: "Actions", key: "actions", sortable: false },
+    ];
+    const hasDashboardData = computed(() =>
+      Boolean(
+        stats.value &&
+          (stats.value.total_patients ||
+            stats.value.total_visits ||
+            stats.value.aide_notes_this_month ||
+            stats.value.nurse_notes_this_month)
+      )
+    );
+
+    function chartMax(items) {
+      return Math.max(...items.map((item) => item.count), 1);
+    }
+
+    function percentage(item, items) {
+      return Math.round((item.count / chartMax(items)) * 100);
+    }
+
+    async function loadDashboard() {
       loading.value = true;
       error.value = "";
 
       try {
-        const response = await fetch(`${apiBaseUrl}/health`);
-        const payload = await response.json();
-
-        if (!response.ok) {
-          throw new Error(payload.status || "Backend health check failed");
-        }
-
-        health.value = payload;
+        const response = await getDashboardStats();
+        stats.value = response.data;
       } catch (err) {
         error.value = err.message;
       } finally {
@@ -28,66 +102,116 @@ export default {
       }
     }
 
-    onMounted(loadHealth);
+    onMounted(loadDashboard);
 
     return {
-      apiBaseUrl,
+      cards,
+      chartSections,
       error,
-      health,
+      hasDashboardData,
+      percentage,
       loading,
-      loadHealth,
+      loadDashboard,
+      recentVisitHeaders,
+      stats,
     };
   },
   template: `
-    <v-container class="py-8" style="max-width: 1120px;">
+    <v-container class="py-8" style="max-width: 1280px;">
       <v-row align="center" class="mb-6">
         <v-col cols="12" md="8">
-          <p class="text-overline mb-2">SeniorMate local development</p>
           <h1 class="text-h4 font-weight-bold mb-2">Care operations dashboard</h1>
           <p class="text-body-1 text-medium-emphasis mb-0">
-            Backend, frontend, PostgreSQL, and MinIO status.
+            A quick view of patient, visit, and care-note activity.
           </p>
         </v-col>
         <v-col cols="12" md="4" class="text-md-right">
-          <v-btn color="primary" variant="flat" :loading="loading" @click="loadHealth">
-            Refresh health
+          <v-btn color="primary" variant="flat" :loading="loading" @click="loadDashboard">
+            Refresh dashboard
           </v-btn>
         </v-col>
       </v-row>
 
-      <v-row>
-        <v-col cols="12" md="4">
-          <v-card variant="tonal">
-            <v-card-title>Backend</v-card-title>
-            <v-card-text>
-              <div class="text-h5 mb-2">{{ health?.status || "Checking" }}</div>
-              <div class="text-body-2">{{ apiBaseUrl }}</div>
-            </v-card-text>
-          </v-card>
-        </v-col>
-        <v-col cols="12" md="4">
-          <v-card variant="tonal">
-            <v-card-title>Database</v-card-title>
-            <v-card-text>
-              <div class="text-h5 mb-2">{{ health?.database || "Checking" }}</div>
-              <div class="text-body-2">PostgreSQL via Docker Compose</div>
-            </v-card-text>
-          </v-card>
-        </v-col>
-        <v-col cols="12" md="4">
-          <v-card variant="tonal">
-            <v-card-title>Storage</v-card-title>
-            <v-card-text>
-              <div class="text-h5 mb-2">MinIO</div>
-              <div class="text-body-2">{{ health?.minio_endpoint || "Configured from environment" }}</div>
-            </v-card-text>
-          </v-card>
-        </v-col>
-      </v-row>
-
-      <v-alert v-if="error" type="error" variant="tonal" class="mt-6">
+      <v-alert v-if="error" type="error" variant="tonal" class="mb-6">
         {{ error }}
       </v-alert>
+
+      <v-skeleton-loader v-if="loading" type="heading, card, card, table" />
+
+      <template v-else-if="stats">
+        <v-alert v-if="!hasDashboardData" type="info" variant="tonal" class="mb-6">
+          No patient, visit, or care-note activity has been recorded yet.
+        </v-alert>
+
+        <v-row class="mb-6">
+          <v-col v-for="card in cards" :key="card.title" cols="12" sm="6" lg="2">
+            <v-card>
+              <v-card-text>
+                <div class="d-flex align-center justify-space-between mb-4">
+                  <v-icon :icon="card.icon" :color="card.color" size="32" />
+                  <div class="text-h4 font-weight-bold">{{ card.value }}</div>
+                </div>
+                <div class="text-body-2 text-medium-emphasis">{{ card.title }}</div>
+              </v-card-text>
+            </v-card>
+          </v-col>
+        </v-row>
+
+        <v-row class="mb-6">
+          <v-col v-for="section in chartSections" :key="section.title" cols="12" md="6">
+            <v-card class="h-100">
+              <v-card-title>{{ section.title }}</v-card-title>
+              <v-card-text>
+                <div v-if="!section.items.length" class="text-medium-emphasis">
+                  No data available.
+                </div>
+                <div v-for="item in section.items" :key="item.label" class="mb-4">
+                  <div class="d-flex justify-space-between mb-1">
+                    <span>{{ item.label }}</span>
+                    <strong>{{ item.count }}</strong>
+                  </div>
+                  <v-progress-linear
+                    :model-value="percentage(item, section.items)"
+                    :color="section.color"
+                    height="10"
+                    rounded
+                  />
+                </div>
+              </v-card-text>
+            </v-card>
+          </v-col>
+        </v-row>
+
+        <v-card>
+          <v-card-title>Recent Visits</v-card-title>
+          <v-data-table
+            :headers="recentVisitHeaders"
+            :items="stats.recent_visits"
+            item-value="id"
+          >
+            <template #no-data>
+              <div class="pa-8 text-center">
+                <v-icon icon="mdi-calendar-clock-outline" size="40" class="mb-3" />
+                <div class="text-h6 mb-2">No recent visits</div>
+              </div>
+            </template>
+
+            <template #[\`item.patient_name\`]="{ item }">
+              {{ item.patient_name || 'Patient not available' }}
+            </template>
+
+            <template #[\`item.status\`]="{ item }">
+              <v-chip :color="item.status === 'completed' ? 'success' : item.status === 'cancelled' ? 'grey' : 'primary'" size="small">
+                {{ item.status }}
+              </v-chip>
+            </template>
+
+            <template #[\`item.actions\`]="{ item }">
+              <v-btn icon="mdi-eye-outline" variant="text" :to="\`/visits/\${item.id}\`" aria-label="View visit" />
+            </template>
+          </v-data-table>
+        </v-card>
+      </template>
     </v-container>
   `,
 };


### PR DESCRIPTION
# Summary

- Added GET /api/dashboard/stats for patient, visit, care-note, grouped chart, and recent visit summaries.
- Replaced the placeholder dashboard with real API-backed metric cards, lightweight Vuetify proportional bar charts, and a recent visits table.
- Documented the dashboard endpoint and local dashboard URL.

## Related Issue / Task

- Feature: 13-dashboard

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- [x] docker-compose exec -T backend pytest
- [x] docker-compose exec -T backend ruff check .
- [x] npm run build
- [x] docker-compose build backend frontend
- [x] curl http://localhost:5001/api/dashboard/stats
- [x] curl http://localhost:5001/api/openapi.json
- [x] git diff --check
- [x] Secret-pattern scan with rg
- [x] Browser verification of the dashboard at http://localhost:5173/

## Screenshots

- Dashboard screenshot captured during local browser verification.

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into main.