### PR TITLE
feat: add patient medical records

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,11 @@ KEYCLOAK_ADMIN_PASSWORD=change-me-local-only
 KEYCLOAK_PORT=8080
 
 MINIO_ENDPOINT=http://localhost:9000
-MINIO_BUCKET=seniormate-local
+MINIO_ACCESS_KEY=local-access-key
+MINIO_SECRET_KEY=change-me-local-only
+MINIO_BUCKET=seniormate-medical-records
+MINIO_SECURE=false
+MEDICAL_RECORD_MAX_FILE_SIZE=10485760
 MINIO_ROOT_USER=local-access-key
 MINIO_ROOT_PASSWORD=change-me-local-only
 MINIO_API_PORT=9000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added patient Medical Records with private MinIO file storage, PostgreSQL metadata, upload/download CRUD APIs, Swagger documentation, tests, and Patient Detail UI integration.
 - Added a reusable frontend UI foundation with a SeniorMate Vuetify theme, shared page and feedback components, standardized tables, responsive spacing, and UI guidelines.
 - Added the dashboard API and frontend dashboard with patient, visit, care-note, chart, and recent visit activity summaries.
 - Added the Nurses Progress Note frontend with visit detail integration, grouped clinical form, read-only detail view, edit workflow, and API service functions.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -6,11 +6,13 @@ from sqlalchemy import text
 from app.config import Config
 from app.extensions import db, migrate
 from app.models import AideNote as AideNote
+from app.models import MedicalRecord as MedicalRecord
 from app.models import NurseNote as NurseNote
 from app.models import Patient as Patient
 from app.models import Visit as Visit
 from app.routes.aide_notes import aide_notes_bp
 from app.routes.dashboard import dashboard_bp
+from app.routes.medical_records import medical_records_bp
 from app.routes.nurse_notes import nurse_notes_bp
 from app.routes.patients import patients_bp
 from app.routes.visits import visits_bp
@@ -27,6 +29,7 @@ def create_app(config_object=Config):
     migrate.init_app(app, db)
     app.register_blueprint(aide_notes_bp)
     app.register_blueprint(dashboard_bp)
+    app.register_blueprint(medical_records_bp)
     app.register_blueprint(nurse_notes_bp)
     app.register_blueprint(patients_bp)
     app.register_blueprint(visits_bp)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -10,5 +10,11 @@ class Config:
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "http://localhost:9000")
-    MINIO_BUCKET = os.getenv("MINIO_BUCKET", "seniormate-local")
+    MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "local-access-key")
+    MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "change-me-local-only")
+    MINIO_BUCKET = os.getenv("MINIO_BUCKET", "seniormate-medical-records")
+    MINIO_SECURE = os.getenv("MINIO_SECURE", "false").lower() == "true"
+    MEDICAL_RECORD_MAX_FILE_SIZE = int(
+        os.getenv("MEDICAL_RECORD_MAX_FILE_SIZE", str(10 * 1024 * 1024))
+    )
     CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:5173").split(",")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,7 +1,8 @@
 from app.models.aide_note import AideNote
+from app.models.medical_record import MedicalRecord
 from app.models.nurse_note import NurseNote
 from app.models.patient import Patient
 from app.models.visit import Visit
 
 
-__all__ = ["AideNote", "NurseNote", "Patient", "Visit"]
+__all__ = ["AideNote", "MedicalRecord", "NurseNote", "Patient", "Visit"]

