### PR TITLE
feat: polish frontend UI foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added a reusable frontend UI foundation with a SeniorMate Vuetify theme, shared page and feedback components, standardized tables, responsive spacing, and UI guidelines.
 - Added the dashboard API and frontend dashboard with patient, visit, care-note, chart, and recent visit activity summaries.
 - Added the Nurses Progress Note frontend with visit detail integration, grouped clinical form, read-only detail view, edit workflow, and API service functions.
 - Added the Nurses Progress Note API with patient/visit-linked clinical records, JSON clinical section storage, duplicate visit-note prevention, Swagger documentation, tests, and API documentation.

--- a/docs/design/ui-guidelines.md
+++ b/docs/design/ui-guidelines.md
@@ -1,0 +1,40 @@
+# SeniorMate UI Guidelines
+
+SeniorMate uses Vuetify with a restrained healthcare administration theme. These conventions keep workflows familiar, readable, and consistent as the product grows.
+
+## Layout
+
+- Use the shared `page-shell` class for page width and responsive padding.
+- Use `PageHeader` for list and dashboard page titles, descriptions, and primary actions.
+- Keep page-level actions in the header and record-level actions in the relevant table row or detail section.
+- Use `SectionCard` for clearly bounded groups of related information.
+
+## Color and Status
+
+- Primary teal identifies main actions and active navigation.
+- Secondary blue-grey supports neutral operational information.
+- Green represents active or completed states.
+- Muted grey represents inactive or cancelled states.
+- Red is reserved for errors and destructive actions.
+- Use `StatusChip` rather than defining status colors in individual pages.
+
+## Feedback States
+
+- Use `LoadingState` while list or page data is loading.
+- Use `EmptyState` when a workflow has no records yet.
+- Use `ErrorAlert` for user-facing request failures.
+- Use `ConfirmDialog` before destructive actions.
+- Success messages should be concise and describe the completed action.
+
+## Tables
+
+- Keep action icons together at the end of each row.
+- Every icon-only action must have an accessible label.
+- Prefer comfortable density and avoid adding low-priority columns that make the table difficult to scan.
+
+## Forms
+
+- Group related fields in cards with clear section titles.
+- Keep required fields visibly labelled and show field-level validation messages near the input.
+- Use two-column layouts only where they collapse cleanly at narrow widths.
+- Keep cancel and save actions together at the end of the form.

