### PR TITLE
feat: add search filters and pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added search, filtering, and pagination for patient, visit, aide note, and nurse note list workflows.
 - Added the dashboard API and frontend dashboard with patient, visit, care-note, chart, and recent visit activity summaries.
 - Added the Nurses Progress Note frontend with visit detail integration, grouped clinical form, read-only detail view, edit workflow, and API service functions.
 - Added the Nurses Progress Note API with patient/visit-linked clinical records, JSON clinical section storage, duplicate visit-note prevention, Swagger documentation, tests, and API documentation.

--- a/backend/app/routes/aide_notes.py
+++ b/backend/app/routes/aide_notes.py
@@ -5,6 +5,12 @@ from flask import Blueprint, jsonify, request
 
 from app.extensions import db
 from app.models import AideNote, Patient, Visit
+from app.routes.query_utils import (
+    end_of_day,
+    paginated_response,
+    parse_iso_date,
+    start_of_day,
+)
 from app.swagger import (
     aide_note_create_spec,
     aide_note_delete_spec,
@@ -153,10 +159,31 @@ def parse_aide_note_payload(payload, partial=False, current_note=None):
 @aide_notes_bp.get("/aide-notes")
 @swag_from(aide_note_list_spec)
 def list_aide_notes():
-    aide_notes = AideNote.query.order_by(AideNote.id.desc()).all()
+    query = AideNote.query
+    patient_id = request.args.get("patient_id", "").strip()
+    visit_id = request.args.get("visit_id", "").strip()
+    aide_name = request.args.get("aide_name", "").strip()
+    start_date = parse_iso_date(request.args.get("start_date"))
+    end_date = parse_iso_date(request.args.get("end_date"))
 
-    return success_response(
-        [aide_note.to_dict() for aide_note in aide_notes],
+    if patient_id:
+        query = query.filter(AideNote.patient_id == int(patient_id))
+
+    if visit_id:
+        query = query.filter(AideNote.visit_id == int(visit_id))
+
+    if aide_name:
+        query = query.filter(AideNote.aide_name.ilike(f"%{aide_name}%"))
+
+    if start_date:
+        query = query.filter(AideNote.created_at >= start_of_day(start_date))
+
+    if end_date:
+        query = query.filter(AideNote.created_at <= end_of_day(end_date))
+
+    return paginated_response(
+        query.order_by(AideNote.id.desc()),
+        lambda aide_note: aide_note.to_dict(),
         "Aide notes retrieved successfully",
     )
 

--- a/backend/app/routes/nurse_notes.py
+++ b/backend/app/routes/nurse_notes.py
@@ -5,6 +5,12 @@ from flask import Blueprint, jsonify, request
 
 from app.extensions import db
 from app.models import NurseNote, Patient, Visit
+from app.routes.query_utils import (
+    end_of_day,
+    paginated_response,
+    parse_iso_date,
+    start_of_day,
+)
 from app.swagger import (
     nurse_note_create_spec,
     nurse_note_delete_spec,
@@ -147,10 +153,31 @@ def parse_nurse_note_payload(payload, partial=False, current_note=None):
 @nurse_notes_bp.get("/nurse-notes")
 @swag_from(nurse_note_list_spec)
 def list_nurse_notes():
-    nurse_notes = NurseNote.query.order_by(NurseNote.id.desc()).all()
+    query = NurseNote.query
+    patient_id = request.args.get("patient_id", "").strip()
+    visit_id = request.args.get("visit_id", "").strip()
+    diagnosis = request.args.get("diagnosis", "").strip()
+    start_date = parse_iso_date(request.args.get("start_date"))
+    end_date = parse_iso_date(request.args.get("end_date"))
 
-    return success_response(
-        [nurse_note.to_dict() for nurse_note in nurse_notes],
+    if patient_id:
+        query = query.filter(NurseNote.patient_id == int(patient_id))
+
+    if visit_id:
+        query = query.filter(NurseNote.visit_id == int(visit_id))
+
+    if diagnosis:
+        query = query.filter(NurseNote.diagnosis.ilike(f"%{diagnosis}%"))
+
+    if start_date:
+        query = query.filter(NurseNote.created_at >= start_of_day(start_date))
+
+    if end_date:
+        query = query.filter(NurseNote.created_at <= end_of_day(end_date))
+
+    return paginated_response(
+        query.order_by(NurseNote.id.desc()),
+        lambda nurse_note: nurse_note.to_dict(),
         "Nurse notes retrieved successfully",
     )
 

--- a/backend/app/routes/patients.py
+++ b/backend/app/routes/patients.py
@@ -2,9 +2,11 @@ from datetime import date
 
 from flasgger import swag_from
 from flask import Blueprint, jsonify, request
+from sqlalchemy import or_
 
 from app.extensions import db
 from app.models import Patient
+from app.routes.query_utils import paginated_response
 from app.swagger import (
     patient_create_spec,
     patient_delete_spec,
@@ -84,10 +86,32 @@ def parse_patient_payload(payload, partial=False):
 @patients_bp.get("")
 @swag_from(patient_list_spec)
 def list_patients():
-    patients = Patient.query.order_by(Patient.id.asc()).all()
+    query = Patient.query
+    search = request.args.get("search", "").strip()
+    status = request.args.get("status", "").strip()
+    gender = request.args.get("gender", "").strip()
 
-    return success_response(
-        [patient.to_dict() for patient in patients],
+    if search:
+        pattern = f"%{search}%"
+        query = query.filter(
+            or_(
+                Patient.first_name.ilike(pattern),
+                Patient.last_name.ilike(pattern),
+                Patient.phone.ilike(pattern),
+                Patient.email.ilike(pattern),
+                Patient.diagnosis_summary.ilike(pattern),
+            )
+        )
+
+    if status:
+        query = query.filter(Patient.status == status)
+
+    if gender:
+        query = query.filter(Patient.gender == gender)
+
+    return paginated_response(
+        query.order_by(Patient.id.asc()),
+        lambda patient: patient.to_dict(),
         "Patients retrieved successfully",
     )
 

--- a/backend/app/routes/query_utils.py
+++ b/backend/app/routes/query_utils.py
@@ -1,0 +1,60 @@
+from datetime import UTC, datetime, time
+from math import ceil
+
+from flask import request
+
+
+def success_response(data, message, status_code=200, pagination=None):
+    payload = {"data": data, "message": message}
+
+    if pagination is not None:
+        payload["pagination"] = pagination
+
+    return payload, status_code
+
+
+def pagination_args(default_per_page=10, max_per_page=100):
+    try:
+        page = int(request.args.get("page", 1))
+    except (TypeError, ValueError):
+        page = 1
+
+    try:
+        per_page = int(request.args.get("per_page", default_per_page))
+    except (TypeError, ValueError):
+        per_page = default_per_page
+
+    return max(page, 1), min(max(per_page, 1), max_per_page)
+
+
+def paginated_response(query, serializer, message):
+    page, per_page = pagination_args()
+    total = query.count()
+    pages = ceil(total / per_page) if total else 0
+    records = query.limit(per_page).offset((page - 1) * per_page).all()
+
+    return success_response(
+        [serializer(record) for record in records],
+        message,
+        pagination={
+            "page": page,
+            "per_page": per_page,
+            "total": total,
+            "pages": pages,
+        },
+    )
+
+
+def parse_iso_date(value):
+    if not value:
+        return None
+
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def start_of_day(value):
+    return datetime.combine(value, time.min, tzinfo=UTC)
+
+
+def end_of_day(value):
+    return datetime.combine(value, time.max, tzinfo=UTC)

--- a/backend/app/routes/visits.py
+++ b/backend/app/routes/visits.py
@@ -2,9 +2,11 @@ from datetime import date, time
 
 from flasgger import swag_from
 from flask import Blueprint, jsonify, request
+from sqlalchemy import or_
 
 from app.extensions import db
 from app.models import Patient, Visit
+from app.routes.query_utils import paginated_response, parse_iso_date
 from app.swagger import (
     patient_visits_list_spec,
     visit_create_spec,
@@ -125,10 +127,48 @@ def parse_visit_payload(payload, partial=False):
 @visits_bp.get("/visits")
 @swag_from(visit_list_spec)
 def list_visits():
-    visits = Visit.query.order_by(Visit.visit_date.desc(), Visit.id.desc()).all()
+    query = Visit.query.join(Patient)
+    search = request.args.get("search", "").strip()
+    patient_id = request.args.get("patient_id", "").strip()
+    visit_type = request.args.get("visit_type", "").strip()
+    staff_role = request.args.get("staff_role", "").strip()
+    status = request.args.get("status", "").strip()
+    start_date = parse_iso_date(request.args.get("start_date"))
+    end_date = parse_iso_date(request.args.get("end_date"))
 
-    return success_response(
-        [visit.to_dict() for visit in visits],
+    if search:
+        pattern = f"%{search}%"
+        query = query.filter(
+            or_(
+                Patient.first_name.ilike(pattern),
+                Patient.last_name.ilike(pattern),
+                Visit.staff_name.ilike(pattern),
+                Visit.visit_type.ilike(pattern),
+                Visit.notes.ilike(pattern),
+            )
+        )
+
+    if patient_id:
+        query = query.filter(Visit.patient_id == int(patient_id))
+
+    if visit_type:
+        query = query.filter(Visit.visit_type == visit_type)
+
+    if staff_role:
+        query = query.filter(Visit.staff_role == staff_role)
+
+    if status:
+        query = query.filter(Visit.status == status)
+
+    if start_date:
+        query = query.filter(Visit.visit_date >= start_date)
+
+    if end_date:
+        query = query.filter(Visit.visit_date <= end_date)
+
+    return paginated_response(
+        query.order_by(Visit.visit_date.desc(), Visit.id.desc()),
+        lambda visit: visit.to_dict(),
         "Visits retrieved successfully",
     )
 

--- a/backend/app/swagger.py
+++ b/backend/app/swagger.py
@@ -298,6 +298,18 @@ dashboard_stats_properties = {
     },
 }
 
+pagination_properties = {
+    "page": {"type": "integer", "example": 1},
+    "per_page": {"type": "integer", "example": 10},
+    "total": {"type": "integer", "example": 42},
+    "pages": {"type": "integer", "example": 5},
+}
+
+pagination_parameters = [
+    {"name": "page", "in": "query", "type": "integer", "required": False},
+    {"name": "per_page", "in": "query", "type": "integer", "required": False},
+]
+
 swagger_config = {
     "headers": [],
     "specs": [
@@ -399,6 +411,10 @@ swagger_template = {
                 },
             },
         },
+        "PaginationMeta": {
+            "type": "object",
+            "properties": pagination_properties,
+        },
         "ErrorResponse": {
             "type": "object",
             "properties": {
@@ -430,6 +446,7 @@ swagger_template = {
                     "type": "array",
                     "items": {"$ref": "#/definitions/Patient"},
                 },
+                "pagination": {"$ref": "#/definitions/PaginationMeta"},
                 "message": {
                     "type": "string",
                     "example": "Patients retrieved successfully",
@@ -453,6 +470,7 @@ swagger_template = {
                     "type": "array",
                     "items": {"$ref": "#/definitions/Visit"},
                 },
+                "pagination": {"$ref": "#/definitions/PaginationMeta"},
                 "message": {
                     "type": "string",
                     "example": "Visits retrieved successfully",
@@ -476,6 +494,7 @@ swagger_template = {
                     "type": "array",
                     "items": {"$ref": "#/definitions/AideNote"},
                 },
+                "pagination": {"$ref": "#/definitions/PaginationMeta"},
                 "message": {
                     "type": "string",
                     "example": "Aide notes retrieved successfully",
@@ -499,6 +518,7 @@ swagger_template = {
                     "type": "array",
                     "items": {"$ref": "#/definitions/NurseNote"},
                 },
+                "pagination": {"$ref": "#/definitions/PaginationMeta"},
                 "message": {
                     "type": "string",
                     "example": "Nurse notes retrieved successfully",
@@ -563,6 +583,12 @@ dashboard_stats_spec = {
 patient_list_spec = {
     "tags": ["Patients"],
     "summary": "List patients",
+    "parameters": [
+        {"name": "search", "in": "query", "type": "string", "required": False},
+        {"name": "status", "in": "query", "type": "string", "required": False},
+        {"name": "gender", "in": "query", "type": "string", "required": False},
+        *pagination_parameters,
+    ],
     "responses": {
         200: {
             "description": "Patients retrieved successfully.",
@@ -676,6 +702,28 @@ patient_delete_spec = {
 visit_list_spec = {
     "tags": ["Visits"],
     "summary": "List visits",
+    "parameters": [
+        {"name": "search", "in": "query", "type": "string", "required": False},
+        {"name": "patient_id", "in": "query", "type": "integer", "required": False},
+        {"name": "visit_type", "in": "query", "type": "string", "required": False},
+        {"name": "staff_role", "in": "query", "type": "string", "required": False},
+        {"name": "status", "in": "query", "type": "string", "required": False},
+        {
+            "name": "start_date",
+            "in": "query",
+            "type": "string",
+            "format": "date",
+            "required": False,
+        },
+        {
+            "name": "end_date",
+            "in": "query",
+            "type": "string",
+            "format": "date",
+            "required": False,
+        },
+        *pagination_parameters,
+    ],
     "responses": {
         200: {
             "description": "Visits retrieved successfully.",
@@ -812,6 +860,26 @@ patient_visits_list_spec = {
 aide_note_list_spec = {
     "tags": ["Aide Notes"],
     "summary": "List aide notes",
+    "parameters": [
+        {"name": "patient_id", "in": "query", "type": "integer", "required": False},
+        {"name": "visit_id", "in": "query", "type": "integer", "required": False},
+        {"name": "aide_name", "in": "query", "type": "string", "required": False},
+        {
+            "name": "start_date",
+            "in": "query",
+            "type": "string",
+            "format": "date",
+            "required": False,
+        },
+        {
+            "name": "end_date",
+            "in": "query",
+            "type": "string",
+            "format": "date",
+            "required": False,
+        },
+        *pagination_parameters,
+    ],
     "responses": {
         200: {
             "description": "Aide notes retrieved successfully.",
@@ -971,6 +1039,26 @@ visit_aide_note_get_spec = {
 nurse_note_list_spec = {
     "tags": ["Nurse Notes"],
     "summary": "List nurse notes",
+    "parameters": [
+        {"name": "patient_id", "in": "query", "type": "integer", "required": False},
+        {"name": "visit_id", "in": "query", "type": "integer", "required": False},
+        {"name": "diagnosis", "in": "query", "type": "string", "required": False},
+        {
+            "name": "start_date",
+            "in": "query",
+            "type": "string",
+            "format": "date",
+            "required": False,
+        },
+        {
+            "name": "end_date",
+            "in": "query",
+            "type": "string",
+            "format": "date",
+            "required": False,
+        },
+        *pagination_parameters,
+    ],
     "responses": {
         200: {
             "description": "Nurse notes retrieved successfully.",

--- a/backend/tests/test_openapi.py
+++ b/backend/tests/test_openapi.py
@@ -85,3 +85,4 @@ def test_openapi_json_includes_patient_schemas(client):
     assert "DashboardRecentVisit" in definitions
     assert "DashboardStats" in definitions
     assert "DashboardStatsResponse" in definitions
+    assert "PaginationMeta" in definitions

--- a/backend/tests/test_search_filters.py
+++ b/backend/tests/test_search_filters.py
@@ -1,0 +1,179 @@
+from datetime import UTC, datetime
+
+
+def current_month_date(day=1):
+    today = datetime.now(UTC).date()
+    return today.replace(day=day).isoformat()
+
+
+def patient_payload(**overrides):
+    payload = {
+        "first_name": "Maria",
+        "last_name": "Santos",
+        "gender": "female",
+        "phone": "+1-555-0100",
+        "email": "maria@example.com",
+        "diagnosis_summary": "Diabetes care and mobility support.",
+        "status": "active",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def create_patient(client, **overrides):
+    return client.post("/api/patients", json=patient_payload(**overrides)).get_json()[
+        "data"
+    ]
+
+
+def visit_payload(patient_id, **overrides):
+    payload = {
+        "patient_id": patient_id,
+        "visit_date": current_month_date(1),
+        "visit_type": "Skilled nursing visit",
+        "staff_name": "Jordan Lee",
+        "staff_role": "nurse",
+        "status": "completed",
+        "notes": "Medication review completed.",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def create_visit(client, patient_id, **overrides):
+    return client.post("/api/visits", json=visit_payload(patient_id, **overrides)).get_json()[
+        "data"
+    ]
+
+
+def create_aide_note(client, patient_id, visit_id, **overrides):
+    payload = {
+        "patient_id": patient_id,
+        "visit_id": visit_id,
+        "aide_name": "Alex Morgan",
+        "time_in": "09:00",
+        "time_out": "10:00",
+    }
+    payload.update(overrides)
+    return client.post("/api/aide-notes", json=payload).get_json()["data"]
+
+
+def create_nurse_note(client, patient_id, visit_id, **overrides):
+    payload = {
+        "patient_id": patient_id,
+        "visit_id": visit_id,
+        "diagnosis": "Hypertension",
+    }
+    payload.update(overrides)
+    return client.post("/api/nurse-notes", json=payload).get_json()["data"]
+
+
+def test_patient_search_and_status_filter(client):
+    create_patient(client)
+    create_patient(
+        client,
+        first_name="John",
+        last_name="Rivera",
+        gender="male",
+        email="john@example.com",
+        diagnosis_summary="Cardiac monitoring.",
+        status="inactive",
+    )
+
+    search_response = client.get("/api/patients?search=diabetes")
+    status_response = client.get("/api/patients?status=inactive")
+
+    assert search_response.status_code == 200
+    assert [patient["first_name"] for patient in search_response.get_json()["data"]] == [
+        "Maria"
+    ]
+    assert status_response.get_json()["pagination"]["total"] == 1
+    assert status_response.get_json()["data"][0]["status"] == "inactive"
+
+
+def test_patient_pagination_metadata(client):
+    create_patient(client, first_name="Ana")
+    create_patient(client, first_name="Ben")
+    create_patient(client, first_name="Cara")
+
+    response = client.get("/api/patients?page=2&per_page=2")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["pagination"] == {
+        "page": 2,
+        "per_page": 2,
+        "total": 3,
+        "pages": 2,
+    }
+    assert len(body["data"]) == 1
+
+
+def test_visit_patient_filter_and_date_range(client):
+    patient = create_patient(client)
+    other_patient = create_patient(client, first_name="John", last_name="Rivera")
+    create_visit(client, patient["id"], visit_date="2026-06-01")
+    create_visit(client, patient["id"], visit_date="2026-06-15")
+    create_visit(client, other_patient["id"], visit_date="2026-06-20")
+
+    patient_response = client.get(f"/api/visits?patient_id={patient['id']}")
+    range_response = client.get("/api/visits?start_date=2026-06-10&end_date=2026-06-30")
+
+    assert patient_response.status_code == 200
+    assert patient_response.get_json()["pagination"]["total"] == 2
+    assert range_response.get_json()["pagination"]["total"] == 2
+    assert all(
+        visit["visit_date"] >= "2026-06-10" for visit in range_response.get_json()["data"]
+    )
+
+
+def test_visit_search_by_patient_name_and_staff(client):
+    patient = create_patient(client, first_name="Clara", last_name="Barton")
+    other_patient = create_patient(client, first_name="John", last_name="Rivera")
+    create_visit(client, patient["id"], staff_name="Nora Nurse")
+    create_visit(client, other_patient["id"], staff_name="Alex Aide")
+
+    patient_search = client.get("/api/visits?search=Clara")
+    staff_search = client.get("/api/visits?search=Alex")
+
+    assert patient_search.get_json()["pagination"]["total"] == 1
+    assert patient_search.get_json()["data"][0]["patient_id"] == patient["id"]
+    assert staff_search.get_json()["pagination"]["total"] == 1
+    assert staff_search.get_json()["data"][0]["staff_name"] == "Alex Aide"
+
+
+def test_aide_note_filtering(client):
+    patient = create_patient(client)
+    other_patient = create_patient(client, first_name="John", last_name="Rivera")
+    visit = create_visit(client, patient["id"])
+    other_visit = create_visit(client, other_patient["id"])
+    create_aide_note(client, patient["id"], visit["id"], aide_name="Alex Morgan")
+    create_aide_note(client, other_patient["id"], other_visit["id"], aide_name="Taylor Reed")
+
+    patient_response = client.get(f"/api/aide-notes?patient_id={patient['id']}")
+    aide_response = client.get("/api/aide-notes?aide_name=Taylor")
+
+    assert patient_response.status_code == 200
+    assert patient_response.get_json()["pagination"]["total"] == 1
+    assert aide_response.get_json()["data"][0]["aide_name"] == "Taylor Reed"
+
+
+def test_nurse_note_filtering(client):
+    patient = create_patient(client)
+    other_patient = create_patient(client, first_name="John", last_name="Rivera")
+    visit = create_visit(client, patient["id"])
+    other_visit = create_visit(client, other_patient["id"])
+    create_nurse_note(client, patient["id"], visit["id"], diagnosis="Hypertension")
+    create_nurse_note(
+        client,
+        other_patient["id"],
+        other_visit["id"],
+        diagnosis="Diabetes monitoring",
+    )
+
+    patient_response = client.get(f"/api/nurse-notes?patient_id={patient['id']}")
+    diagnosis_response = client.get("/api/nurse-notes?diagnosis=diabetes")
+
+    assert patient_response.status_code == 200
+    assert patient_response.get_json()["pagination"]["total"] == 1
+    assert diagnosis_response.get_json()["data"][0]["diagnosis"] == "Diabetes monitoring"

--- a/docs/architecture/api-design.md
+++ b/docs/architecture/api-design.md
@@ -20,6 +20,21 @@ Validation and not-found responses include a clear message and, when applicable,
 }
 ```
 
+List endpoints support simple pagination with `page` and `per_page` query parameters. Paginated responses keep the existing `data` array and add metadata:
+
+```json
+{
+  "data": [],
+  "message": "Records retrieved successfully",
+  "pagination": {
+    "page": 1,
+    "per_page": 10,
+    "total": 25,
+    "pages": 3
+  }
+}
+```
+
 ## Interactive API Documentation
 
 SeniorMate exposes browser-based Swagger documentation for local API testing:
@@ -139,6 +154,14 @@ The Patient API is available under `/api/patients`.
 ### List Patients
 
 `GET /api/patients`
+
+Supported query parameters:
+
+- `search`: matches first name, last name, phone, email, or diagnosis summary
+- `status`: filters by `active` or `inactive`
+- `gender`: filters by gender value
+- `page`
+- `per_page`
 
 Example response:
 
@@ -315,6 +338,18 @@ The Visit API records caregiver and nursing visits linked to patients.
 ### List Visits
 
 `GET /api/visits`
+
+Supported query parameters:
+
+- `search`: matches patient name, staff name, visit type, or notes
+- `patient_id`
+- `visit_type`
+- `staff_role`
+- `status`
+- `start_date`: filters visits on or after `YYYY-MM-DD`
+- `end_date`: filters visits on or before `YYYY-MM-DD`
+- `page`
+- `per_page`
 
 Example response:
 
@@ -516,6 +551,16 @@ The Aide Note API records Home Health Aide visit documentation linked to both a 
 ### List Aide Notes
 
 `GET /api/aide-notes`
+
+Supported query parameters:
+
+- `patient_id`
+- `visit_id`
+- `aide_name`: partial match
+- `start_date`: filters notes created on or after `YYYY-MM-DD`
+- `end_date`: filters notes created on or before `YYYY-MM-DD`
+- `page`
+- `per_page`
 
 Example response:
 
@@ -863,6 +908,16 @@ The frontend Nurse Notes UI is available at `http://localhost:5173/nurse-notes` 
 ### List Nurse Notes
 
 `GET /api/nurse-notes`
+
+Supported query parameters:
+
+- `patient_id`
+- `visit_id`
+- `diagnosis`: partial match
+- `start_date`: filters notes created on or after `YYYY-MM-DD`
+- `end_date`: filters notes created on or before `YYYY-MM-DD`
+- `page`
+- `per_page`
 
 Example response:
 

--- a/frontend/src/services/aideNotes.js
+++ b/frontend/src/services/aideNotes.js
@@ -1,7 +1,8 @@
 import { apiRequest } from "./http.js";
+import { withQuery } from "./query.js";
 
-export async function listAideNotes() {
-  return apiRequest("/aide-notes");
+export async function listAideNotes(params = {}) {
+  return apiRequest(withQuery("/aide-notes", params));
 }
 
 export async function getAideNote(id) {

--- a/frontend/src/services/nurseNotes.js
+++ b/frontend/src/services/nurseNotes.js
@@ -1,7 +1,8 @@
 import { apiRequest } from "./http.js";
+import { withQuery } from "./query.js";
 
-export async function listNurseNotes() {
-  return apiRequest("/nurse-notes");
+export async function listNurseNotes(params = {}) {
+  return apiRequest(withQuery("/nurse-notes", params));
 }
 
 export async function getNurseNote(id) {

--- a/frontend/src/services/patients.js
+++ b/frontend/src/services/patients.js
@@ -1,7 +1,8 @@
 import { apiRequest } from "./http.js";
+import { withQuery } from "./query.js";
 
-export async function listPatients() {
-  return apiRequest("/patients");
+export async function listPatients(params = {}) {
+  return apiRequest(withQuery("/patients", params));
 }
 
 export async function getPatient(id) {

--- a/frontend/src/services/query.js
+++ b/frontend/src/services/query.js
@@ -1,0 +1,12 @@
+export function withQuery(path, params = {}) {
+  const query = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && value !== "") {
+      query.set(key, value);
+    }
+  }
+
+  const queryString = query.toString();
+  return queryString ? `${path}?${queryString}` : path;
+}

--- a/frontend/src/services/visits.js
+++ b/frontend/src/services/visits.js
@@ -1,7 +1,8 @@
 import { apiRequest } from "./http.js";
+import { withQuery } from "./query.js";
 
-export async function listVisits() {
-  return apiRequest("/visits");
+export async function listVisits(params = {}) {
+  return apiRequest(withQuery("/visits", params));
 }
 
 export async function getVisit(id) {

--- a/frontend/src/views/AideNoteListView.js
+++ b/frontend/src/views/AideNoteListView.js
@@ -15,6 +15,16 @@ export default {
     const deleting = ref(false);
     const selectedNote = ref(null);
     const confirmDelete = ref(false);
+    const filters = ref({
+      patient_id: "",
+      visit_id: "",
+      aide_name: "",
+      start_date: "",
+      end_date: "",
+      page: 1,
+      per_page: 10,
+    });
+    const pagination = ref({ page: 1, per_page: 10, total: 0, pages: 0 });
 
     const headers = [
       { title: "Patient", key: "patient_name" },
@@ -51,11 +61,12 @@ export default {
 
       try {
         const [noteResponse, patientResponse, visitResponse] = await Promise.all([
-          listAideNotes(),
-          listPatients(),
-          listVisits(),
+          listAideNotes(filters.value),
+          listPatients({ per_page: 100 }),
+          listVisits({ per_page: 100 }),
         ]);
         aideNotes.value = noteResponse.data;
+        pagination.value = noteResponse.pagination || pagination.value;
         patients.value = patientResponse.data;
         visits.value = visitResponse.data;
       } catch (err) {
@@ -63,6 +74,29 @@ export default {
       } finally {
         loading.value = false;
       }
+    }
+
+    async function applyFilters() {
+      filters.value.page = 1;
+      await loadAideNotes();
+    }
+
+    async function clearFilters() {
+      filters.value = {
+        patient_id: "",
+        visit_id: "",
+        aide_name: "",
+        start_date: "",
+        end_date: "",
+        page: 1,
+        per_page: 10,
+      };
+      await loadAideNotes();
+    }
+
+    async function changePage(page) {
+      filters.value.page = page;
+      await loadAideNotes();
     }
 
     function askDelete(note) {
@@ -94,11 +128,16 @@ export default {
 
     return {
       askDelete,
+      applyFilters,
+      changePage,
+      clearFilters,
       confirmDelete,
       deleting,
       error,
+      filters,
       headers,
       loading,
+      pagination,
       removeAideNote,
       rows,
       selectedNote,
@@ -120,6 +159,37 @@ export default {
       <v-alert v-if="success" type="success" variant="tonal" class="mb-4">
         {{ success }}
       </v-alert>
+
+      <v-card class="mb-4">
+        <v-card-text>
+          <v-row align="center">
+            <v-col cols="12" md="3">
+              <v-text-field v-model="filters.aide_name" label="Aide name" prepend-inner-icon="mdi-magnify" clearable hide-details @keyup.enter="applyFilters" />
+            </v-col>
+            <v-col cols="12" md="3">
+              <v-select
+                v-model="filters.patient_id"
+                label="Patient"
+                :items="patients.map((patient) => ({ title: patient.first_name + ' ' + patient.last_name, value: patient.id }))"
+                item-title="title"
+                item-value="value"
+                clearable
+                hide-details
+              />
+            </v-col>
+            <v-col cols="12" md="2">
+              <v-text-field v-model="filters.start_date" label="Start date" type="date" hide-details />
+            </v-col>
+            <v-col cols="12" md="2">
+              <v-text-field v-model="filters.end_date" label="End date" type="date" hide-details />
+            </v-col>
+            <v-col cols="12" md="2" class="d-flex ga-2 justify-md-end">
+              <v-btn color="primary" :loading="loading" @click="applyFilters">Apply</v-btn>
+              <v-btn variant="text" @click="clearFilters">Clear</v-btn>
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
 
       <v-card>
         <v-data-table :headers="headers" :items="rows" :loading="loading" item-value="id">
@@ -145,6 +215,15 @@ export default {
           </template>
         </v-data-table>
       </v-card>
+
+      <div class="d-flex justify-end mt-4" v-if="pagination.pages > 1">
+        <v-pagination
+          :model-value="pagination.page"
+          :length="pagination.pages"
+          total-visible="5"
+          @update:model-value="changePage"
+        />
+      </div>
 
       <v-dialog v-model="confirmDelete" max-width="440">
         <v-card>

--- a/frontend/src/views/NurseNoteListView.js
+++ b/frontend/src/views/NurseNoteListView.js
@@ -15,6 +15,16 @@ export default {
     const deleting = ref(false);
     const selectedNote = ref(null);
     const confirmDelete = ref(false);
+    const filters = ref({
+      patient_id: "",
+      visit_id: "",
+      diagnosis: "",
+      start_date: "",
+      end_date: "",
+      page: 1,
+      per_page: 10,
+    });
+    const pagination = ref({ page: 1, per_page: 10, total: 0, pages: 0 });
 
     const headers = [
       { title: "Patient", key: "patient_name" },
@@ -49,11 +59,12 @@ export default {
 
       try {
         const [noteResponse, patientResponse, visitResponse] = await Promise.all([
-          listNurseNotes(),
-          listPatients(),
-          listVisits(),
+          listNurseNotes(filters.value),
+          listPatients({ per_page: 100 }),
+          listVisits({ per_page: 100 }),
         ]);
         nurseNotes.value = noteResponse.data;
+        pagination.value = noteResponse.pagination || pagination.value;
         patients.value = patientResponse.data;
         visits.value = visitResponse.data;
       } catch (err) {
@@ -61,6 +72,29 @@ export default {
       } finally {
         loading.value = false;
       }
+    }
+
+    async function applyFilters() {
+      filters.value.page = 1;
+      await loadNurseNotes();
+    }
+
+    async function clearFilters() {
+      filters.value = {
+        patient_id: "",
+        visit_id: "",
+        diagnosis: "",
+        start_date: "",
+        end_date: "",
+        page: 1,
+        per_page: 10,
+      };
+      await loadNurseNotes();
+    }
+
+    async function changePage(page) {
+      filters.value.page = page;
+      await loadNurseNotes();
     }
 
     function askDelete(note) {
@@ -92,11 +126,16 @@ export default {
 
     return {
       askDelete,
+      applyFilters,
+      changePage,
+      clearFilters,
       confirmDelete,
       deleting,
       error,
+      filters,
       headers,
       loading,
+      pagination,
       removeNurseNote,
       rows,
       selectedNote,
@@ -118,6 +157,37 @@ export default {
       <v-alert v-if="success" type="success" variant="tonal" class="mb-4">
         {{ success }}
       </v-alert>
+
+      <v-card class="mb-4">
+        <v-card-text>
+          <v-row align="center">
+            <v-col cols="12" md="3">
+              <v-text-field v-model="filters.diagnosis" label="Diagnosis" prepend-inner-icon="mdi-magnify" clearable hide-details @keyup.enter="applyFilters" />
+            </v-col>
+            <v-col cols="12" md="3">
+              <v-select
+                v-model="filters.patient_id"
+                label="Patient"
+                :items="patients.map((patient) => ({ title: patient.first_name + ' ' + patient.last_name, value: patient.id }))"
+                item-title="title"
+                item-value="value"
+                clearable
+                hide-details
+              />
+            </v-col>
+            <v-col cols="12" md="2">
+              <v-text-field v-model="filters.start_date" label="Start date" type="date" hide-details />
+            </v-col>
+            <v-col cols="12" md="2">
+              <v-text-field v-model="filters.end_date" label="End date" type="date" hide-details />
+            </v-col>
+            <v-col cols="12" md="2" class="d-flex ga-2 justify-md-end">
+              <v-btn color="primary" :loading="loading" @click="applyFilters">Apply</v-btn>
+              <v-btn variant="text" @click="clearFilters">Clear</v-btn>
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
 
       <v-card>
         <v-data-table :headers="headers" :items="rows" :loading="loading" item-value="id">
@@ -143,6 +213,15 @@ export default {
           </template>
         </v-data-table>
       </v-card>
+
+      <div class="d-flex justify-end mt-4" v-if="pagination.pages > 1">
+        <v-pagination
+          :model-value="pagination.page"
+          :length="pagination.pages"
+          total-visible="5"
+          @update:model-value="changePage"
+        />
+      </div>
 
       <v-dialog v-model="confirmDelete" max-width="440">
         <v-card>

--- a/frontend/src/views/PatientListView.js
+++ b/frontend/src/views/PatientListView.js
@@ -11,6 +11,14 @@ export default {
     const deleting = ref(false);
     const selectedPatient = ref(null);
     const confirmDelete = ref(false);
+    const filters = ref({
+      search: "",
+      status: "",
+      gender: "",
+      page: 1,
+      per_page: 10,
+    });
+    const pagination = ref({ page: 1, per_page: 10, total: 0, pages: 0 });
 
     const headers = [
       { title: "Full name", key: "full_name" },
@@ -33,13 +41,35 @@ export default {
       error.value = "";
 
       try {
-        const response = await listPatients();
+        const response = await listPatients(filters.value);
         patients.value = response.data;
+        pagination.value = response.pagination || pagination.value;
       } catch (err) {
         error.value = err.message;
       } finally {
         loading.value = false;
       }
+    }
+
+    async function applyFilters() {
+      filters.value.page = 1;
+      await loadPatients();
+    }
+
+    async function clearFilters() {
+      filters.value = {
+        search: "",
+        status: "",
+        gender: "",
+        page: 1,
+        per_page: 10,
+      };
+      await loadPatients();
+    }
+
+    async function changePage(page) {
+      filters.value.page = page;
+      await loadPatients();
     }
 
     function askDelete(patient) {
@@ -71,12 +101,17 @@ export default {
 
     return {
       askDelete,
+      applyFilters,
+      changePage,
+      clearFilters,
       confirmDelete,
       deleting,
       error,
+      filters,
       headers,
       loadPatients,
       loading,
+      pagination,
       patients,
       removePatient,
       rows,
@@ -104,6 +139,45 @@ export default {
       <v-alert v-if="success" type="success" variant="tonal" class="mb-4">
         {{ success }}
       </v-alert>
+
+      <v-card class="mb-4">
+        <v-card-text>
+          <v-row align="center">
+            <v-col cols="12" md="5">
+              <v-text-field
+                v-model="filters.search"
+                label="Search patients"
+                prepend-inner-icon="mdi-magnify"
+                clearable
+                hide-details
+                @keyup.enter="applyFilters"
+              />
+            </v-col>
+            <v-col cols="12" md="2">
+              <v-select
+                v-model="filters.status"
+                label="Status"
+                :items="['active', 'inactive']"
+                clearable
+                hide-details
+              />
+            </v-col>
+            <v-col cols="12" md="2">
+              <v-select
+                v-model="filters.gender"
+                label="Gender"
+                :items="['female', 'male', 'nonbinary', 'other']"
+                clearable
+                hide-details
+              />
+            </v-col>
+            <v-col cols="12" md="3" class="d-flex ga-2 justify-md-end">
+              <v-btn color="primary" :loading="loading" @click="applyFilters">Apply</v-btn>
+              <v-btn variant="text" @click="clearFilters">Clear</v-btn>
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
 
       <v-card>
         <v-data-table
@@ -137,6 +211,15 @@ export default {
           </template>
         </v-data-table>
       </v-card>
+
+      <div class="d-flex justify-end mt-4" v-if="pagination.pages > 1">
+        <v-pagination
+          :model-value="pagination.page"
+          :length="pagination.pages"
+          total-visible="5"
+          @update:model-value="changePage"
+        />
+      </div>
 
       <v-dialog v-model="confirmDelete" max-width="440">
         <v-card>

--- a/frontend/src/views/VisitListView.js
+++ b/frontend/src/views/VisitListView.js
@@ -13,6 +13,17 @@ export default {
     const deleting = ref(false);
     const selectedVisit = ref(null);
     const confirmDelete = ref(false);
+    const filters = ref({
+      search: "",
+      visit_type: "",
+      staff_role: "",
+      status: "",
+      start_date: "",
+      end_date: "",
+      page: 1,
+      per_page: 10,
+    });
+    const pagination = ref({ page: 1, per_page: 10, total: 0, pages: 0 });
 
     const headers = [
       { title: "Patient", key: "patient_name" },
@@ -41,6 +52,9 @@ export default {
         patient_name: patientNames.value[visit.patient_id] || `Patient #${visit.patient_id}`,
       }))
     );
+    const visitTypes = computed(() =>
+      [...new Set(visits.value.map((visit) => visit.visit_type).filter(Boolean))]
+    );
 
     async function loadVisits() {
       loading.value = true;
@@ -48,16 +62,41 @@ export default {
 
       try {
         const [visitResponse, patientResponse] = await Promise.all([
-          listVisits(),
-          listPatients(),
+          listVisits(filters.value),
+          listPatients({ per_page: 100 }),
         ]);
         visits.value = visitResponse.data;
+        pagination.value = visitResponse.pagination || pagination.value;
         patients.value = patientResponse.data;
       } catch (err) {
         error.value = err.message;
       } finally {
         loading.value = false;
       }
+    }
+
+    async function applyFilters() {
+      filters.value.page = 1;
+      await loadVisits();
+    }
+
+    async function clearFilters() {
+      filters.value = {
+        search: "",
+        visit_type: "",
+        staff_role: "",
+        status: "",
+        start_date: "",
+        end_date: "",
+        page: 1,
+        per_page: 10,
+      };
+      await loadVisits();
+    }
+
+    async function changePage(page) {
+      filters.value.page = page;
+      await loadVisits();
     }
 
     function askDelete(visit) {
@@ -89,15 +128,21 @@ export default {
 
     return {
       askDelete,
+      applyFilters,
+      changePage,
+      clearFilters,
       confirmDelete,
       deleting,
       error,
+      filters,
       headers,
       loading,
+      pagination,
       removeVisit,
       rows,
       selectedVisit,
       success,
+      visitTypes,
     };
   },
   template: `
@@ -120,6 +165,42 @@ export default {
       <v-alert v-if="success" type="success" variant="tonal" class="mb-4">
         {{ success }}
       </v-alert>
+
+      <v-card class="mb-4">
+        <v-card-text>
+          <v-row align="center">
+            <v-col cols="12" md="4">
+              <v-text-field
+                v-model="filters.search"
+                label="Search visits"
+                prepend-inner-icon="mdi-magnify"
+                clearable
+                hide-details
+                @keyup.enter="applyFilters"
+              />
+            </v-col>
+            <v-col cols="12" md="2">
+              <v-select v-model="filters.visit_type" label="Visit type" :items="visitTypes" clearable hide-details />
+            </v-col>
+            <v-col cols="12" md="2">
+              <v-select v-model="filters.staff_role" label="Staff role" :items="['aide', 'nurse']" clearable hide-details />
+            </v-col>
+            <v-col cols="12" md="2">
+              <v-select v-model="filters.status" label="Status" :items="['scheduled', 'completed', 'cancelled']" clearable hide-details />
+            </v-col>
+            <v-col cols="12" md="2">
+              <v-text-field v-model="filters.start_date" label="Start date" type="date" hide-details />
+            </v-col>
+            <v-col cols="12" md="2">
+              <v-text-field v-model="filters.end_date" label="End date" type="date" hide-details />
+            </v-col>
+            <v-col cols="12" md="10" class="d-flex ga-2 justify-md-end">
+              <v-btn color="primary" :loading="loading" @click="applyFilters">Apply</v-btn>
+              <v-btn variant="text" @click="clearFilters">Clear</v-btn>
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
 
       <v-card>
         <v-data-table
@@ -157,6 +238,15 @@ export default {
           </template>
         </v-data-table>
       </v-card>
+
+      <div class="d-flex justify-end mt-4" v-if="pagination.pages > 1">
+        <v-pagination
+          :model-value="pagination.page"
+          :length="pagination.pages"
+          total-visible="5"
+          @update:model-value="changePage"
+        />
+      </div>
 
       <v-dialog v-model="confirmDelete" max-width="440">
         <v-card>


### PR DESCRIPTION
# Summary

- Added search, filtering, and pagination to patients, visits, aide notes, and nurse notes list APIs.
- Updated frontend list pages with practical search/filter controls and pagination-aware service calls.
- Documented query parameters, pagination metadata, and Swagger list response updates.

## Related Issue / Task

- Feature: 14-search-filter

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- [x] docker-compose exec -T backend pytest
- [x] docker-compose exec -T backend ruff check .
- [x] npm run build
- [x] docker-compose build backend frontend
- [x] curl patient search endpoint
- [x] curl visit filter/date-range endpoint
- [x] git diff --check
- [x] Secret-pattern scan with rg
- [x] Browser verification of Patients and Visits search/filter UI

## Screenshots

- Patient and visit search/filter screenshots captured during local browser verification.

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into main.