--- a/backend/app/models/medical_record.py
+++ b/backend/app/models/medical_record.py
@@ -1,0 +1,62 @@
+from datetime import UTC, datetime
+
+from app.extensions import db
+
+
+class MedicalRecord(db.Model):
+    __tablename__ = "medical_records"
+
+    id = db.Column(db.Integer, primary_key=True)
+    patient_id = db.Column(
+        db.Integer,
+        db.ForeignKey("patients.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    title = db.Column(db.String(255), nullable=False)
+    description = db.Column(db.Text, nullable=True)
+    record_type = db.Column(db.String(100), nullable=True)
+    file_name = db.Column(db.String(255), nullable=False)
+    file_mime_type = db.Column(db.String(150), nullable=False)
+    file_size = db.Column(db.BigInteger, nullable=False)
+    storage_bucket = db.Column(db.String(255), nullable=False)
+    storage_object_key = db.Column(db.String(1024), nullable=False, unique=True)
+    uploaded_by = db.Column(db.String(200), nullable=True)
+    uploaded_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    created_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    patient = db.relationship("Patient", back_populates="medical_records")
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "patient_id": self.patient_id,
+            "title": self.title,
+            "description": self.description,
+            "record_type": self.record_type,
+            "file_name": self.file_name,
+            "file_mime_type": self.file_mime_type,
+            "file_size": self.file_size,
+            "storage_bucket": self.storage_bucket,
+            "storage_object_key": self.storage_object_key,
+            "uploaded_by": self.uploaded_by,
+            "uploaded_at": self.uploaded_at.isoformat()
+            if self.uploaded_at
+            else None,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/backend/app/models/patient.py
+++ b/backend/app/models/patient.py
@@ -49,6 +49,11 @@ class Patient(db.Model):
         back_populates="patient",
         cascade="all, delete-orphan",
     )
+    medical_records = db.relationship(
+        "MedicalRecord",
+        back_populates="patient",
+        cascade="all, delete-orphan",
+    )
 
     def to_dict(self):
         return {

--- a/backend/app/routes/medical_records.py
+++ b/backend/app/routes/medical_records.py
@@ -1,0 +1,323 @@
+from uuid import uuid4
+from zipfile import BadZipFile, ZipFile
+
+from flasgger import swag_from
+from flask import Blueprint, Response, current_app, jsonify, request, stream_with_context
+from werkzeug.utils import secure_filename
+
+from app.extensions import db
+from app.models import MedicalRecord, Patient
+from app.storage import MedicalRecordStorageError, get_medical_record_storage
+from app.swagger import (
+    medical_record_create_spec,
+    medical_record_delete_spec,
+    medical_record_download_spec,
+    medical_record_get_spec,
+    medical_record_list_spec,
+    medical_record_update_spec,
+    patient_medical_records_list_spec,
+)
+
+
+medical_records_bp = Blueprint("medical_records", __name__, url_prefix="/api")
+
+ALLOWED_FILE_TYPES = {
+    "application/pdf": {".pdf"},
+    "image/jpeg": {".jpg", ".jpeg"},
+    "image/png": {".png"},
+    "application/msword": {".doc"},
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": {
+        ".docx"
+    },
+}
+EDITABLE_FIELDS = {"title", "description", "record_type", "uploaded_by"}
+
+
+def success_response(data, message, status_code=200):
+    return jsonify({"data": data, "message": message}), status_code
+
+
+def error_response(message, status_code=400, errors=None):
+    payload = {"message": message}
+    if errors:
+        payload["errors"] = errors
+    return jsonify(payload), status_code
+
+
+def normalized_text(value):
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def parse_patient_id(value):
+    try:
+        patient_id = int(value)
+    except (TypeError, ValueError):
+        return None
+    return patient_id if patient_id > 0 else None
+
+
+def file_size(file_storage):
+    stream = file_storage.stream
+    current_position = stream.tell()
+    stream.seek(0, 2)
+    size = stream.tell()
+    stream.seek(current_position)
+    return size
+
+
+def file_content_matches_type(file_storage):
+    stream = file_storage.stream
+    stream.seek(0)
+    signature = stream.read(8)
+    stream.seek(0)
+
+    if file_storage.mimetype == "application/pdf":
+        return signature.startswith(b"%PDF-")
+    if file_storage.mimetype == "image/jpeg":
+        return signature.startswith(b"\xff\xd8\xff")
+    if file_storage.mimetype == "image/png":
+        return signature == b"\x89PNG\r\n\x1a\n"
+    if file_storage.mimetype == "application/msword":
+        return signature == b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+    if (
+        file_storage.mimetype
+        == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    ):
+        try:
+            with ZipFile(stream) as archive:
+                names = set(archive.namelist())
+                return "[Content_Types].xml" in names and any(
+                    name.startswith("word/") for name in names
+                )
+        except BadZipFile:
+            return False
+        finally:
+            stream.seek(0)
+    return False
+
+
+def validate_upload():
+    errors = {}
+    patient_id = parse_patient_id(request.form.get("patient_id"))
+    title = normalized_text(request.form.get("title"))
+    upload = request.files.get("file")
+    patient = None
+
+    if patient_id is None:
+        errors["patient_id"] = "This field is required and must be a valid integer."
+    else:
+        patient = db.session.get(Patient, patient_id)
+        if patient is None:
+            errors["patient_id"] = "Patient not found."
+
+    if title is None:
+        errors["title"] = "This field is required."
+
+    if upload is None or not upload.filename:
+        errors["file"] = "This field is required."
+        return None, errors
+
+    safe_name = secure_filename(upload.filename)
+    extension = f".{safe_name.rsplit('.', 1)[-1].lower()}" if "." in safe_name else ""
+    allowed_extensions = ALLOWED_FILE_TYPES.get(upload.mimetype)
+    if not safe_name or not allowed_extensions or extension not in allowed_extensions:
+        errors["file"] = "Use a PDF, JPEG, PNG, DOC, or DOCX file."
+    elif not file_content_matches_type(upload):
+        errors["file"] = "File content does not match the selected document type."
+
+    size = file_size(upload)
+    if size <= 0:
+        errors["file"] = "The uploaded file is empty."
+    elif size > current_app.config["MEDICAL_RECORD_MAX_FILE_SIZE"]:
+        max_mb = current_app.config["MEDICAL_RECORD_MAX_FILE_SIZE"] // (1024 * 1024)
+        errors["file"] = f"File size must not exceed {max_mb} MB."
+
+    if errors:
+        return None, errors
+
+    upload.stream.seek(0)
+    return {
+        "patient": patient,
+        "patient_id": patient_id,
+        "title": title,
+        "description": normalized_text(request.form.get("description")),
+        "record_type": normalized_text(request.form.get("record_type")),
+        "uploaded_by": normalized_text(request.form.get("uploaded_by")),
+        "upload": upload,
+        "file_name": safe_name,
+        "file_size": size,
+    }, {}
+
+
+def parse_metadata_payload(payload):
+    if not isinstance(payload, dict):
+        return None, {"request": "JSON body is required."}
+
+    data = {}
+    errors = {}
+    for field in EDITABLE_FIELDS:
+        if field in payload:
+            data[field] = normalized_text(payload[field])
+
+    if "title" in data and data["title"] is None:
+        errors["title"] = "This field is required."
+
+    return data, errors
+
+
+@medical_records_bp.get("/medical-records")
+@swag_from(medical_record_list_spec)
+def list_medical_records():
+    records = MedicalRecord.query.order_by(MedicalRecord.uploaded_at.desc()).all()
+    return success_response(
+        [record.to_dict() for record in records],
+        "Medical records retrieved successfully",
+    )
+
+
+@medical_records_bp.get("/medical-records/<int:medical_record_id>")
+@swag_from(medical_record_get_spec)
+def get_medical_record(medical_record_id):
+    record = db.session.get(MedicalRecord, medical_record_id)
+    if record is None:
+        return error_response("Medical record not found", 404)
+    return success_response(record.to_dict(), "Medical record retrieved successfully")
+
+
+@medical_records_bp.post("/medical-records")
+@swag_from(medical_record_create_spec)
+def create_medical_record():
+    data, errors = validate_upload()
+    if errors:
+        return error_response("Invalid medical record data", 400, errors)
+
+    object_key = f"patients/{data['patient_id']}/{uuid4().hex}_{data['file_name']}"
+    storage = get_medical_record_storage()
+
+    try:
+        storage.upload(
+            object_key,
+            data["upload"].stream,
+            data["file_size"],
+            data["upload"].mimetype,
+        )
+    except MedicalRecordStorageError as exc:
+        return error_response(str(exc), 502)
+
+    record = MedicalRecord(
+        patient_id=data["patient_id"],
+        title=data["title"],
+        description=data["description"],
+        record_type=data["record_type"],
+        file_name=data["file_name"],
+        file_mime_type=data["upload"].mimetype,
+        file_size=data["file_size"],
+        storage_bucket=storage.bucket,
+        storage_object_key=object_key,
+        uploaded_by=data["uploaded_by"],
+    )
+
+    try:
+        db.session.add(record)
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        storage.delete(object_key)
+        raise
+
+    return success_response(
+        record.to_dict(),
+        "Medical record uploaded successfully",
+        201,
+    )
+
+
+@medical_records_bp.put("/medical-records/<int:medical_record_id>")
+@swag_from(medical_record_update_spec)
+def update_medical_record(medical_record_id):
+    record = db.session.get(MedicalRecord, medical_record_id)
+    if record is None:
+        return error_response("Medical record not found", 404)
+
+    data, errors = parse_metadata_payload(request.get_json(silent=True))
+    if errors:
+        return error_response("Invalid medical record data", 400, errors)
+
+    for field, value in data.items():
+        setattr(record, field, value)
+    db.session.commit()
+
+    return success_response(
+        record.to_dict(),
+        "Medical record updated successfully",
+    )
+
+
+@medical_records_bp.delete("/medical-records/<int:medical_record_id>")
+@swag_from(medical_record_delete_spec)
+def delete_medical_record(medical_record_id):
+    record = db.session.get(MedicalRecord, medical_record_id)
+    if record is None:
+        return error_response("Medical record not found", 404)
+
+    try:
+        get_medical_record_storage().delete(record.storage_object_key)
+    except MedicalRecordStorageError as exc:
+        return error_response(str(exc), 502)
+
+    db.session.delete(record)
+    db.session.commit()
+    return success_response(
+        {"id": medical_record_id},
+        "Medical record deleted successfully",
+    )
+
+
+@medical_records_bp.get("/patients/<int:patient_id>/medical-records")
+@swag_from(patient_medical_records_list_spec)
+def list_patient_medical_records(patient_id):
+    patient = db.session.get(Patient, patient_id)
+    if patient is None:
+        return error_response("Patient not found", 404)
+
+    records = (
+        MedicalRecord.query.filter_by(patient_id=patient_id)
+        .order_by(MedicalRecord.uploaded_at.desc())
+        .all()
+    )
+    return success_response(
+        [record.to_dict() for record in records],
+        "Patient medical records retrieved successfully",
+    )
+
+
+@medical_records_bp.get("/medical-records/<int:medical_record_id>/download")
+@swag_from(medical_record_download_spec)
+def download_medical_record(medical_record_id):
+    record = db.session.get(MedicalRecord, medical_record_id)
+    if record is None:
+        return error_response("Medical record not found", 404)
+
+    try:
+        source = get_medical_record_storage().open(record.storage_object_key)
+    except FileNotFoundError:
+        return error_response("Stored medical record file not found", 404)
+    except MedicalRecordStorageError as exc:
+        return error_response(str(exc), 502)
+
+    @stream_with_context
+    def generate():
+        try:
+            while chunk := source.read(64 * 1024):
+                yield chunk
+        finally:
+            source.close()
+            if hasattr(source, "release_conn"):
+                source.release_conn()
+
+    response = Response(generate(), mimetype=record.file_mime_type)
+    response.headers["Content-Disposition"] = (
+        f'attachment; filename="{record.file_name}"'
+    )
+    response.headers["Content-Length"] = str(record.file_size)
+    return response

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -1,0 +1,81 @@
+from urllib.parse import urlparse
+
+from flask import current_app
+from minio import Minio
+from minio.error import S3Error
+
+
+class MedicalRecordStorageError(Exception):
+    pass
+
+
+class MinioMedicalRecordStorage:
+    def __init__(self, client, bucket):
+        self.client = client
+        self.bucket = bucket
+
+    def ensure_bucket(self):
+        try:
+            if not self.client.bucket_exists(self.bucket):
+                self.client.make_bucket(self.bucket)
+        except Exception as exc:
+            raise MedicalRecordStorageError("Medical record storage is unavailable.") from exc
+
+    def upload(self, object_key, stream, length, content_type):
+        self.ensure_bucket()
+        try:
+            self.client.put_object(
+                self.bucket,
+                object_key,
+                stream,
+                length,
+                content_type=content_type,
+            )
+        except Exception as exc:
+            raise MedicalRecordStorageError("Medical record upload failed.") from exc
+
+    def open(self, object_key):
+        try:
+            return self.client.get_object(self.bucket, object_key)
+        except S3Error as exc:
+            if exc.code in {"NoSuchKey", "NoSuchObject"}:
+                raise FileNotFoundError(object_key) from exc
+            raise MedicalRecordStorageError("Medical record download failed.") from exc
+        except Exception as exc:
+            raise MedicalRecordStorageError("Medical record download failed.") from exc
+
+    def delete(self, object_key):
+        try:
+            self.client.remove_object(self.bucket, object_key)
+        except S3Error as exc:
+            if exc.code not in {"NoSuchKey", "NoSuchObject"}:
+                raise MedicalRecordStorageError(
+                    "Medical record storage cleanup failed."
+                ) from exc
+        except Exception as exc:
+            raise MedicalRecordStorageError(
+                "Medical record storage cleanup failed."
+            ) from exc
+
+
+def build_minio_storage():
+    endpoint = current_app.config["MINIO_ENDPOINT"]
+    parsed = urlparse(endpoint)
+    minio_endpoint = parsed.netloc or parsed.path
+    secure = current_app.config["MINIO_SECURE"]
+
+    client = Minio(
+        minio_endpoint,
+        access_key=current_app.config["MINIO_ACCESS_KEY"],
+        secret_key=current_app.config["MINIO_SECRET_KEY"],
+        secure=secure,
+    )
+    return MinioMedicalRecordStorage(client, current_app.config["MINIO_BUCKET"])
+
+
+def get_medical_record_storage():
+    storage = current_app.extensions.get("medical_record_storage")
+    if storage is None:
+        storage = build_minio_storage()
+        current_app.extensions["medical_record_storage"] = storage
+    return storage

--- a/backend/app/swagger.py
+++ b/backend/app/swagger.py
@@ -298,6 +298,59 @@ dashboard_stats_properties = {
     },
 }
 