--- a/frontend/src/components/ConfirmDialog.js
+++ b/frontend/src/components/ConfirmDialog.js
@@ -1,0 +1,47 @@
+export default {
+  props: {
+    modelValue: {
+      type: Boolean,
+      required: true,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+    message: {
+      type: String,
+      required: true,
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    confirmLabel: {
+      type: String,
+      default: "Delete",
+    },
+  },
+  emits: ["update:modelValue", "confirm"],
+  template: `
+    <v-dialog
+      :model-value="modelValue"
+      max-width="440"
+      @update:model-value="$emit('update:modelValue', $event)"
+    >
+      <v-card>
+        <v-card-title class="d-flex align-center ga-2">
+          <v-icon icon="mdi-alert-outline" color="error" />
+          {{ title }}
+        </v-card-title>
+        <v-card-text>{{ message }}</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="$emit('update:modelValue', false)">Cancel</v-btn>
+          <v-btn color="error" variant="flat" :loading="loading" @click="$emit('confirm')">
+            {{ confirmLabel }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  `,
+};

--- a/frontend/src/components/EmptyState.js
+++ b/frontend/src/components/EmptyState.js
@@ -1,0 +1,44 @@
+export default {
+  props: {
+    icon: {
+      type: String,
+      default: "mdi-inbox-outline",
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+    description: {
+      type: String,
+      default: "",
+    },
+    actionLabel: {
+      type: String,
+      default: "",
+    },
+    actionTo: {
+      type: String,
+      default: "",
+    },
+  },
+  template: `
+    <div class="empty-state">
+      <div class="empty-state__icon">
+        <v-icon :icon="icon" size="34" />
+      </div>
+      <div class="text-subtitle-1 font-weight-medium">{{ title }}</div>
+      <div v-if="description" class="text-body-2 text-medium-emphasis mt-1">
+        {{ description }}
+      </div>
+      <v-btn
+        v-if="actionLabel"
+        color="primary"
+        variant="tonal"
+        :to="actionTo"
+        class="mt-4"
+      >
+        {{ actionLabel }}
+      </v-btn>
+    </div>
+  `,
+};

--- a/frontend/src/components/ErrorAlert.js
+++ b/frontend/src/components/ErrorAlert.js
@@ -1,0 +1,20 @@
+export default {
+  props: {
+    message: {
+      type: String,
+      default: "",
+    },
+  },
+  template: `
+    <v-alert
+      v-if="message"
+      type="error"
+      variant="tonal"
+      icon="mdi-alert-circle-outline"
+      class="mb-5"
+      role="alert"
+    >
+      {{ message }}
+    </v-alert>
+  `,
+};

--- a/frontend/src/components/LoadingState.js
+++ b/frontend/src/components/LoadingState.js
@@ -1,0 +1,13 @@
+export default {
+  props: {
+    type: {
+      type: String,
+      default: "table-row@5",
+    },
+  },
+  template: `
+    <div class="loading-state" aria-live="polite" aria-label="Loading content">
+      <v-skeleton-loader :type="type" />
+    </div>
+  `,
+};

--- a/frontend/src/components/PageHeader.js
+++ b/frontend/src/components/PageHeader.js
@@ -1,0 +1,32 @@
+export default {
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    subtitle: {
+      type: String,
+      default: "",
+    },
+    icon: {
+      type: String,
+      default: "",
+    },
+  },
+  template: `
+    <div class="page-header">
+      <div class="page-header__copy">
+        <div v-if="icon" class="page-header__icon" aria-hidden="true">
+          <v-icon :icon="icon" size="22" />
+        </div>
+        <div>
+          <h1 class="page-header__title">{{ title }}</h1>
+          <p v-if="subtitle" class="page-header__subtitle">{{ subtitle }}</p>
+        </div>
+      </div>
+      <div class="page-header__actions">
+        <slot name="actions" />
+      </div>
+    </div>
+  `,
+};

--- a/frontend/src/components/SectionCard.js
+++ b/frontend/src/components/SectionCard.js
@@ -1,0 +1,31 @@
+export default {
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    subtitle: {
+      type: String,
+      default: "",
+    },
+    icon: {
+      type: String,
+      default: "",
+    },
+  },
+  template: `
+    <v-card class="section-card">
+      <div class="section-card__header">
+        <v-icon v-if="icon" :icon="icon" color="primary" size="20" />
+        <div>
+          <div class="section-card__title">{{ title }}</div>
+          <div v-if="subtitle" class="section-card__subtitle">{{ subtitle }}</div>
+        </div>
+      </div>
+      <v-divider />
+      <v-card-text>
+        <slot />
+      </v-card-text>
+    </v-card>
+  `,
+};

--- a/frontend/src/components/StatusChip.js
+++ b/frontend/src/components/StatusChip.js
@@ -1,0 +1,26 @@
+const colors = {
+  active: "success",
+  inactive: "grey",
+  scheduled: "info",
+  completed: "success",
+  cancelled: "grey",
+};
+
+export default {
+  props: {
+    status: {
+      type: String,
+      default: "",
+    },
+  },
+  computed: {
+    chipColor() {
+      return colors[this.status] || "primary";
+    },
+  },
+  template: `
+    <v-chip :color="chipColor" size="small" variant="tonal" class="text-capitalize">
+      {{ status || 'Not set' }}
+    </v-chip>
+  `,
+};

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,5 +1,6 @@
 import "@mdi/font/css/materialdesignicons.css";
 import "vuetify/styles";
+import "./styles/main.css";
 
 import { createApp } from "vue";
 import { createVuetify } from "vuetify";
@@ -8,6 +9,13 @@ import * as directives from "vuetify/directives";
 import { aliases, mdi } from "vuetify/iconsets/mdi";
 
 import App from "./views/App.js";
+import ConfirmDialog from "./components/ConfirmDialog.js";
+import EmptyState from "./components/EmptyState.js";
+import ErrorAlert from "./components/ErrorAlert.js";
+import LoadingState from "./components/LoadingState.js";
+import PageHeader from "./components/PageHeader.js";
+import SectionCard from "./components/SectionCard.js";
+import StatusChip from "./components/StatusChip.js";
 import router from "./router.js";
 
 const vuetify = createVuetify({
@@ -18,6 +26,64 @@ const vuetify = createVuetify({
     aliases,
     sets: { mdi },
   },
+  theme: {
+    defaultTheme: "seniorMateLight",
+    themes: {
+      seniorMateLight: {
+        dark: false,
+        colors: {
+          background: "#F4F7F7",
+          surface: "#FFFFFF",
+          primary: "#1F6F68",
+          secondary: "#4D6D78",
+          success: "#3E7D5A",
+          info: "#3E7188",
+          warning: "#9B6B23",
+          error: "#B54747",
+          "on-background": "#20302F",
+          "on-surface": "#20302F",
+        },
+        variables: {
+          "border-color": "#CBD7D5",
+          "border-opacity": 0.72,
+          "high-emphasis-opacity": 0.9,
+          "medium-emphasis-opacity": 0.72,
+        },
+      },
+    },
+  },
+  defaults: {
+    VCard: {
+      elevation: 0,
+      border: true,
+      rounded: "lg",
+    },
+    VBtn: {
+      rounded: "lg",
+    },
+    VTextField: {
+      variant: "outlined",
+      density: "comfortable",
+    },
+    VSelect: {
+      variant: "outlined",
+      density: "comfortable",
+    },
+    VTextarea: {
+      variant: "outlined",
+      density: "comfortable",
+    },
+  },
 });
 
-createApp(App).use(router).use(vuetify).mount("#app");
+createApp(App)
+  .component("ConfirmDialog", ConfirmDialog)
+  .component("EmptyState", EmptyState)
+  .component("ErrorAlert", ErrorAlert)
+  .component("LoadingState", LoadingState)
+  .component("PageHeader", PageHeader)
+  .component("SectionCard", SectionCard)
+  .component("StatusChip", StatusChip)
+  .use(router)
+  .use(vuetify)
+  .mount("#app");

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1,0 +1,208 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+html {
+  background: #f4f7f7;
+}
+
+body {
+  margin: 0;
+  color: #20302f;
+  background: #f4f7f7;
+}
+
+.app-surface {
+  min-height: 100%;
+  background: #f4f7f7;
+}
+
+.page-shell {
+  width: 100%;
+  max-width: 1360px;
+  margin: 0 auto;
+  padding: 32px 28px 48px;
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+.page-header__copy {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+}
+
+.page-header__icon,
+.empty-state__icon {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  color: #1f6f68;
+  background: #e4f1ef;
+  border-radius: 8px;
+  flex: 0 0 auto;
+}
+
+.page-header__title {
+  margin: 0;
+  color: #1f302f;
+  font-size: 1.75rem;
+  line-height: 1.2;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.page-header__subtitle {
+  margin: 6px 0 0;
+  color: #647675;
+  font-size: 0.925rem;
+  line-height: 1.5;
+}
+
+.page-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.section-card {
+  height: 100%;
+}
+
+.page-shell .v-card-title {
+  padding: 18px 20px;
+  color: #263938;
+  font-size: 1rem;
+  font-weight: 650;
+}
+
+.page-shell .v-card-text {
+  line-height: 1.55;
+}
+
+.page-shell .v-form > .v-card {
+  margin-bottom: 20px;
+}
+
+.section-card__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 64px;
+  padding: 16px 20px;
+}
+
+.section-card__title {
+  color: #263938;
+  font-size: 1rem;
+  font-weight: 650;
+}
+
+.section-card__subtitle {
+  margin-top: 2px;
+  color: #6b7c7b;
+  font-size: 0.8rem;
+}
+
+.empty-state {
+  padding: 42px 24px;
+  text-align: center;
+}
+
+.empty-state__icon {
+  margin: 0 auto 14px;
+}
+
+.loading-state {
+  padding: 8px;
+}
+
+.metric-card {
+  min-height: 142px;
+  border-top: 3px solid rgb(var(--v-theme-primary));
+}
+
+.metric-card__value {
+  color: #20302f;
+  font-size: 2rem;
+  line-height: 1;
+  font-weight: 700;
+}
+
+.data-card .v-data-table-header__content {
+  color: #516462;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.data-card .v-data-table__tr:hover td {
+  background: #f8fbfa;
+}
+
+.table-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  white-space: nowrap;
+}
+
+.app-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 20px 18px 16px;
+}
+
+.app-brand__mark {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  color: white;
+  background: #1f6f68;
+  border-radius: 8px;
+}
+
+.app-brand__name {
+  color: #20302f;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.app-brand__caption {
+  margin-top: 1px;
+  color: #71817f;
+  font-size: 0.72rem;
+}
+
+@media (max-width: 700px) {
+  .page-shell {
+    padding: 24px 16px 36px;
+  }
+
+  .page-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .page-header__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .page-header__actions .v-btn {
+    flex: 1 1 auto;
+  }
+}

--- a/frontend/src/views/AideNoteDetailView.js
+++ b/frontend/src/views/AideNoteDetailView.js
@@ -90,7 +90,7 @@ export default {
     };
   },
   template: `
-    <v-container class="py-8" style="max-width: 1120px;">
+    <div class="page-shell">
       <v-btn variant="text" prepend-icon="mdi-arrow-left" to="/aide-notes" class="mb-4">
         Aide Notes
       </v-btn>
@@ -151,6 +151,6 @@ export default {
           </v-col>
         </v-row>
       </template>
-    </v-container>
+    </div>
   `,
 };