+medical_record_properties = {
+    "id": {"type": "integer", "example": 1},
+    "patient_id": {"type": "integer", "example": 1},
+    "title": {"type": "string", "example": "Updated care plan"},
+    "description": {
+        "type": "string",
+        "nullable": True,
+        "example": "Care plan approved by the clinical team.",
+    },
+    "record_type": {
+        "type": "string",
+        "nullable": True,
+        "example": "care_plan",
+    },
+    "file_name": {"type": "string", "example": "care-plan.pdf"},
+    "file_mime_type": {"type": "string", "example": "application/pdf"},
+    "file_size": {"type": "integer", "format": "int64", "example": 245760},
+    "storage_bucket": {
+        "type": "string",
+        "example": "seniormate-medical-records",
+    },
+    "storage_object_key": {
+        "type": "string",
+        "example": "patients/1/0f8c2f_care-plan.pdf",
+    },
+    "uploaded_by": {
+        "type": "string",
+        "nullable": True,
+        "example": "Jordan Lee",
+    },
+    "uploaded_at": {
+        "type": "string",
+        "format": "date-time",
+        "example": "2026-06-09T10:00:00+00:00",
+    },
+    "created_at": {
+        "type": "string",
+        "format": "date-time",
+        "example": "2026-06-09T10:00:00+00:00",
+    },
+    "updated_at": {
+        "type": "string",
+        "format": "date-time",
+        "example": "2026-06-09T10:00:00+00:00",
+    },
+}
+
+medical_record_update_properties = {
+    key: value
+    for key, value in medical_record_properties.items()
+    if key in {"title", "description", "record_type", "uploaded_by"}
+}
+
 swagger_config = {
     "headers": [],
     "specs": [
@@ -376,6 +429,14 @@ swagger_template = {
         "NurseNoteUpdate": {
             "type": "object",
             "properties": nurse_note_request_properties,
+        },
+        "MedicalRecord": {
+            "type": "object",
+            "properties": medical_record_properties,
+        },
+        "MedicalRecordUpdate": {
+            "type": "object",
+            "properties": medical_record_update_properties,
         },
         "DashboardGroupItem": {
             "type": "object",
@@ -502,6 +563,29 @@ swagger_template = {
                 "message": {
                     "type": "string",
                     "example": "Nurse notes retrieved successfully",
+                },
+            },
+        },
+        "MedicalRecordResponse": {
+            "type": "object",
+            "properties": {
+                "data": {"$ref": "#/definitions/MedicalRecord"},
+                "message": {
+                    "type": "string",
+                    "example": "Medical record retrieved successfully",
+                },
+            },
+        },
+        "MedicalRecordListResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/MedicalRecord"},
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Medical records retrieved successfully",
                 },
             },
         },
@@ -1122,6 +1206,211 @@ visit_nurse_note_get_spec = {
         },
         404: {
             "description": "Visit or nurse note not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+medical_record_list_spec = {
+    "tags": ["Medical Records"],
+    "summary": "List medical records",
+    "responses": {
+        200: {
+            "description": "Medical records retrieved successfully.",
+            "schema": {"$ref": "#/definitions/MedicalRecordListResponse"},
+        }
+    },
+}
+
+medical_record_get_spec = {
+    "tags": ["Medical Records"],
+    "summary": "Retrieve medical record metadata",
+    "parameters": [
+        {
+            "name": "medical_record_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Medical record retrieved successfully.",
+            "schema": {"$ref": "#/definitions/MedicalRecordResponse"},
+        },
+        404: {
+            "description": "Medical record not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+medical_record_create_spec = {
+    "tags": ["Medical Records"],
+    "summary": "Upload a medical record",
+    "consumes": ["multipart/form-data"],
+    "parameters": [
+        {
+            "name": "patient_id",
+            "in": "formData",
+            "type": "integer",
+            "required": True,
+        },
+        {
+            "name": "title",
+            "in": "formData",
+            "type": "string",
+            "required": True,
+        },
+        {
+            "name": "file",
+            "in": "formData",
+            "type": "file",
+            "required": True,
+        },
+        {
+            "name": "description",
+            "in": "formData",
+            "type": "string",
+            "required": False,
+        },
+        {
+            "name": "record_type",
+            "in": "formData",
+            "type": "string",
+            "required": False,
+        },
+        {
+            "name": "uploaded_by",
+            "in": "formData",
+            "type": "string",
+            "required": False,
+        },
+    ],
+    "responses": {
+        201: {
+            "description": "Medical record uploaded successfully.",
+            "schema": {"$ref": "#/definitions/MedicalRecordResponse"},
+        },
+        400: {
+            "description": "Invalid medical record data.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+        502: {
+            "description": "Medical record storage is unavailable.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+medical_record_update_spec = {
+    "tags": ["Medical Records"],
+    "summary": "Update medical record metadata",
+    "parameters": [
+        {
+            "name": "medical_record_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        },
+        {
+            "name": "body",
+            "in": "body",
+            "required": True,
+            "schema": {"$ref": "#/definitions/MedicalRecordUpdate"},
+        },
+    ],
+    "responses": {
+        200: {
+            "description": "Medical record updated successfully.",
+            "schema": {"$ref": "#/definitions/MedicalRecordResponse"},
+        },
+        400: {
+            "description": "Invalid medical record data.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+        404: {
+            "description": "Medical record not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+medical_record_delete_spec = {
+    "tags": ["Medical Records"],
+    "summary": "Delete a medical record and its private object",
+    "parameters": [
+        {
+            "name": "medical_record_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Medical record deleted successfully.",
+            "schema": {"$ref": "#/definitions/DeleteSuccessResponse"},
+        },
+        404: {
+            "description": "Medical record not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+patient_medical_records_list_spec = {
+    "tags": ["Medical Records"],
+    "summary": "List medical records for a patient",
+    "parameters": [
+        {
+            "name": "patient_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Patient medical records retrieved successfully.",
+            "schema": {"$ref": "#/definitions/MedicalRecordListResponse"},
+        },
+        404: {
+            "description": "Patient not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+medical_record_download_spec = {
+    "tags": ["Medical Records"],
+    "summary": "Download a private medical record file",
+    "produces": [
+        "application/pdf",
+        "image/jpeg",
+        "image/png",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ],
+    "parameters": [
+        {
+            "name": "medical_record_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "The file is streamed through the backend as an attachment.",
+            "schema": {"type": "file"},
+        },
+        404: {
+            "description": "Medical record metadata or stored file not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+        502: {
+            "description": "Medical record storage is unavailable.",
             "schema": {"$ref": "#/definitions/ErrorResponse"},
         },
     },

--- a/backend/migrations/versions/20260609_0005_create_medical_records_table.py
+++ b/backend/migrations/versions/20260609_0005_create_medical_records_table.py
@@ -1,0 +1,51 @@
+"""create medical records table
+
+Revision ID: 20260609_0005
+Revises: 20260531_0004
+Create Date: 2026-06-09 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260609_0005"
+down_revision = "20260531_0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "medical_records",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("patient_id", sa.Integer(), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("record_type", sa.String(length=100), nullable=True),
+        sa.Column("file_name", sa.String(length=255), nullable=False),
+        sa.Column("file_mime_type", sa.String(length=150), nullable=False),
+        sa.Column("file_size", sa.BigInteger(), nullable=False),
+        sa.Column("storage_bucket", sa.String(length=255), nullable=False),
+        sa.Column("storage_object_key", sa.String(length=1024), nullable=False),
+        sa.Column("uploaded_by", sa.String(length=200), nullable=True),
+        sa.Column("uploaded_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["patient_id"], ["patients.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "storage_object_key",
+            name="uq_medical_records_storage_object_key",
+        ),
+    )
+    op.create_index(
+        "ix_medical_records_patient_id",
+        "medical_records",
+        ["patient_id"],
+    )
+
+
+def downgrade():
+    op.drop_index("ix_medical_records_patient_id", table_name="medical_records")
+    op.drop_table("medical_records")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,4 +4,5 @@ Flask-Migrate==4.1.0
 Flask-SQLAlchemy==3.1.1
 flasgger==0.9.7b2
 gunicorn==23.0.0
+minio==7.2.20
 psycopg[binary]==3.2.9

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,3 +1,5 @@
+from io import BytesIO
+
 import pytest
 
 from app import create_app
@@ -9,11 +11,34 @@ class TestConfig(Config):
     TESTING = True
     SQLALCHEMY_DATABASE_URI = "sqlite+pysqlite:///:memory:"
     CORS_ORIGINS = ["http://localhost:5173"]
+    MEDICAL_RECORD_MAX_FILE_SIZE = 1024 * 1024
+
+
+class FakeMedicalRecordStorage:
+    bucket = "test-medical-records"
+
+    def __init__(self):
+        self.objects = {}
+
+    def upload(self, object_key, stream, length, content_type):
+        self.objects[object_key] = {
+            "content": stream.read(length),
+            "content_type": content_type,
+        }
+
+    def open(self, object_key):
+        if object_key not in self.objects:
+            raise FileNotFoundError(object_key)
+        return BytesIO(self.objects[object_key]["content"])
+
+    def delete(self, object_key):
+        self.objects.pop(object_key, None)
 
 
 @pytest.fixture()
 def app():
     app = create_app(TestConfig)
+    app.extensions["medical_record_storage"] = FakeMedicalRecordStorage()
 
     with app.app_context():
         db.create_all()
@@ -25,3 +50,8 @@ def app():
 @pytest.fixture()
 def client(app):
     return app.test_client()
+
+
+@pytest.fixture()
+def medical_record_storage(app):
+    return app.extensions["medical_record_storage"]

--- a/backend/tests/test_medical_records.py
+++ b/backend/tests/test_medical_records.py
@@ -1,0 +1,213 @@
+from io import BytesIO
+
+
+def create_patient(client, **overrides):
+    payload = {
+        "first_name": "Maria",
+        "last_name": "Santos",
+    }
+    payload.update(overrides)
+    return client.post("/api/patients", json=payload).get_json()["data"]
+
+
+def upload_payload(patient_id=None, include_file=True, **overrides):
+    payload = {
+        "title": "Updated care plan",
+        "description": "Clinical plan for the next certification period.",
+        "record_type": "care_plan",
+        "uploaded_by": "Jordan Lee",
+    }
+    if patient_id is not None:
+        payload["patient_id"] = str(patient_id)
+    if include_file:
+        payload["file"] = (
+            BytesIO(b"%PDF-1.4 test medical record"),
+            "care-plan.pdf",
+            "application/pdf",
+        )
+    payload.update(overrides)
+    return payload
+
+
+def upload_record(client, patient_id, **overrides):
+    return client.post(
+        "/api/medical-records",
+        data=upload_payload(patient_id, **overrides),
+        content_type="multipart/form-data",
+    )
+
+
+def test_upload_medical_record_stores_metadata_and_object(
+    client,
+    medical_record_storage,
+):
+    patient = create_patient(client)
+
+    response = upload_record(client, patient["id"])
+    body = response.get_json()
+
+    assert response.status_code == 201
+    assert body["message"] == "Medical record uploaded successfully"
+    assert body["data"]["patient_id"] == patient["id"]
+    assert body["data"]["file_name"] == "care-plan.pdf"
+    assert body["data"]["file_mime_type"] == "application/pdf"
+    assert body["data"]["storage_bucket"] == medical_record_storage.bucket
+    assert body["data"]["storage_object_key"] in medical_record_storage.objects
+
+
+def test_list_medical_records(client):
+    patient = create_patient(client)
+    upload_record(client, patient["id"])
+
+    response = client.get("/api/medical-records")
+
+    assert response.status_code == 200
+    assert len(response.get_json()["data"]) == 1
+
+
+def test_list_medical_records_for_patient(client):
+    patient = create_patient(client)
+    other_patient = create_patient(client, first_name="John", last_name="Rivera")
+    upload_record(client, patient["id"])
+    upload_record(client, other_patient["id"], title="Assessment")
+
+    response = client.get(f"/api/patients/{patient['id']}/medical-records")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert len(body["data"]) == 1
+    assert body["data"][0]["patient_id"] == patient["id"]
+
+
+def test_get_medical_record(client):
+    patient = create_patient(client)
+    created = upload_record(client, patient["id"]).get_json()["data"]
+
+    response = client.get(f"/api/medical-records/{created['id']}")
+
+    assert response.status_code == 200
+    assert response.get_json()["data"]["title"] == "Updated care plan"
+
+
+def test_update_medical_record_metadata(client):
+    patient = create_patient(client)
+    created = upload_record(client, patient["id"]).get_json()["data"]
+
+    response = client.put(
+        f"/api/medical-records/{created['id']}",
+        json={
+            "title": "Signed care plan",
+            "record_type": "signed_care_plan",
+            "uploaded_by": "Taylor Morgan",
+        },
+    )
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["data"]["title"] == "Signed care plan"
+    assert body["data"]["record_type"] == "signed_care_plan"
+    assert body["data"]["file_name"] == "care-plan.pdf"
+
+
+def test_download_medical_record_streams_private_object(client):
+    patient = create_patient(client)
+    created = upload_record(client, patient["id"]).get_json()["data"]
+
+    response = client.get(f"/api/medical-records/{created['id']}/download")
+
+    assert response.status_code == 200
+    assert response.data == b"%PDF-1.4 test medical record"
+    assert response.mimetype == "application/pdf"
+    assert "care-plan.pdf" in response.headers["Content-Disposition"]
+
+
+def test_delete_medical_record_removes_metadata_and_object(
+    client,
+    medical_record_storage,
+):
+    patient = create_patient(client)
+    created = upload_record(client, patient["id"]).get_json()["data"]
+    object_key = created["storage_object_key"]
+
+    response = client.delete(f"/api/medical-records/{created['id']}")
+
+    assert response.status_code == 200
+    assert object_key not in medical_record_storage.objects
+    assert client.get(f"/api/medical-records/{created['id']}").status_code == 404
+
+
+def test_upload_requires_patient_id(client):
+    response = client.post(
+        "/api/medical-records",
+        data=upload_payload(),
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    assert "patient_id" in response.get_json()["errors"]
+
+
+def test_upload_requires_file(client):
+    patient = create_patient(client)
+
+    response = client.post(
+        "/api/medical-records",
+        data=upload_payload(patient["id"], include_file=False),
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["file"] == "This field is required."
+
+
+def test_upload_rejects_invalid_patient_id(client):
+    response = upload_record(client, 999)
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["patient_id"] == "Patient not found."
+
+
+def test_upload_rejects_unsupported_file_type(client):
+    patient = create_patient(client)
+
+    response = upload_record(
+        client,
+        patient["id"],
+        file=(BytesIO(b"executable"), "malware.exe", "application/octet-stream"),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["file"] == (
+        "Use a PDF, JPEG, PNG, DOC, or DOCX file."
+    )
+
+
+def test_upload_rejects_file_with_mismatched_content(client):
+    patient = create_patient(client)
+
+    response = upload_record(
+        client,
+        patient["id"],
+        file=(BytesIO(b"not actually a PDF"), "care-plan.pdf", "application/pdf"),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["file"] == (
+        "File content does not match the selected document type."
+    )
+
+
+def test_upload_rejects_file_over_configured_size(client):
+    patient = create_patient(client)
+    oversized_pdf = b"%PDF-" + (b"x" * (1024 * 1024))
+
+    response = upload_record(
+        client,
+        patient["id"],
+        file=(BytesIO(oversized_pdf), "large.pdf", "application/pdf"),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["file"] == (
+        "File size must not exceed 1 MB."
+    )

--- a/backend/tests/test_openapi.py
+++ b/backend/tests/test_openapi.py
@@ -33,6 +33,10 @@ def test_openapi_json_includes_health_and_patient_endpoints(client):
     assert "/api/nurse-notes/{nurse_note_id}" in paths
     assert "/api/patients/{patient_id}/nurse-notes" in paths
     assert "/api/visits/{visit_id}/nurse-note" in paths
+    assert "/api/medical-records" in paths
+    assert "/api/medical-records/{medical_record_id}" in paths
+    assert "/api/patients/{patient_id}/medical-records" in paths
+    assert "/api/medical-records/{medical_record_id}/download" in paths
     assert "get" in paths["/api/health"]
     assert "get" in paths["/api/dashboard/stats"]
     assert {"get", "post"} <= set(paths["/api/patients"].keys())
@@ -54,6 +58,12 @@ def test_openapi_json_includes_health_and_patient_endpoints(client):
     )
     assert "get" in paths["/api/patients/{patient_id}/nurse-notes"]
     assert "get" in paths["/api/visits/{visit_id}/nurse-note"]
+    assert {"get", "post"} <= set(paths["/api/medical-records"].keys())
+    assert {"get", "put", "delete"} <= set(
+        paths["/api/medical-records/{medical_record_id}"].keys()
+    )
+    assert "get" in paths["/api/patients/{patient_id}/medical-records"]
+    assert "get" in paths["/api/medical-records/{medical_record_id}/download"]
 
 
 def test_openapi_json_includes_patient_schemas(client):
@@ -85,3 +95,7 @@ def test_openapi_json_includes_patient_schemas(client):
     assert "DashboardRecentVisit" in definitions
     assert "DashboardStats" in definitions
     assert "DashboardStatsResponse" in definitions
+    assert "MedicalRecord" in definitions
+    assert "MedicalRecordUpdate" in definitions
+    assert "MedicalRecordResponse" in definitions
+    assert "MedicalRecordListResponse" in definitions

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,11 @@ services:
       BACKEND_PORT: 5000
       DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://seniormate:change-me-local-only@postgres:5432/seniormate}
       MINIO_ENDPOINT: ${MINIO_ENDPOINT:-http://minio:9000}
-      MINIO_BUCKET: ${MINIO_BUCKET:-seniormate-local}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-local-access-key}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-change-me-local-only}
+      MINIO_BUCKET: ${MINIO_BUCKET:-seniormate-medical-records}
+      MINIO_SECURE: ${MINIO_SECURE:-false}
+      MEDICAL_RECORD_MAX_FILE_SIZE: ${MEDICAL_RECORD_MAX_FILE_SIZE:-10485760}
     ports:
       - "${BACKEND_PORT:-5001}:5000"
     volumes:

--- a/docs/architecture/api-design.md
+++ b/docs/architecture/api-design.md
@@ -291,6 +291,102 @@ Example response:
 }
 ```
 
+## Medical Records API
+
+Medical Records store patient document metadata in PostgreSQL and file bytes in a
+private MinIO bucket. The API never returns public object-store URLs. Downloads
+are streamed through the authenticated application boundary so the bucket can
+remain private.
+
+Supported uploads:
+
+- PDF (`.pdf`)
+- JPEG (`.jpg`, `.jpeg`)
+- PNG (`.png`)
+- Microsoft Word (`.doc`, `.docx`)
+
+The default upload limit is 10 MB and can be changed with
+`MEDICAL_RECORD_MAX_FILE_SIZE`.
+
+### Upload a Medical Record
+
+`POST /api/medical-records`
+
+Use `multipart/form-data` with:
+
+- `patient_id` (required)
+- `title` (required)
+- `file` (required)
+- `description` (optional)
+- `record_type` (optional)
+- `uploaded_by` (optional)
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "patient_id": 1,
+    "title": "Updated care plan",
+    "description": "Care plan approved by the clinical team.",
+    "record_type": "care_plan",
+    "file_name": "care-plan.pdf",
+    "file_mime_type": "application/pdf",
+    "file_size": 245760,
+    "storage_bucket": "seniormate-medical-records",
+    "storage_object_key": "patients/1/0f8c2f_care-plan.pdf",
+    "uploaded_by": "Jordan Lee",
+    "uploaded_at": "2026-06-09T10:00:00+00:00",
+    "created_at": "2026-06-09T10:00:00+00:00",
+    "updated_at": "2026-06-09T10:00:00+00:00"
+  },
+  "message": "Medical record uploaded successfully"
+}
+```
+
+### List Medical Records
+
+- `GET /api/medical-records`
+- `GET /api/patients/<patient_id>/medical-records`
+
+Both endpoints return medical record metadata only. They do not return file
+contents or public object URLs.
+
+### Retrieve and Update Metadata
+
+- `GET /api/medical-records/<id>`
+- `PUT /api/medical-records/<id>`
+
+The update endpoint accepts JSON fields for `title`, `description`,
+`record_type`, and `uploaded_by`. Replacing the stored file is intentionally not
+part of this first version.
+
+Example update:
+
+```json
+{
+  "title": "Signed care plan",
+  "record_type": "signed_care_plan",
+  "uploaded_by": "Taylor Morgan"
+}
+```
+
+### Download a Medical Record
+
+`GET /api/medical-records/<id>/download`
+
+The backend reads the private MinIO object and streams it as an attachment using
+the stored MIME type and file name.
+
+### Delete a Medical Record
+
+`DELETE /api/medical-records/<id>`
+
+Deletion removes the object from MinIO and then removes its PostgreSQL metadata.
+A missing object is handled gracefully so stale metadata can still be cleaned
+up.
+
 ## Visit API
 
 The Visit API records caregiver and nursing visits linked to patients.

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -66,6 +66,23 @@ Default local MinIO console values:
 
 - User: `local-access-key`
 - Password: `change-me-local-only`
+- Private medical-record bucket: `seniormate-medical-records`
+
+The backend creates the medical-record bucket automatically on the first upload
+if it does not exist. The bucket is not configured for public access.
+
+Medical Record storage settings:
+
+- `MINIO_ENDPOINT`: backend connection URL for MinIO
+- `MINIO_ACCESS_KEY`: application access key
+- `MINIO_SECRET_KEY`: application secret key
+- `MINIO_BUCKET`: private bucket used for patient documents
+- `MINIO_SECURE`: set to `true` when the MinIO endpoint uses TLS
+- `MEDICAL_RECORD_MAX_FILE_SIZE`: maximum upload size in bytes; defaults to
+  `10485760` (10 MB)
+
+Supported uploads are PDF, JPEG, PNG, DOC, and DOCX files. PostgreSQL stores
+metadata and MinIO stores the file bytes.
 
 ## Backend Setup
 
@@ -126,6 +143,9 @@ The main app remains usable without login for now.
 - If ports are already in use, adjust `BACKEND_PORT`, `FRONTEND_PORT`, `POSTGRES_PORT`, `MINIO_API_PORT`, or `MINIO_CONSOLE_PORT` in `.env`.
 - If the backend health endpoint reports `database: unavailable`, wait for PostgreSQL to finish starting or restart the backend container.
 - If frontend dependencies behave oddly, rebuild the frontend container with `docker compose build frontend`.
+- If medical record uploads fail, confirm MinIO is running and that the backend
+  `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` match the local MinIO root
+  credentials.
 - If local data needs to be reset, run `docker compose down -v`.
 
 ## Validation Before Pull Requests

--- a/frontend/src/components/MedicalRecordsSection.js
+++ b/frontend/src/components/MedicalRecordsSection.js
@@ -1,0 +1,433 @@
+import { onMounted, ref } from "vue";
+
+import {
+  deleteMedicalRecord,
+  downloadMedicalRecord,
+  getPatientMedicalRecords,
+  updateMedicalRecord,
+  uploadMedicalRecord,
+} from "../services/medicalRecords.js";
+
+
+const emptyUploadForm = () => ({
+  title: "",
+  description: "",
+  record_type: "",
+  uploaded_by: "",
+  file: null,
+});
+
+const emptyEditForm = () => ({
+  title: "",
+  description: "",
+  record_type: "",
+  uploaded_by: "",
+});
+
+export default {
+  props: {
+    patientId: {
+      type: Number,
+      required: true,
+    },
+  },
+  setup(props) {
+    const records = ref([]);
+    const loading = ref(true);
+    const error = ref("");
+    const success = ref("");
+    const uploadDialog = ref(false);
+    const editDialog = ref(false);
+    const confirmDelete = ref(false);
+    const uploading = ref(false);
+    const saving = ref(false);
+    const deleting = ref(false);
+    const downloadingId = ref(null);
+    const selectedRecord = ref(null);
+    const uploadForm = ref(emptyUploadForm());
+    const editForm = ref(emptyEditForm());
+
+    const headers = [
+      { title: "Title", key: "title" },
+      { title: "Type", key: "record_type" },
+      { title: "File", key: "file_name" },
+      { title: "Size", key: "file_size" },
+      { title: "Uploaded", key: "uploaded_at" },
+      { title: "Actions", key: "actions", sortable: false },
+    ];
+
+    const recordTypes = [
+      { title: "Assessment", value: "assessment" },
+      { title: "Care plan", value: "care_plan" },
+      { title: "Prescription", value: "prescription" },
+      { title: "Lab result", value: "lab_result" },
+      { title: "Scan", value: "scan" },
+      { title: "Other", value: "other" },
+    ];
+
+    async function loadRecords() {
+      loading.value = true;
+      error.value = "";
+      try {
+        const response = await getPatientMedicalRecords(props.patientId);
+        records.value = response.data;
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    function openUpload() {
+      uploadForm.value = emptyUploadForm();
+      error.value = "";
+      uploadDialog.value = true;
+    }
+
+    function selectedFile() {
+      const value = uploadForm.value.file;
+      return Array.isArray(value) ? value[0] : value;
+    }
+
+    async function submitUpload() {
+      const file = selectedFile();
+      if (!uploadForm.value.title.trim() || !file) {
+        error.value = "Title and file are required.";
+        return;
+      }
+
+      uploading.value = true;
+      error.value = "";
+      success.value = "";
+      try {
+        await uploadMedicalRecord({
+          ...uploadForm.value,
+          patient_id: props.patientId,
+          title: uploadForm.value.title.trim(),
+          file,
+        });
+        uploadDialog.value = false;
+        success.value = "Medical record uploaded successfully.";
+        await loadRecords();
+      } catch (err) {
+        error.value = err.payload?.errors?.file || err.message;
+      } finally {
+        uploading.value = false;
+      }
+    }
+
+    function openEdit(record) {
+      selectedRecord.value = record;
+      editForm.value = {
+        title: record.title || "",
+        description: record.description || "",
+        record_type: record.record_type || "",
+        uploaded_by: record.uploaded_by || "",
+      };
+      error.value = "";
+      editDialog.value = true;
+    }
+
+    async function saveMetadata() {
+      if (!editForm.value.title.trim()) {
+        error.value = "Title is required.";
+        return;
+      }
+
+      saving.value = true;
+      error.value = "";
+      success.value = "";
+      try {
+        await updateMedicalRecord(selectedRecord.value.id, {
+          ...editForm.value,
+          title: editForm.value.title.trim(),
+        });
+        editDialog.value = false;
+        success.value = "Medical record details updated.";
+        await loadRecords();
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        saving.value = false;
+      }
+    }
+
+    function askDelete(record) {
+      selectedRecord.value = record;
+      confirmDelete.value = true;
+    }
+
+    async function removeRecord() {
+      if (!selectedRecord.value) return;
+
+      deleting.value = true;
+      error.value = "";
+      success.value = "";
+      try {
+        await deleteMedicalRecord(selectedRecord.value.id);
+        confirmDelete.value = false;
+        success.value = "Medical record deleted successfully.";
+        selectedRecord.value = null;
+        await loadRecords();
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        deleting.value = false;
+      }
+    }
+
+    async function downloadRecord(record) {
+      downloadingId.value = record.id;
+      error.value = "";
+      try {
+        const blob = await downloadMedicalRecord(record.id);
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement("a");
+        anchor.href = url;
+        anchor.download = record.file_name;
+        document.body.appendChild(anchor);
+        anchor.click();
+        anchor.remove();
+        URL.revokeObjectURL(url);
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        downloadingId.value = null;
+      }
+    }
+
+    function formatBytes(bytes) {
+      if (!bytes) return "0 B";
+      if (bytes < 1024 * 1024) return `${Math.ceil(bytes / 1024)} KB`;
+      return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    }
+
+    function formatDate(value) {
+      if (!value) return "Not available";
+      return new Intl.DateTimeFormat(undefined, {
+        dateStyle: "medium",
+      }).format(new Date(value));
+    }
+
+    onMounted(loadRecords);
+
+    return {
+      askDelete,
+      confirmDelete,
+      deleting,
+      downloadRecord,
+      downloadingId,
+      editDialog,
+      editForm,
+      error,
+      formatBytes,
+      formatDate,
+      headers,
+      loading,
+      openEdit,
+      openUpload,
+      recordTypes,
+      records,
+      removeRecord,
+      saveMetadata,
+      saving,
+      selectedRecord,
+      submitUpload,
+      success,
+      uploadDialog,
+      uploadForm,
+      uploading,
+    };
+  },
+  template: `
+    <SectionCard
+      title="Medical Records"
+      subtitle="Private patient documents stored securely in MinIO."
+      icon="mdi-file-document-multiple-outline"
+      class="data-card mb-6"
+    >
+      <template #default>
+        <div class="d-flex flex-wrap justify-space-between align-center ga-3 mb-4">
+          <div class="text-body-2 text-medium-emphasis">
+            PDFs, images, Word documents, care plans, prescriptions, and assessments.
+          </div>
+          <v-btn color="primary" prepend-icon="mdi-upload-outline" @click="openUpload">
+            Upload record
+          </v-btn>
+        </div>
+
+        <ErrorAlert :message="error" />
+        <v-alert v-if="success" type="success" variant="tonal" class="mb-4">
+          {{ success }}
+        </v-alert>
+
+        <v-data-table
+          :headers="headers"
+          :items="records"
+          :loading="loading"
+          item-value="id"
+          density="comfortable"
+        >
+          <template #loading>
+            <LoadingState />
+          </template>
+
+          <template #no-data>
+            <EmptyState
+              icon="mdi-file-document-plus-outline"
+              title="No medical records"
+              description="Upload the first clinical document for this patient."
+            />
+          </template>
+
+          <template #[\`item.record_type\`]="{ item }">
+            {{ item.record_type?.replaceAll('_', ' ') || 'Other' }}
+          </template>
+
+          <template #[\`item.file_name\`]="{ item }">
+            <div>
+              <div class="font-weight-medium">{{ item.file_name }}</div>
+              <div class="text-caption text-medium-emphasis">{{ item.file_mime_type }}</div>
+            </div>
+          </template>
+
+          <template #[\`item.file_size\`]="{ item }">
+            {{ formatBytes(item.file_size) }}
+          </template>
+
+          <template #[\`item.uploaded_at\`]="{ item }">
+            <div>{{ formatDate(item.uploaded_at) }}</div>
+            <div v-if="item.uploaded_by" class="text-caption text-medium-emphasis">
+              {{ item.uploaded_by }}
+            </div>
+          </template>
+
+          <template #[\`item.actions\`]="{ item }">
+            <div class="table-actions">
+              <v-btn
+                icon="mdi-download-outline"
+                variant="text"
+                color="primary"
+                :loading="downloadingId === item.id"
+                aria-label="Download medical record"
+                @click="downloadRecord(item)"
+              />
+              <v-btn
+                icon="mdi-pencil-outline"
+                variant="text"
+                aria-label="Edit medical record details"
+                @click="openEdit(item)"
+              />
+              <v-btn
+                icon="mdi-delete-outline"
+                variant="text"
+                color="error"
+                aria-label="Delete medical record"
+                @click="askDelete(item)"
+              />
+            </div>
+          </template>
+        </v-data-table>
+      </template>
+    </SectionCard>
+
+    <v-dialog v-model="uploadDialog" max-width="680">
+      <v-card>
+        <v-card-title class="d-flex align-center ga-2">
+          <v-icon icon="mdi-upload-outline" color="primary" />
+          Upload medical record
+        </v-card-title>
+        <v-card-text>
+          <v-form @submit.prevent="submitUpload">
+            <v-row>
+              <v-col cols="12" md="7">
+                <v-text-field v-model="uploadForm.title" label="Title *" />
+              </v-col>
+              <v-col cols="12" md="5">
+                <v-select
+                  v-model="uploadForm.record_type"
+                  :items="recordTypes"
+                  label="Record type"
+                  clearable
+                />
+              </v-col>
+              <v-col cols="12">
+                <v-file-input
+                  v-model="uploadForm.file"
+                  label="Document *"
+                  accept=".pdf,.jpg,.jpeg,.png,.doc,.docx"
+                  prepend-icon="mdi-paperclip"
+                  show-size
+                  hint="PDF, JPEG, PNG, DOC, or DOCX. Maximum 10 MB."
+                  persistent-hint
+                />
+              </v-col>
+              <v-col cols="12">
+                <v-textarea
+                  v-model="uploadForm.description"
+                  label="Description"
+                  rows="3"
+                />
+              </v-col>
+              <v-col cols="12">
+                <v-text-field v-model="uploadForm.uploaded_by" label="Uploaded by" />
+              </v-col>
+            </v-row>
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="uploadDialog = false">Cancel</v-btn>
+          <v-btn color="primary" :loading="uploading" @click="submitUpload">
+            Upload record
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="editDialog" max-width="640">
+      <v-card>
+        <v-card-title class="d-flex align-center ga-2">
+          <v-icon icon="mdi-file-edit-outline" color="primary" />
+          Edit medical record
+        </v-card-title>
+        <v-card-text>
+          <v-row>
+            <v-col cols="12" md="7">
+              <v-text-field v-model="editForm.title" label="Title *" />
+            </v-col>
+            <v-col cols="12" md="5">
+              <v-select
+                v-model="editForm.record_type"
+                :items="recordTypes"
+                label="Record type"
+                clearable
+              />
+            </v-col>
+            <v-col cols="12">
+              <v-textarea v-model="editForm.description" label="Description" rows="3" />
+            </v-col>
+            <v-col cols="12">
+              <v-text-field v-model="editForm.uploaded_by" label="Uploaded by" />
+            </v-col>
+          </v-row>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="editDialog = false">Cancel</v-btn>
+          <v-btn color="primary" :loading="saving" @click="saveMetadata">
+            Save changes
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <ConfirmDialog
+      v-model="confirmDelete"
+      title="Delete medical record"
+      :message="\`Delete \${selectedRecord?.title || 'this medical record'} and its stored file? This cannot be undone.\`"
+      :loading="deleting"
+      @confirm="removeRecord"
+    />
+  `,
+};

--- a/frontend/src/services/http.js
+++ b/frontend/src/services/http.js
@@ -14,12 +14,13 @@ export async function parseResponse(response) {
 }
 
 export async function apiRequest(path, options = {}) {
+  const isFormData = options.body instanceof FormData;
   const response = await fetch(`${apiBaseUrl}${path}`, {
+    ...options,
     headers: {
-      "Content-Type": "application/json",
+      ...(!isFormData ? { "Content-Type": "application/json" } : {}),
       ...(options.headers || {}),
     },
-    ...options,
   });
 
   return parseResponse(response);

--- a/frontend/src/services/medicalRecords.js
+++ b/frontend/src/services/medicalRecords.js
@@ -1,0 +1,50 @@
+import { apiBaseUrl } from "../config.js";
+import { apiRequest, parseResponse } from "./http.js";
+
+
+export async function listMedicalRecords() {
+  return apiRequest("/medical-records");
+}
+
+export async function getMedicalRecord(id) {
+  return apiRequest(`/medical-records/${id}`);
+}
+
+export async function uploadMedicalRecord(medicalRecord) {
+  const formData = new FormData();
+  Object.entries(medicalRecord).forEach(([key, value]) => {
+    if (value !== null && value !== undefined && value !== "") {
+      formData.append(key, value);
+    }
+  });
+
+  return apiRequest("/medical-records", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+export async function updateMedicalRecord(id, medicalRecord) {
+  return apiRequest(`/medical-records/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(medicalRecord),
+  });
+}
+
+export async function deleteMedicalRecord(id) {
+  return apiRequest(`/medical-records/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export async function getPatientMedicalRecords(patientId) {
+  return apiRequest(`/patients/${patientId}/medical-records`);
+}
+
+export async function downloadMedicalRecord(id) {
+  const response = await fetch(`${apiBaseUrl}/medical-records/${id}/download`);
+  if (!response.ok) {
+    await parseResponse(response);
+  }
+  return response.blob();
+}

--- a/frontend/src/views/PatientDetailView.js
+++ b/frontend/src/views/PatientDetailView.js
@@ -1,9 +1,13 @@
 import { computed, onMounted, ref } from "vue";
 
+import MedicalRecordsSection from "../components/MedicalRecordsSection.js";
 import { getPatient } from "../services/patients.js";
 import { deleteVisit, listPatientVisits } from "../services/visits.js";
 
 export default {
+  components: {
+    MedicalRecordsSection,
+  },
   props: {
     id: {
       type: String,
@@ -153,6 +157,8 @@ export default {
             </v-card>
           </v-col>
         </v-row>
+
+        <MedicalRecordsSection :patient-id="patient.id" />
 
         <v-card>
           <v-card-title>Visits</v-card-title>


### PR DESCRIPTION
# Summary

- Adds a patient-linked `MedicalRecord` model and migration for document metadata.
- Stores file bytes in a private MinIO bucket through the official MinIO Python SDK while PostgreSQL stores metadata and object keys only.
- Adds multipart upload, metadata CRUD, patient record listing, private download streaming, validation, Swagger documentation, and automated tests.
- Adds a Medical Records workspace to Patient Detail with upload, download, metadata editing, and confirmed deletion.
- Documents MinIO credentials, automatic private bucket creation, supported file types, and the configurable 10 MB default limit.

The official `minio` SDK was chosen because it directly supports MinIO bucket creation and private object operations without adding an abstraction intended for unrelated cloud providers. A small application adapter keeps it injectable and allows tests to use an in-memory fake store.

## Related Issue / Task

- Feature: `16-medical-records`

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `/private/tmp/seniormate-feature16-py312/bin/ruff check .`
- `/private/tmp/seniormate-feature16-py312/bin/pytest` (`61 passed`)
- `npm run build`
- `docker-compose config`
- Fresh SQLite migration upgrade through revision `20260609_0005`
- Repository secret-pattern scan
- Manual browser verification of Patient Detail, Medical Records empty state, responsive table, and upload dialog

The local Colima Docker daemon was unavailable, so full local Compose startup was not repeated. The Compose configuration validates successfully and the PR Docker workflow will build the backend and frontend images.

## Screenshots

Manual screenshots were captured for the Patient Detail Medical Records section and upload dialog during browser validation. The test patient contained synthetic local data only.

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.