--- a/frontend/src/views/AideNoteFormView.js
+++ b/frontend/src/views/AideNoteFormView.js
@@ -246,7 +246,7 @@ export default {
     };
   },
   template: `
-    <v-container class="py-8" style="max-width: 1120px;">
+    <div class="page-shell">
       <v-btn variant="text" prepend-icon="mdi-arrow-left" to="/aide-notes" class="mb-4">
         Aide Notes
       </v-btn>
@@ -381,6 +381,6 @@ export default {
           </v-btn>
         </div>
       </v-form>
-    </v-container>
+    </div>
   `,
 };

--- a/frontend/src/views/AideNoteListView.js
+++ b/frontend/src/views/AideNoteListView.js
@@ -106,32 +106,30 @@ export default {
     };
   },
   template: `
-    <v-container class="py-8" style="max-width: 1280px;">
-      <v-row align="center" class="mb-5">
-        <v-col cols="12" md="8">
-          <h1 class="text-h4 font-weight-bold mb-1">Aide Notes</h1>
-          <p class="text-body-2 text-medium-emphasis mb-0">Review Home Health Aide documentation linked to visits.</p>
-        </v-col>
-      </v-row>
+    <div class="page-shell">
+      <PageHeader
+        title="Aide Notes"
+        subtitle="Review Home Health Aide documentation linked to visits."
+        icon="mdi-clipboard-check-outline"
+      />
 
-      <v-alert v-if="error" type="error" variant="tonal" class="mb-4">
-        {{ error }}
-      </v-alert>
+      <ErrorAlert :message="error" />
       <v-alert v-if="success" type="success" variant="tonal" class="mb-4">
         {{ success }}
       </v-alert>
 
-      <v-card>
+      <v-card class="data-card">
         <v-data-table :headers="headers" :items="rows" :loading="loading" item-value="id">
           <template #loading>
-            <v-skeleton-loader type="table-row@5" />
+            <LoadingState />
           </template>
 
           <template #no-data>
-            <div class="pa-8 text-center">
-              <v-icon icon="mdi-clipboard-check-outline" size="40" class="mb-3" />
-              <div class="text-h6 mb-2">No aide notes yet</div>
-            </div>
+            <EmptyState
+              icon="mdi-clipboard-text-outline"
+              title="No aide notes yet"
+              description="Aide notes created from visit details will appear here."
+            />
           </template>
 
           <template #[\`item.patient_name\`]="{ item }">
@@ -139,28 +137,22 @@ export default {
           </template>
 
           <template #[\`item.actions\`]="{ item }">
-            <v-btn icon="mdi-eye-outline" variant="text" :to="\`/aide-notes/\${item.id}\`" aria-label="View aide note" />
-            <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/aide-notes/\${item.id}/edit\`" aria-label="Edit aide note" />
-            <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete aide note" @click="askDelete(item)" />
+            <div class="table-actions">
+              <v-btn icon="mdi-eye-outline" variant="text" :to="\`/aide-notes/\${item.id}\`" aria-label="View aide note" />
+              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/aide-notes/\${item.id}/edit\`" aria-label="Edit aide note" />
+              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete aide note" @click="askDelete(item)" />
+            </div>
           </template>
         </v-data-table>
       </v-card>
 
-      <v-dialog v-model="confirmDelete" max-width="440">
-        <v-card>
-          <v-card-title>Delete aide note</v-card-title>
-          <v-card-text>
-            Delete aide note for {{ selectedNote?.patient_name }}?
-          </v-card-text>
-          <v-card-actions>
-            <v-spacer />
-            <v-btn variant="text" @click="confirmDelete = false">Cancel</v-btn>
-            <v-btn color="error" variant="flat" :loading="deleting" @click="removeAideNote">
-              Delete
-            </v-btn>
-          </v-card-actions>
-        </v-card>
-      </v-dialog>
-    </v-container>
+      <ConfirmDialog
+        v-model="confirmDelete"
+        title="Delete aide note"
+        :message="\`Delete the aide note for \${selectedNote?.patient_name || 'this patient'}?\`"
+        :loading="deleting"
+        @confirm="removeAideNote"
+      />
+    </div>
   `,
 };

--- a/frontend/src/views/App.js
+++ b/frontend/src/views/App.js
@@ -19,25 +19,48 @@ export default {
   },
   template: `
     <v-app>
-      <v-navigation-drawer v-model="drawer" width="248">
-        <v-list density="comfortable" nav>
+      <v-navigation-drawer v-model="drawer" width="260" color="surface">
+        <div class="app-brand">
+          <div class="app-brand__mark">
+            <v-icon icon="mdi-heart-pulse" size="22" />
+          </div>
+          <div>
+            <div class="app-brand__name">SeniorMate</div>
+            <div class="app-brand__caption">Care operations</div>
+          </div>
+        </div>
+
+        <v-divider />
+
+        <v-list density="comfortable" nav class="px-3 pt-4">
+          <v-list-subheader>Workspace</v-list-subheader>
           <v-list-item
             v-for="item in navItems"
             :key="item.to"
             :prepend-icon="item.icon"
             :title="item.title"
             :to="item.to"
-            rounded="0"
+            active-color="primary"
+            rounded="lg"
+            class="mb-1"
           />
         </v-list>
+
+        <template #append>
+          <div class="pa-4 text-caption text-medium-emphasis">
+            SeniorMate development
+          </div>
+        </template>
       </v-navigation-drawer>
 
-      <v-app-bar flat border>
-        <v-app-bar-nav-icon @click="drawer = !drawer" />
-        <v-app-bar-title>SeniorMate</v-app-bar-title>
+      <v-app-bar flat border color="surface" height="64">
+        <v-app-bar-nav-icon aria-label="Toggle navigation" @click="drawer = !drawer" />
+        <v-app-bar-title class="text-subtitle-1 font-weight-medium">
+          Care workspace
+        </v-app-bar-title>
       </v-app-bar>
 
-      <v-main>
+      <v-main class="app-surface">
         <router-view />
       </v-main>
     </v-app>

--- a/frontend/src/views/DashboardView.js
+++ b/frontend/src/views/DashboardView.js
@@ -117,51 +117,49 @@ export default {
     };
   },
   template: `
-    <v-container class="py-8" style="max-width: 1280px;">
-      <v-row align="center" class="mb-6">
-        <v-col cols="12" md="8">
-          <h1 class="text-h4 font-weight-bold mb-2">Care operations dashboard</h1>
-          <p class="text-body-1 text-medium-emphasis mb-0">
-            A quick view of patient, visit, and care-note activity.
-          </p>
-        </v-col>
-        <v-col cols="12" md="4" class="text-md-right">
+    <div class="page-shell">
+      <PageHeader
+        title="Care operations dashboard"
+        subtitle="A quick view of patient, visit, and care-note activity."
+        icon="mdi-view-dashboard-outline"
+      >
+        <template #actions>
           <v-btn color="primary" variant="flat" :loading="loading" @click="loadDashboard">
             Refresh dashboard
           </v-btn>
-        </v-col>
-      </v-row>
+        </template>
+      </PageHeader>
 
-      <v-alert v-if="error" type="error" variant="tonal" class="mb-6">
-        {{ error }}
-      </v-alert>
+      <ErrorAlert :message="error" />
 
-      <v-skeleton-loader v-if="loading" type="heading, card, card, table" />
+      <LoadingState v-if="loading" type="heading, card, card, table" />
 
       <template v-else-if="stats">
-        <v-alert v-if="!hasDashboardData" type="info" variant="tonal" class="mb-6">
-          No patient, visit, or care-note activity has been recorded yet.
-        </v-alert>
+        <EmptyState
+          v-if="!hasDashboardData"
+          icon="mdi-chart-box-outline"
+          title="No activity yet"
+          description="Patient, visit, and care-note activity will appear here as records are added."
+          class="mb-6"
+        />
 
-        <v-row class="mb-6">
-          <v-col v-for="card in cards" :key="card.title" cols="12" sm="6" lg="2">
-            <v-card>
-              <v-card-text>
+        <v-row class="mb-7">
+          <v-col v-for="card in cards" :key="card.title" cols="12" sm="6" lg>
+            <v-card class="metric-card">
+              <v-card-text class="pa-5">
                 <div class="d-flex align-center justify-space-between mb-4">
-                  <v-icon :icon="card.icon" :color="card.color" size="32" />
-                  <div class="text-h4 font-weight-bold">{{ card.value }}</div>
+                  <v-icon :icon="card.icon" :color="card.color" size="28" />
+                  <div class="metric-card__value">{{ card.value }}</div>
                 </div>
-                <div class="text-body-2 text-medium-emphasis">{{ card.title }}</div>
+                <div class="text-body-2 font-weight-medium">{{ card.title }}</div>
               </v-card-text>
             </v-card>
           </v-col>
         </v-row>
 
-        <v-row class="mb-6">
+        <v-row class="mb-7">
           <v-col v-for="section in chartSections" :key="section.title" cols="12" md="6">
-            <v-card class="h-100">
-              <v-card-title>{{ section.title }}</v-card-title>
-              <v-card-text>
+            <SectionCard :title="section.title" icon="mdi-chart-bar">
                 <div v-if="!section.items.length" class="text-medium-emphasis">
                   No data available.
                 </div>
@@ -177,41 +175,46 @@ export default {
                     rounded
                   />
                 </div>
-              </v-card-text>
-            </v-card>
+            </SectionCard>
           </v-col>
         </v-row>
 
-        <v-card>
-          <v-card-title>Recent Visits</v-card-title>
-          <v-data-table
-            :headers="recentVisitHeaders"
-            :items="stats.recent_visits"
-            item-value="id"
-          >
-            <template #no-data>
-              <div class="pa-8 text-center">
-                <v-icon icon="mdi-calendar-clock-outline" size="40" class="mb-3" />
-                <div class="text-h6 mb-2">No recent visits</div>
-              </div>
-            </template>
+        <SectionCard
+          title="Recent Visits"
+          subtitle="The latest care activity across patients."
+          icon="mdi-calendar-clock-outline"
+          class="data-card"
+        >
+            <v-data-table
+              :headers="recentVisitHeaders"
+              :items="stats.recent_visits"
+              item-value="id"
+              density="comfortable"
+            >
+              <template #no-data>
+                <EmptyState
+                  icon="mdi-calendar-blank-outline"
+                  title="No recent visits"
+                  description="New visits will appear here."
+                />
+              </template>
 
-            <template #[\`item.patient_name\`]="{ item }">
-              {{ item.patient_name || 'Patient not available' }}
-            </template>
+              <template #[\`item.patient_name\`]="{ item }">
+                {{ item.patient_name || 'Patient not available' }}
+              </template>
 
-            <template #[\`item.status\`]="{ item }">
-              <v-chip :color="item.status === 'completed' ? 'success' : item.status === 'cancelled' ? 'grey' : 'primary'" size="small">
-                {{ item.status }}
-              </v-chip>
-            </template>
+              <template #[\`item.status\`]="{ item }">
+                <StatusChip :status="item.status" />
+              </template>
 
-            <template #[\`item.actions\`]="{ item }">
-              <v-btn icon="mdi-eye-outline" variant="text" :to="\`/visits/\${item.id}\`" aria-label="View visit" />
-            </template>
-          </v-data-table>
-        </v-card>
+              <template #[\`item.actions\`]="{ item }">
+                <div class="table-actions">
+                  <v-btn icon="mdi-eye-outline" variant="text" :to="\`/visits/\${item.id}\`" aria-label="View visit" />
+                </div>
+              </template>
+            </v-data-table>
+        </SectionCard>
       </template>
-    </v-container>
+    </div>
   `,
 };

--- a/frontend/src/views/NurseNoteDetailView.js
+++ b/frontend/src/views/NurseNoteDetailView.js
@@ -119,7 +119,7 @@ export default {
     };
   },
   template: `
-    <v-container class="py-8" style="max-width: 1120px;">
+    <div class="page-shell">
       <v-btn variant="text" prepend-icon="mdi-arrow-left" to="/nurse-notes" class="mb-4">
         Nurse Notes
       </v-btn>
@@ -190,6 +190,6 @@ export default {
           <v-card-text>{{ nurseNote[section.key] || 'Not provided' }}</v-card-text>
         </v-card>
       </template>
-    </v-container>
+    </div>
   `,
 };

--- a/frontend/src/views/NurseNoteFormView.js
+++ b/frontend/src/views/NurseNoteFormView.js
@@ -392,7 +392,7 @@ export default {
     };
   },
   template: `
-    <v-container class="py-8" style="max-width: 1120px;">
+    <div class="page-shell">
       <v-btn variant="text" prepend-icon="mdi-arrow-left" to="/nurse-notes" class="mb-4">
         Nurse Notes
       </v-btn>
@@ -495,6 +495,6 @@ export default {
           </v-btn>
         </div>
       </v-form>
-    </v-container>
+    </div>
   `,
 };

--- a/frontend/src/views/NurseNoteListView.js
+++ b/frontend/src/views/NurseNoteListView.js
@@ -104,32 +104,30 @@ export default {
     };
   },
   template: `
-    <v-container class="py-8" style="max-width: 1280px;">
-      <v-row align="center" class="mb-5">
-        <v-col cols="12" md="8">
-          <h1 class="text-h4 font-weight-bold mb-1">Nurse Notes</h1>
-          <p class="text-body-2 text-medium-emphasis mb-0">Review Nurses Progress Notes linked to clinical visits.</p>
-        </v-col>
-      </v-row>
+    <div class="page-shell">
+      <PageHeader
+        title="Nurse Notes"
+        subtitle="Review Nurses Progress Notes linked to clinical visits."
+        icon="mdi-clipboard-pulse-outline"
+      />
 
-      <v-alert v-if="error" type="error" variant="tonal" class="mb-4">
-        {{ error }}
-      </v-alert>
+      <ErrorAlert :message="error" />
       <v-alert v-if="success" type="success" variant="tonal" class="mb-4">
         {{ success }}
       </v-alert>
 
-      <v-card>
+      <v-card class="data-card">
         <v-data-table :headers="headers" :items="rows" :loading="loading" item-value="id">
           <template #loading>
-            <v-skeleton-loader type="table-row@5" />
+            <LoadingState />
           </template>
 
           <template #no-data>
-            <div class="pa-8 text-center">
-              <v-icon icon="mdi-clipboard-pulse-outline" size="40" class="mb-3" />
-              <div class="text-h6 mb-2">No nurse notes yet</div>
-            </div>
+            <EmptyState
+              icon="mdi-clipboard-text-outline"
+              title="No nurse notes yet"
+              description="Nurse notes created from visit details will appear here."
+            />
           </template>
 
           <template #[\`item.patient_name\`]="{ item }">
@@ -137,28 +135,22 @@ export default {
           </template>
 
           <template #[\`item.actions\`]="{ item }">
-            <v-btn icon="mdi-eye-outline" variant="text" :to="\`/nurse-notes/\${item.id}\`" aria-label="View nurse note" />
-            <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/nurse-notes/\${item.id}/edit\`" aria-label="Edit nurse note" />
-            <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete nurse note" @click="askDelete(item)" />
+            <div class="table-actions">
+              <v-btn icon="mdi-eye-outline" variant="text" :to="\`/nurse-notes/\${item.id}\`" aria-label="View nurse note" />
+              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/nurse-notes/\${item.id}/edit\`" aria-label="Edit nurse note" />
+              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete nurse note" @click="askDelete(item)" />
+            </div>
           </template>
         </v-data-table>
       </v-card>
 
-      <v-dialog v-model="confirmDelete" max-width="440">
-        <v-card>
-          <v-card-title>Delete nurse note</v-card-title>
-          <v-card-text>
-            Delete nurse note for {{ selectedNote?.patient_name }}?
-          </v-card-text>
-          <v-card-actions>
-            <v-spacer />
-            <v-btn variant="text" @click="confirmDelete = false">Cancel</v-btn>
-            <v-btn color="error" variant="flat" :loading="deleting" @click="removeNurseNote">
-              Delete
-            </v-btn>
-          </v-card-actions>
-        </v-card>
-      </v-dialog>
-    </v-container>
+      <ConfirmDialog
+        v-model="confirmDelete"
+        title="Delete nurse note"
+        :message="\`Delete the nurse note for \${selectedNote?.patient_name || 'this patient'}?\`"
+        :loading="deleting"
+        @confirm="removeNurseNote"
+      />
+    </div>
   `,
 };

--- a/frontend/src/views/PatientDetailView.js
+++ b/frontend/src/views/PatientDetailView.js
@@ -94,7 +94,7 @@ export default {
     };
   },
   template: `
-    <v-container class="py-8" style="max-width: 1120px;">
+    <div class="page-shell">
       <v-btn variant="text" prepend-icon="mdi-arrow-left" to="/patients" class="mb-4">
         Patients
       </v-btn>
@@ -199,6 +199,6 @@ export default {
           </v-card-actions>
         </v-card>
       </v-dialog>
-    </v-container>
+    </div>
   `,
 };

--- a/frontend/src/views/PatientFormView.js
+++ b/frontend/src/views/PatientFormView.js
@@ -120,7 +120,7 @@ export default {
     };
   },
   template: `
-    <v-container class="py-8" style="max-width: 960px;">
+    <div class="page-shell" style="max-width: 1040px;">
       <v-btn variant="text" prepend-icon="mdi-arrow-left" to="/patients" class="mb-4">
         Patients
       </v-btn>
@@ -204,6 +204,6 @@ export default {
           </v-btn>
         </div>
       </v-form>
-    </v-container>
+    </div>
   `,
 };

--- a/frontend/src/views/PatientListView.js
+++ b/frontend/src/views/PatientListView.js
@@ -85,27 +85,25 @@ export default {
     };
   },
   template: `
-    <v-container class="py-8" style="max-width: 1280px;">
-      <v-row align="center" class="mb-5">
-        <v-col cols="12" md="8">
-          <h1 class="text-h4 font-weight-bold mb-1">Patients</h1>
-          <p class="text-body-2 text-medium-emphasis mb-0">Manage patient demographics and emergency contacts.</p>
-        </v-col>
-        <v-col cols="12" md="4" class="text-md-right">
+    <div class="page-shell">
+      <PageHeader
+        title="Patients"
+        subtitle="Manage patient demographics and emergency contacts."
+        icon="mdi-account-heart-outline"
+      >
+        <template #actions>
           <v-btn color="primary" prepend-icon="mdi-plus" to="/patients/new">
             New patient
           </v-btn>
-        </v-col>
-      </v-row>
+        </template>
+      </PageHeader>
 
-      <v-alert v-if="error" type="error" variant="tonal" class="mb-4">
-        {{ error }}
-      </v-alert>
+      <ErrorAlert :message="error" />
       <v-alert v-if="success" type="success" variant="tonal" class="mb-4">
         {{ success }}
       </v-alert>
 
-      <v-card>
+      <v-card class="data-card">
         <v-data-table
           :headers="headers"
           :items="rows"
@@ -113,46 +111,40 @@ export default {
           item-value="id"
         >
           <template #loading>
-            <v-skeleton-loader type="table-row@5" />
+            <LoadingState />
           </template>
 
           <template #no-data>
-            <div class="pa-8 text-center">
-              <v-icon icon="mdi-account-heart-outline" size="40" class="mb-3" />
-              <div class="text-h6 mb-2">No patients yet</div>
-              <v-btn color="primary" variant="flat" to="/patients/new">Create patient</v-btn>
-            </div>
+            <EmptyState
+              icon="mdi-account-plus-outline"
+              title="No patients yet"
+              description="Create the first patient profile to begin tracking care."
+              action-label="Create patient"
+              action-to="/patients/new"
+            />
           </template>
 
           <template #[\`item.status\`]="{ item }">
-            <v-chip :color="item.status === 'active' ? 'success' : 'grey'" size="small">
-              {{ item.status }}
-            </v-chip>
+            <StatusChip :status="item.status" />
           </template>
 
           <template #[\`item.actions\`]="{ item }">
-            <v-btn icon="mdi-eye-outline" variant="text" :to="\`/patients/\${item.id}\`" aria-label="View patient" />
-            <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/patients/\${item.id}/edit\`" aria-label="Edit patient" />
-            <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete patient" @click="askDelete(item)" />
+            <div class="table-actions">
+              <v-btn icon="mdi-eye-outline" variant="text" :to="\`/patients/\${item.id}\`" aria-label="View patient" />
+              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/patients/\${item.id}/edit\`" aria-label="Edit patient" />
+              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete patient" @click="askDelete(item)" />
+            </div>
           </template>
         </v-data-table>
       </v-card>
 
-      <v-dialog v-model="confirmDelete" max-width="440">
-        <v-card>
-          <v-card-title>Delete patient</v-card-title>
-          <v-card-text>
-            Delete {{ selectedPatient?.full_name }}?
-          </v-card-text>
-          <v-card-actions>
-            <v-spacer />
-            <v-btn variant="text" @click="confirmDelete = false">Cancel</v-btn>
-            <v-btn color="error" variant="flat" :loading="deleting" @click="removePatient">
-              Delete
-            </v-btn>
-          </v-card-actions>
-        </v-card>
-      </v-dialog>
-    </v-container>
+      <ConfirmDialog
+        v-model="confirmDelete"
+        title="Delete patient"
+        :message="\`Delete \${selectedPatient?.full_name || 'this patient'}? This cannot be undone.\`"
+        :loading="deleting"
+        @confirm="removePatient"
+      />
+    </div>
   `,
 };

--- a/frontend/src/views/VisitDetailView.js
+++ b/frontend/src/views/VisitDetailView.js
@@ -82,7 +82,7 @@ export default {
     };
   },
   template: `
-    <v-container class="py-8" style="max-width: 1120px;">
+    <div class="page-shell">
       <v-btn variant="text" prepend-icon="mdi-arrow-left" to="/visits" class="mb-4">
         Visits
       </v-btn>
@@ -206,6 +206,6 @@ export default {
           </v-col>
         </v-row>
       </template>
-    </v-container>
+    </div>
   `,
 };

--- a/frontend/src/views/VisitFormView.js
+++ b/frontend/src/views/VisitFormView.js
@@ -139,7 +139,7 @@ export default {
     };
   },
   template: `
-    <v-container class="py-8" style="max-width: 960px;">
+    <div class="page-shell" style="max-width: 1040px;">
       <v-btn variant="text" prepend-icon="mdi-arrow-left" to="/visits" class="mb-4">
         Visits
       </v-btn>
@@ -232,6 +232,6 @@ export default {
           </v-btn>
         </div>
       </v-form>
-    </v-container>
+    </div>
   `,
 };

--- a/frontend/src/views/VisitListView.js
+++ b/frontend/src/views/VisitListView.js
@@ -101,27 +101,25 @@ export default {
     };
   },
   template: `
-    <v-container class="py-8" style="max-width: 1440px;">
-      <v-row align="center" class="mb-5">
-        <v-col cols="12" md="8">
-          <h1 class="text-h4 font-weight-bold mb-1">Visits</h1>
-          <p class="text-body-2 text-medium-emphasis mb-0">Track caregiver and nursing visits for active patients.</p>
-        </v-col>
-        <v-col cols="12" md="4" class="text-md-right">
+    <div class="page-shell">
+      <PageHeader
+        title="Visits"
+        subtitle="Track caregiver and nursing visits for active patients."
+        icon="mdi-calendar-clock-outline"
+      >
+        <template #actions>
           <v-btn color="primary" prepend-icon="mdi-plus" to="/visits/new">
             New visit
           </v-btn>
-        </v-col>
-      </v-row>
+        </template>
+      </PageHeader>
 
-      <v-alert v-if="error" type="error" variant="tonal" class="mb-4">
-        {{ error }}
-      </v-alert>
+      <ErrorAlert :message="error" />
       <v-alert v-if="success" type="success" variant="tonal" class="mb-4">
         {{ success }}
       </v-alert>
 
-      <v-card>
+      <v-card class="data-card">
         <v-data-table
           :headers="headers"
           :items="rows"
@@ -129,15 +127,17 @@ export default {
           item-value="id"
         >
           <template #loading>
-            <v-skeleton-loader type="table-row@5" />
+            <LoadingState />
           </template>
 
           <template #no-data>
-            <div class="pa-8 text-center">
-              <v-icon icon="mdi-calendar-clock-outline" size="40" class="mb-3" />
-              <div class="text-h6 mb-2">No visits yet</div>
-              <v-btn color="primary" variant="flat" to="/visits/new">Create visit</v-btn>
-            </div>
+            <EmptyState
+              icon="mdi-calendar-plus-outline"
+              title="No visits yet"
+              description="Schedule the first patient visit to begin tracking care activity."
+              action-label="Create visit"
+              action-to="/visits/new"
+            />
           </template>
 
           <template #[\`item.patient_name\`]="{ item }">
@@ -145,34 +145,26 @@ export default {
           </template>
 
           <template #[\`item.status\`]="{ item }">
-            <v-chip :color="item.status === 'completed' ? 'success' : item.status === 'cancelled' ? 'grey' : 'primary'" size="small">
-              {{ item.status }}
-            </v-chip>
+            <StatusChip :status="item.status" />
           </template>
 
           <template #[\`item.actions\`]="{ item }">
-            <v-btn icon="mdi-eye-outline" variant="text" :to="\`/visits/\${item.id}\`" aria-label="View visit" />
-            <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/visits/\${item.id}/edit\`" aria-label="Edit visit" />
-            <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete visit" @click="askDelete(item)" />
+            <div class="table-actions">
+              <v-btn icon="mdi-eye-outline" variant="text" :to="\`/visits/\${item.id}\`" aria-label="View visit" />
+              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/visits/\${item.id}/edit\`" aria-label="Edit visit" />
+              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete visit" @click="askDelete(item)" />
+            </div>
           </template>
         </v-data-table>
       </v-card>
 
-      <v-dialog v-model="confirmDelete" max-width="440">
-        <v-card>
-          <v-card-title>Delete visit</v-card-title>
-          <v-card-text>
-            Delete {{ selectedVisit?.visit_type }} for {{ selectedVisit?.patient_name }}?
-          </v-card-text>
-          <v-card-actions>
-            <v-spacer />
-            <v-btn variant="text" @click="confirmDelete = false">Cancel</v-btn>
-            <v-btn color="error" variant="flat" :loading="deleting" @click="removeVisit">
-              Delete
-            </v-btn>
-          </v-card-actions>
-        </v-card>
-      </v-dialog>
-    </v-container>
+      <ConfirmDialog
+        v-model="confirmDelete"
+        title="Delete visit"
+        :message="\`Delete \${selectedVisit?.visit_type || 'this visit'} for \${selectedVisit?.patient_name || 'this patient'}?\`"
+        :loading="deleting"
+        @confirm="removeVisit"
+      />
+    </div>
   `,
 };


### PR DESCRIPTION
# Summary

- Introduces a calm, accessible SeniorMate Vuetify theme and a consistent application shell.
- Adds reusable page, feedback, status, section, loading, empty-state, and confirmation components.
- Standardizes dashboard, patient, visit, aide-note, and nurse-note layouts, tables, actions, and responsive spacing.
- Documents the frontend UI conventions in `docs/design/ui-guidelines.md`.

## Related Issue / Task

- Feature: `15-ui-polish-foundation`

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [x] Refactor

## Testing Performed

- `npm run build`
- `git diff --check`
- Repository secret-pattern scan with `rg`
- Manual visual QA in the in-app browser at desktop and narrow widths
- Docker-backed checks were not available because the local Colima Docker daemon was not running; no backend code was changed.

## Screenshots

After screenshots were captured during local visual QA for the dashboard, patient empty/error state, and nurse-note form. The API was unavailable during capture, so the screenshots also verify the standardized error and empty states. No reliable pre-change screenshot was available from the clean `main` checkout.

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.