### PR TITLE
feat: add patient assessments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added patient assessments with optional visit linkage, structured JSON findings, CRUD APIs, Swagger documentation, backend tests, and patient/visit frontend workflows.
 - Added private MinIO-backed patient profile photos with upload, preview, verification, deletion, safe API metadata, and initials fallback across patient and visit screens.
 - Added patient Medical Records with private MinIO file storage, PostgreSQL metadata, upload/download CRUD APIs, Swagger documentation, tests, and Patient Detail UI integration.
 - Added a reusable frontend UI foundation with a SeniorMate Vuetify theme, shared page and feedback components, standardized tables, responsive spacing, and UI guidelines.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -9,7 +9,9 @@ from app.models import AideNote as AideNote
 from app.models import MedicalRecord as MedicalRecord
 from app.models import NurseNote as NurseNote
 from app.models import Patient as Patient
+from app.models import PatientAssessment as PatientAssessment
 from app.models import Visit as Visit
+from app.routes.assessments import assessments_bp
 from app.routes.aide_notes import aide_notes_bp
 from app.routes.dashboard import dashboard_bp
 from app.routes.medical_records import medical_records_bp
@@ -27,6 +29,7 @@ def create_app(config_object=Config):
 
     db.init_app(app)
     migrate.init_app(app, db)
+    app.register_blueprint(assessments_bp)
     app.register_blueprint(aide_notes_bp)
     app.register_blueprint(dashboard_bp)
     app.register_blueprint(medical_records_bp)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,7 +2,15 @@ from app.models.aide_note import AideNote
 from app.models.medical_record import MedicalRecord
 from app.models.nurse_note import NurseNote
 from app.models.patient import Patient
+from app.models.patient_assessment import PatientAssessment
 from app.models.visit import Visit
 
 
-__all__ = ["AideNote", "MedicalRecord", "NurseNote", "Patient", "Visit"]
+__all__ = [
+    "AideNote",
+    "MedicalRecord",
+    "NurseNote",
+    "Patient",
+    "PatientAssessment",
+    "Visit",
+]

--- a/backend/app/models/patient.py
+++ b/backend/app/models/patient.py
@@ -60,6 +60,11 @@ class Patient(db.Model):
         back_populates="patient",
         cascade="all, delete-orphan",
     )
+    assessments = db.relationship(
+        "PatientAssessment",
+        back_populates="patient",
+        cascade="all, delete-orphan",
+    )
 
     def to_dict(self):
         return {

--- a/backend/app/models/patient_assessment.py
+++ b/backend/app/models/patient_assessment.py
@@ -1,0 +1,73 @@
+from datetime import UTC, datetime
+
+from sqlalchemy import CheckConstraint
+
+from app.extensions import db
+
+
+class PatientAssessment(db.Model):
+    __tablename__ = "patient_assessments"
+    __table_args__ = (
+        CheckConstraint(
+            "assessment_type IN "
+            "('fall_risk', 'nutrition', 'mobility', 'cognitive', 'general')",
+            name="ck_patient_assessments_type",
+        ),
+        CheckConstraint(
+            "status IN ('draft', 'completed')",
+            name="ck_patient_assessments_status",
+        ),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    patient_id = db.Column(
+        db.Integer,
+        db.ForeignKey("patients.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    visit_id = db.Column(
+        db.Integer,
+        db.ForeignKey("visits.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    assessment_type = db.Column(db.String(50), nullable=False)
+    assessment_date = db.Column(db.Date, nullable=False)
+    performed_by = db.Column(db.String(200), nullable=True)
+    summary = db.Column(db.Text, nullable=True)
+    findings = db.Column(db.JSON, nullable=True)
+    recommendations = db.Column(db.Text, nullable=True)
+    status = db.Column(db.String(20), nullable=False, default="draft")
+    created_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    patient = db.relationship("Patient", back_populates="assessments")
+    visit = db.relationship("Visit", back_populates="assessments")
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "patient_id": self.patient_id,
+            "visit_id": self.visit_id,
+            "assessment_type": self.assessment_type,
+            "assessment_date": self.assessment_date.isoformat()
+            if self.assessment_date
+            else None,
+            "performed_by": self.performed_by,
+            "summary": self.summary,
+            "findings": self.findings,
+            "recommendations": self.recommendations,
+            "status": self.status,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/backend/app/models/visit.py
+++ b/backend/app/models/visit.py
@@ -55,6 +55,11 @@ class Visit(db.Model):
         cascade="all, delete-orphan",
         uselist=False,
     )
+    assessments = db.relationship(
+        "PatientAssessment",
+        back_populates="visit",
+        passive_deletes=True,
+    )
 
     def to_dict(self):
         return {

--- a/backend/app/routes/assessments.py
+++ b/backend/app/routes/assessments.py
@@ -1,0 +1,247 @@
+from datetime import date
+
+from flasgger import swag_from
+from flask import Blueprint, jsonify, request
+
+from app.extensions import db
+from app.models import Patient, PatientAssessment, Visit
+from app.swagger import (
+    assessment_create_spec,
+    assessment_delete_spec,
+    assessment_get_spec,
+    assessment_list_spec,
+    assessment_update_spec,
+    patient_assessments_list_spec,
+    visit_assessments_list_spec,
+)
+
+
+assessments_bp = Blueprint("assessments", __name__, url_prefix="/api")
+
+ASSESSMENT_TYPES = {
+    "fall_risk",
+    "nutrition",
+    "mobility",
+    "cognitive",
+    "general",
+}
+ASSESSMENT_STATUSES = {"draft", "completed"}
+ASSESSMENT_FIELDS = {
+    "patient_id",
+    "visit_id",
+    "assessment_type",
+    "assessment_date",
+    "performed_by",
+    "summary",
+    "findings",
+    "recommendations",
+    "status",
+}
+
+
+def success_response(data, message, status_code=200):
+    return jsonify({"data": data, "message": message}), status_code
+
+
+def error_response(message, status_code=400, errors=None):
+    payload = {"message": message}
+    if errors:
+        payload["errors"] = errors
+    return jsonify(payload), status_code
+
+
+def parse_assessment_payload(payload, partial=False, current_assessment=None):
+    if not isinstance(payload, dict):
+        return None, {"request": "JSON body is required."}
+
+    data = {field: payload[field] for field in ASSESSMENT_FIELDS if field in payload}
+    errors = {}
+    patient = None
+    visit = None
+
+    if not partial or "patient_id" in data:
+        patient_id = data.get("patient_id")
+        if patient_id in (None, ""):
+            errors["patient_id"] = "This field is required."
+        elif not isinstance(patient_id, int):
+            errors["patient_id"] = "Patient ID must be an integer."
+        else:
+            patient = db.session.get(Patient, patient_id)
+            if patient is None:
+                errors["patient_id"] = "Patient not found."
+    elif current_assessment is not None:
+        patient = db.session.get(Patient, current_assessment.patient_id)
+
+    if "visit_id" in data and data["visit_id"] not in (None, ""):
+        if not isinstance(data["visit_id"], int):
+            errors["visit_id"] = "Visit ID must be an integer."
+        else:
+            visit = db.session.get(Visit, data["visit_id"])
+            if visit is None:
+                errors["visit_id"] = "Visit not found."
+    elif "visit_id" in data:
+        data["visit_id"] = None
+    elif current_assessment is not None and current_assessment.visit_id is not None:
+        visit = db.session.get(Visit, current_assessment.visit_id)
+
+    if patient is not None and visit is not None and visit.patient_id != patient.id:
+        errors["visit_id"] = "Visit does not belong to the selected patient."
+
+    if not partial or "assessment_type" in data:
+        assessment_type = data.get("assessment_type")
+        if not isinstance(assessment_type, str) or not assessment_type.strip():
+            errors["assessment_type"] = "This field is required."
+        elif assessment_type not in ASSESSMENT_TYPES:
+            errors["assessment_type"] = "Select a supported assessment type."
+
+    if not partial or "assessment_date" in data:
+        assessment_date = data.get("assessment_date")
+        if assessment_date in (None, ""):
+            errors["assessment_date"] = "This field is required."
+        else:
+            try:
+                data["assessment_date"] = date.fromisoformat(assessment_date)
+            except (TypeError, ValueError):
+                errors["assessment_date"] = "Use ISO date format YYYY-MM-DD."
+
+    if "status" in data:
+        if data["status"] not in ASSESSMENT_STATUSES:
+            errors["status"] = "Status must be draft or completed."
+    elif not partial:
+        data["status"] = "draft"
+
+    if (
+        "findings" in data
+        and data["findings"] is not None
+        and not isinstance(data["findings"], (dict, list))
+    ):
+        errors["findings"] = "Findings must be a JSON object or array."
+
+    for field in ("performed_by", "summary", "recommendations"):
+        if field in data and isinstance(data[field], str):
+            data[field] = data[field].strip() or None
+
+    return data, errors
+
+
+@assessments_bp.get("/assessments")
+@swag_from(assessment_list_spec)
+def list_assessments():
+    assessments = PatientAssessment.query.order_by(
+        PatientAssessment.assessment_date.desc(),
+        PatientAssessment.id.desc(),
+    ).all()
+    return success_response(
+        [assessment.to_dict() for assessment in assessments],
+        "Assessments retrieved successfully",
+    )
+
+
+@assessments_bp.get("/assessments/<int:assessment_id>")
+@swag_from(assessment_get_spec)
+def get_assessment(assessment_id):
+    assessment = db.session.get(PatientAssessment, assessment_id)
+    if assessment is None:
+        return error_response("Assessment not found", 404)
+    return success_response(
+        assessment.to_dict(),
+        "Assessment retrieved successfully",
+    )
+
+
+@assessments_bp.post("/assessments")
+@swag_from(assessment_create_spec)
+def create_assessment():
+    data, errors = parse_assessment_payload(request.get_json(silent=True))
+    if errors:
+        return error_response("Invalid assessment data", 400, errors)
+
+    assessment = PatientAssessment(**data)
+    db.session.add(assessment)
+    db.session.commit()
+    return success_response(
+        assessment.to_dict(),
+        "Assessment created successfully",
+        201,
+    )
+
+
+@assessments_bp.put("/assessments/<int:assessment_id>")
+@swag_from(assessment_update_spec)
+def update_assessment(assessment_id):
+    assessment = db.session.get(PatientAssessment, assessment_id)
+    if assessment is None:
+        return error_response("Assessment not found", 404)
+
+    data, errors = parse_assessment_payload(
+        request.get_json(silent=True),
+        partial=True,
+        current_assessment=assessment,
+    )
+    if errors:
+        return error_response("Invalid assessment data", 400, errors)
+
+    for field, value in data.items():
+        setattr(assessment, field, value)
+    db.session.commit()
+    return success_response(
+        assessment.to_dict(),
+        "Assessment updated successfully",
+    )
+
+
+@assessments_bp.delete("/assessments/<int:assessment_id>")
+@swag_from(assessment_delete_spec)
+def delete_assessment(assessment_id):
+    assessment = db.session.get(PatientAssessment, assessment_id)
+    if assessment is None:
+        return error_response("Assessment not found", 404)
+
+    db.session.delete(assessment)
+    db.session.commit()
+    return success_response(
+        {"id": assessment_id},
+        "Assessment deleted successfully",
+    )
+
+
+@assessments_bp.get("/patients/<int:patient_id>/assessments")
+@swag_from(patient_assessments_list_spec)
+def list_patient_assessments(patient_id):
+    patient = db.session.get(Patient, patient_id)
+    if patient is None:
+        return error_response("Patient not found", 404)
+
+    assessments = (
+        PatientAssessment.query.filter_by(patient_id=patient_id)
+        .order_by(
+            PatientAssessment.assessment_date.desc(),
+            PatientAssessment.id.desc(),
+        )
+        .all()
+    )
+    return success_response(
+        [assessment.to_dict() for assessment in assessments],
+        "Patient assessments retrieved successfully",
+    )
+
+
+@assessments_bp.get("/visits/<int:visit_id>/assessments")
+@swag_from(visit_assessments_list_spec)
+def list_visit_assessments(visit_id):
+    visit = db.session.get(Visit, visit_id)
+    if visit is None:
+        return error_response("Visit not found", 404)
+
+    assessments = (
+        PatientAssessment.query.filter_by(visit_id=visit_id)
+        .order_by(
+            PatientAssessment.assessment_date.desc(),
+            PatientAssessment.id.desc(),
+        )
+        .all()
+    )
+    return success_response(
+        [assessment.to_dict() for assessment in assessments],
+        "Visit assessments retrieved successfully",
+    )

--- a/backend/app/swagger.py
+++ b/backend/app/swagger.py
@@ -272,6 +272,68 @@ nurse_note_request_properties = {
     if key not in {"id", "created_at", "updated_at"}
 }
 
+assessment_findings_schema = {
+    "nullable": True,
+    "description": "Flexible JSON object or array containing assessment findings.",
+    "example": {
+        "risk_level": "moderate",
+        "observations": ["Uses walker", "Needs standby assistance"],
+    },
+}
+
+patient_assessment_properties = {
+    "id": {"type": "integer", "example": 1},
+    "patient_id": {"type": "integer", "example": 1},
+    "visit_id": {"type": "integer", "nullable": True, "example": 2},
+    "assessment_type": {
+        "type": "string",
+        "enum": ["fall_risk", "nutrition", "mobility", "cognitive", "general"],
+        "example": "fall_risk",
+    },
+    "assessment_date": {
+        "type": "string",
+        "format": "date",
+        "example": "2026-06-10",
+    },
+    "performed_by": {
+        "type": "string",
+        "nullable": True,
+        "example": "Jordan Lee, RN",
+    },
+    "summary": {
+        "type": "string",
+        "nullable": True,
+        "example": "Moderate fall risk identified during home visit.",
+    },
+    "findings": assessment_findings_schema,
+    "recommendations": {
+        "type": "string",
+        "nullable": True,
+        "example": "Continue walker use and clear the hallway.",
+    },
+    "status": {
+        "type": "string",
+        "enum": ["draft", "completed"],
+        "example": "completed",
+    },
+    "created_at": {
+        "type": "string",
+        "format": "date-time",
+        "example": "2026-06-10T10:00:00+00:00",
+    },
+    "updated_at": {
+        "type": "string",
+        "format": "date-time",
+        "example": "2026-06-10T10:00:00+00:00",
+    },
+}
+
+patient_assessment_request_properties = {
+    key: value
+    for key, value in patient_assessment_properties.items()
+    if key not in {"id", "created_at", "updated_at"}
+}
+
 dashboard_group_item_properties = {
     "label": {"type": "string", "example": "active"},
     "count": {"type": "integer", "example": 4},
@@ -462,6 +524,19 @@ swagger_template = {
             "type": "object",
             "properties": nurse_note_request_properties,
         },
+        "PatientAssessment": {
+            "type": "object",
+            "properties": patient_assessment_properties,
+        },
+        "PatientAssessmentCreate": {
+            "type": "object",
+            "required": ["patient_id", "assessment_type", "assessment_date"],
+            "properties": patient_assessment_request_properties,
+        },
+        "PatientAssessmentUpdate": {
+            "type": "object",
+            "properties": patient_assessment_request_properties,
+        },
         "MedicalRecord": {
             "type": "object",
             "properties": medical_record_properties,
@@ -595,6 +670,29 @@ swagger_template = {
                 "message": {
                     "type": "string",
                     "example": "Nurse notes retrieved successfully",
+                },
+            },
+        },
+        "PatientAssessmentResponse": {
+            "type": "object",
+            "properties": {
+                "data": {"$ref": "#/definitions/PatientAssessment"},
+                "message": {
+                    "type": "string",
+                    "example": "Assessment retrieved successfully",
+                },
+            },
+        },
+        "PatientAssessmentListResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/PatientAssessment"},
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Assessments retrieved successfully",
                 },
             },
         },
@@ -1570,6 +1668,165 @@ medical_record_download_spec = {
         },
         502: {
             "description": "Medical record storage is unavailable.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+assessment_list_spec = {
+    "tags": ["Patient Assessments"],
+    "summary": "List patient assessments",
+    "responses": {
+        200: {
+            "description": "Assessments retrieved successfully.",
+            "schema": {"$ref": "#/definitions/PatientAssessmentListResponse"},
+        }
+    },
+}
+
+assessment_get_spec = {
+    "tags": ["Patient Assessments"],
+    "summary": "Retrieve a patient assessment",
+    "parameters": [
+        {
+            "name": "assessment_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Assessment retrieved successfully.",
+            "schema": {"$ref": "#/definitions/PatientAssessmentResponse"},
+        },
+        404: {
+            "description": "Assessment not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+assessment_create_spec = {
+    "tags": ["Patient Assessments"],
+    "summary": "Create a patient assessment",
+    "parameters": [
+        {
+            "name": "body",
+            "in": "body",
+            "required": True,
+            "schema": {"$ref": "#/definitions/PatientAssessmentCreate"},
+        }
+    ],
+    "responses": {
+        201: {
+            "description": "Assessment created successfully.",
+            "schema": {"$ref": "#/definitions/PatientAssessmentResponse"},
+        },
+        400: {
+            "description": "Invalid assessment data.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+assessment_update_spec = {
+    "tags": ["Patient Assessments"],
+    "summary": "Update a patient assessment",
+    "parameters": [
+        {
+            "name": "assessment_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        },
+        {
+            "name": "body",
+            "in": "body",
+            "required": True,
+            "schema": {"$ref": "#/definitions/PatientAssessmentUpdate"},
+        },
+    ],
+    "responses": {
+        200: {
+            "description": "Assessment updated successfully.",
+            "schema": {"$ref": "#/definitions/PatientAssessmentResponse"},
+        },
+        400: {
+            "description": "Invalid assessment data.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+        404: {
+            "description": "Assessment not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+assessment_delete_spec = {
+    "tags": ["Patient Assessments"],
+    "summary": "Delete a patient assessment",
+    "parameters": [
+        {
+            "name": "assessment_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Assessment deleted successfully.",
+            "schema": {"$ref": "#/definitions/DeleteSuccessResponse"},
+        },
+        404: {
+            "description": "Assessment not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+patient_assessments_list_spec = {
+    "tags": ["Patient Assessments"],
+    "summary": "List assessments for a patient",
+    "parameters": [
+        {
+            "name": "patient_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Patient assessments retrieved successfully.",
+            "schema": {"$ref": "#/definitions/PatientAssessmentListResponse"},
+        },
+        404: {
+            "description": "Patient not found.",
+            "schema": {"$ref": "#/definitions/ErrorResponse"},
+        },
+    },
+}
+
+visit_assessments_list_spec = {
+    "tags": ["Patient Assessments"],
+    "summary": "List assessments for a visit",
+    "parameters": [
+        {
+            "name": "visit_id",
+            "in": "path",
+            "type": "integer",
+            "required": True,
+        }
+    ],
+    "responses": {
+        200: {
+            "description": "Visit assessments retrieved successfully.",
+            "schema": {"$ref": "#/definitions/PatientAssessmentListResponse"},
+        },
+        404: {
+            "description": "Visit not found.",
             "schema": {"$ref": "#/definitions/ErrorResponse"},
         },
     },

--- a/backend/migrations/versions/20260610_0007_create_patient_assessments_table.py
+++ b/backend/migrations/versions/20260610_0007_create_patient_assessments_table.py
@@ -1,0 +1,82 @@
+"""create patient assessments table
+
+Revision ID: 20260610_0007
+Revises: 20260610_0006
+Create Date: 2026-06-10 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260610_0007"
+down_revision = "20260610_0006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "patient_assessments",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("patient_id", sa.Integer(), nullable=False),
+        sa.Column("visit_id", sa.Integer(), nullable=True),
+        sa.Column("assessment_type", sa.String(length=50), nullable=False),
+        sa.Column("assessment_date", sa.Date(), nullable=False),
+        sa.Column("performed_by", sa.String(length=200), nullable=True),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("findings", sa.JSON(), nullable=True),
+        sa.Column("recommendations", sa.Text(), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            nullable=False,
+            server_default="draft",
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "assessment_type IN "
+            "('fall_risk', 'nutrition', 'mobility', 'cognitive', 'general')",
+            name="ck_patient_assessments_type",
+        ),
+        sa.CheckConstraint(
+            "status IN ('draft', 'completed')",
+            name="ck_patient_assessments_status",
+        ),
+        sa.ForeignKeyConstraint(
+            ["patient_id"],
+            ["patients.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["visit_id"],
+            ["visits.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_patient_assessments_patient_id"),
+        "patient_assessments",
+        ["patient_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_patient_assessments_visit_id"),
+        "patient_assessments",
+        ["visit_id"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(
+        op.f("ix_patient_assessments_visit_id"),
+        table_name="patient_assessments",
+    )
+    op.drop_index(
+        op.f("ix_patient_assessments_patient_id"),
+        table_name="patient_assessments",
+    )
+    op.drop_table("patient_assessments")

--- a/backend/tests/test_assessments.py
+++ b/backend/tests/test_assessments.py
@@ -1,0 +1,195 @@
+def create_patient(client, first_name="Maria", last_name="Santos"):
+    return client.post(
+        "/api/patients",
+        json={"first_name": first_name, "last_name": last_name},
+    ).get_json()["data"]
+
+
+def create_visit(client, patient_id):
+    return client.post(
+        "/api/visits",
+        json={
+            "patient_id": patient_id,
+            "visit_date": "2026-06-10",
+            "visit_type": "Skilled nursing visit",
+            "staff_role": "nurse",
+        },
+    ).get_json()["data"]
+
+
+def assessment_payload(patient_id, **overrides):
+    payload = {
+        "patient_id": patient_id,
+        "assessment_type": "fall_risk",
+        "assessment_date": "2026-06-10",
+        "performed_by": "Jordan Lee, RN",
+        "summary": "Moderate fall risk identified.",
+        "findings": {
+            "risk_level": "moderate",
+            "observations": ["Uses walker"],
+        },
+        "recommendations": "Continue walker use.",
+        "status": "completed",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def create_assessment(client, patient_id, **overrides):
+    return client.post(
+        "/api/assessments",
+        json=assessment_payload(patient_id, **overrides),
+    )
+
+
+def test_create_assessment(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+
+    response = create_assessment(client, patient["id"], visit_id=visit["id"])
+    body = response.get_json()
+
+    assert response.status_code == 201
+    assert body["message"] == "Assessment created successfully"
+    assert body["data"]["patient_id"] == patient["id"]
+    assert body["data"]["visit_id"] == visit["id"]
+    assert body["data"]["assessment_type"] == "fall_risk"
+    assert body["data"]["findings"]["risk_level"] == "moderate"
+
+
+def test_list_assessments(client):
+    patient = create_patient(client)
+    create_assessment(client, patient["id"])
+
+    response = client.get("/api/assessments")
+
+    assert response.status_code == 200
+    assert response.get_json()["message"] == "Assessments retrieved successfully"
+    assert len(response.get_json()["data"]) == 1
+
+
+def test_get_assessment(client):
+    patient = create_patient(client)
+    created = create_assessment(client, patient["id"]).get_json()["data"]
+
+    response = client.get(f"/api/assessments/{created['id']}")
+
+    assert response.status_code == 200
+    assert response.get_json()["data"]["id"] == created["id"]
+
+
+def test_update_assessment(client):
+    patient = create_patient(client)
+    created = create_assessment(client, patient["id"]).get_json()["data"]
+
+    response = client.put(
+        f"/api/assessments/{created['id']}",
+        json={
+            "assessment_type": "mobility",
+            "summary": "Mobility improved with supervision.",
+            "status": "draft",
+        },
+    )
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["message"] == "Assessment updated successfully"
+    assert body["data"]["assessment_type"] == "mobility"
+    assert body["data"]["status"] == "draft"
+
+
+def test_delete_assessment(client):
+    patient = create_patient(client)
+    created = create_assessment(client, patient["id"]).get_json()["data"]
+
+    response = client.delete(f"/api/assessments/{created['id']}")
+
+    assert response.status_code == 200
+    assert response.get_json()["message"] == "Assessment deleted successfully"
+    assert client.get(f"/api/assessments/{created['id']}").status_code == 404
+
+
+def test_list_assessments_for_patient(client):
+    patient = create_patient(client)
+    other_patient = create_patient(client, "John", "Rivera")
+    create_assessment(client, patient["id"])
+    create_assessment(client, other_patient["id"], assessment_type="nutrition")
+
+    response = client.get(f"/api/patients/{patient['id']}/assessments")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["message"] == "Patient assessments retrieved successfully"
+    assert len(body["data"]) == 1
+    assert body["data"][0]["patient_id"] == patient["id"]
+
+
+def test_list_assessments_for_visit(client):
+    patient = create_patient(client)
+    visit = create_visit(client, patient["id"])
+    other_visit = create_visit(client, patient["id"])
+    create_assessment(client, patient["id"], visit_id=visit["id"])
+    create_assessment(
+        client,
+        patient["id"],
+        visit_id=other_visit["id"],
+        assessment_type="general",
+    )
+
+    response = client.get(f"/api/visits/{visit['id']}/assessments")
+    body = response.get_json()
+
+    assert response.status_code == 200
+    assert body["message"] == "Visit assessments retrieved successfully"
+    assert len(body["data"]) == 1
+    assert body["data"][0]["visit_id"] == visit["id"]
+
+
+def test_create_assessment_rejects_invalid_patient(client):
+    response = create_assessment(client, 999)
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["patient_id"] == "Patient not found."
+
+
+def test_create_assessment_rejects_invalid_visit(client):
+    patient = create_patient(client)
+
+    response = create_assessment(client, patient["id"], visit_id=999)
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["visit_id"] == "Visit not found."
+
+
+def test_create_assessment_rejects_visit_for_different_patient(client):
+    patient = create_patient(client)
+    other_patient = create_patient(client, "John", "Rivera")
+    visit = create_visit(client, other_patient["id"])
+
+    response = create_assessment(client, patient["id"], visit_id=visit["id"])
+
+    assert response.status_code == 400
+    assert response.get_json()["errors"]["visit_id"] == (
+        "Visit does not belong to the selected patient."
+    )
+
+
+def test_create_assessment_requires_core_fields(client):
+    response = client.post("/api/assessments", json={})
+    errors = response.get_json()["errors"]
+
+    assert response.status_code == 400
+    assert errors["patient_id"] == "This field is required."
+    assert errors["assessment_type"] == "This field is required."
+    assert errors["assessment_date"] == "This field is required."
+
+
+def test_assessment_defaults_to_draft(client):
+    patient = create_patient(client)
+    payload = assessment_payload(patient["id"])
+    payload.pop("status")
+
+    response = client.post("/api/assessments", json=payload)
+
+    assert response.status_code == 201
+    assert response.get_json()["data"]["status"] == "draft"

--- a/backend/tests/test_openapi.py
+++ b/backend/tests/test_openapi.py
@@ -39,6 +39,10 @@ def test_openapi_json_includes_health_and_patient_endpoints(client):
     assert "/api/medical-records/{medical_record_id}/download" in paths
     assert "/api/patients/{patient_id}/photo" in paths
     assert "/api/patients/{patient_id}/photo/verify" in paths
+    assert "/api/assessments" in paths
+    assert "/api/assessments/{assessment_id}" in paths
+    assert "/api/patients/{patient_id}/assessments" in paths
+    assert "/api/visits/{visit_id}/assessments" in paths
     assert "get" in paths["/api/health"]
     assert "get" in paths["/api/dashboard/stats"]
     assert {"get", "post"} <= set(paths["/api/patients"].keys())
@@ -70,6 +74,12 @@ def test_openapi_json_includes_health_and_patient_endpoints(client):
         paths["/api/patients/{patient_id}/photo"].keys()
     )
     assert "patch" in paths["/api/patients/{patient_id}/photo/verify"]
+    assert {"get", "post"} <= set(paths["/api/assessments"].keys())
+    assert {"get", "put", "delete"} <= set(
+        paths["/api/assessments/{assessment_id}"].keys()
+    )
+    assert "get" in paths["/api/patients/{patient_id}/assessments"]
+    assert "get" in paths["/api/visits/{visit_id}/assessments"]
 
 
 def test_openapi_json_includes_patient_schemas(client):
@@ -106,3 +116,8 @@ def test_openapi_json_includes_patient_schemas(client):
     assert "MedicalRecordResponse" in definitions
     assert "MedicalRecordListResponse" in definitions
     assert "PatientPhotoVerification" in definitions
+    assert "PatientAssessment" in definitions
+    assert "PatientAssessmentCreate" in definitions
+    assert "PatientAssessmentUpdate" in definitions
+    assert "PatientAssessmentResponse" in definitions
+    assert "PatientAssessmentListResponse" in definitions

--- a/docs/architecture/api-design.md
+++ b/docs/architecture/api-design.md
@@ -1295,3 +1295,112 @@ Example response:
   "message": "Nurse note deleted successfully"
 }
 ```
+
+## Patient Assessments
+
+Patient assessments capture structured care findings for a patient and may
+optionally be linked to a visit. Supported assessment types are:
+
+- `fall_risk`
+- `nutrition`
+- `mobility`
+- `cognitive`
+- `general`
+
+Assessment status is `draft` by default and may be changed to `completed`.
+The `findings` field is stored as JSON so each assessment type can evolve
+without requiring a new database column for every observation.
+
+### Assessment Endpoints
+
+- `GET /api/assessments`
+- `GET /api/assessments/<id>`
+- `POST /api/assessments`
+- `PUT /api/assessments/<id>`
+- `DELETE /api/assessments/<id>`
+- `GET /api/patients/<patient_id>/assessments`
+- `GET /api/visits/<visit_id>/assessments`
+
+### Create an Assessment
+
+`POST /api/assessments`
+
+Example request:
+
+```json
+{
+  "patient_id": 1,
+  "visit_id": 4,
+  "assessment_type": "fall_risk",
+  "assessment_date": "2026-06-10",
+  "performed_by": "Jordan Lee, RN",
+  "summary": "Moderate fall risk identified during the home visit.",
+  "findings": {
+    "risk_level": "moderate",
+    "observations": [
+      "Uses walker",
+      "Needs standby assistance"
+    ]
+  },
+  "recommendations": "Continue walker use and clear the hallway.",
+  "status": "completed"
+}
+```
+
+Example response:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "patient_id": 1,
+    "visit_id": 4,
+    "assessment_type": "fall_risk",
+    "assessment_date": "2026-06-10",
+    "performed_by": "Jordan Lee, RN",
+    "summary": "Moderate fall risk identified during the home visit.",
+    "findings": {
+      "risk_level": "moderate",
+      "observations": [
+        "Uses walker",
+        "Needs standby assistance"
+      ]
+    },
+    "recommendations": "Continue walker use and clear the hallway.",
+    "status": "completed",
+    "created_at": "2026-06-10T10:00:00+00:00",
+    "updated_at": "2026-06-10T10:00:00+00:00"
+  },
+  "message": "Assessment created successfully"
+}
+```
+
+`patient_id`, `assessment_type`, and `assessment_date` are required. When a
+`visit_id` is supplied, the visit must exist and belong to the selected
+patient.
+
+### Update an Assessment
+
+`PUT /api/assessments/<id>`
+
+Example request:
+
+```json
+{
+  "summary": "Fall risk reduced after environmental changes.",
+  "status": "completed"
+}
+```
+
+### List Assessments for a Patient
+
+`GET /api/patients/<patient_id>/assessments`
+
+Assessments are returned newest assessment date first.
+
+### List Assessments for a Visit
+
+`GET /api/visits/<visit_id>/assessments`
+
+This endpoint returns all assessments linked to the visit. A visit can have
+multiple assessment types.

--- a/frontend/src/components/PatientAssessmentsSection.js
+++ b/frontend/src/components/PatientAssessmentsSection.js
@@ -1,0 +1,187 @@
+import { onMounted, ref } from "vue";
+
+import {
+  deleteAssessment,
+  getPatientAssessments,
+} from "../services/assessments.js";
+
+
+const assessmentLabels = {
+  fall_risk: "Fall risk",
+  nutrition: "Nutrition",
+  mobility: "Mobility",
+  cognitive: "Cognitive",
+  general: "General",
+};
+
+export default {
+  props: {
+    patientId: {
+      type: Number,
+      required: true,
+    },
+  },
+  setup(props) {
+    const assessments = ref([]);
+    const loading = ref(true);
+    const error = ref("");
+    const success = ref("");
+    const confirmDelete = ref(false);
+    const deleting = ref(false);
+    const selectedAssessment = ref(null);
+
+    const headers = [
+      { title: "Date", key: "assessment_date" },
+      { title: "Type", key: "assessment_type" },
+      { title: "Performed by", key: "performed_by" },
+      { title: "Status", key: "status" },
+      { title: "Actions", key: "actions", sortable: false },
+    ];
+
+    async function loadAssessments() {
+      loading.value = true;
+      error.value = "";
+      try {
+        const response = await getPatientAssessments(props.patientId);
+        assessments.value = response.data;
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    function askDelete(assessment) {
+      selectedAssessment.value = assessment;
+      confirmDelete.value = true;
+    }
+
+    async function removeAssessment() {
+      if (!selectedAssessment.value) return;
+
+      deleting.value = true;
+      error.value = "";
+      success.value = "";
+      try {
+        await deleteAssessment(selectedAssessment.value.id);
+        confirmDelete.value = false;
+        selectedAssessment.value = null;
+        success.value = "Assessment deleted successfully.";
+        await loadAssessments();
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        deleting.value = false;
+      }
+    }
+
+    function assessmentLabel(value) {
+      return assessmentLabels[value] || value;
+    }
+
+    onMounted(loadAssessments);
+
+    return {
+      assessmentLabel,
+      assessments,
+      askDelete,
+      confirmDelete,
+      deleting,
+      error,
+      headers,
+      loading,
+      removeAssessment,
+      selectedAssessment,
+      success,
+    };
+  },
+  template: `
+    <SectionCard
+      title="Assessments"
+      subtitle="Structured clinical and care assessments for this patient."
+      icon="mdi-clipboard-text-search-outline"
+      class="data-card mb-6"
+    >
+      <div class="d-flex flex-wrap justify-end ga-3 mb-4">
+        <v-btn
+          color="primary"
+          prepend-icon="mdi-clipboard-plus-outline"
+          :to="\`/assessments/new?patient_id=\${patientId}\`"
+        >
+          New assessment
+        </v-btn>
+      </div>
+
+      <ErrorAlert :message="error" />
+      <v-alert v-if="success" type="success" variant="tonal" class="mb-4">
+        {{ success }}
+      </v-alert>
+
+      <LoadingState v-if="loading" label="Loading assessments" />
+
+      <v-data-table
+        v-else
+        :headers="headers"
+        :items="assessments"
+        item-value="id"
+      >
+        <template #no-data>
+          <EmptyState
+            icon="mdi-clipboard-text-outline"
+            title="No assessments yet"
+            message="Create the first structured assessment for this patient."
+          >
+            <v-btn
+              color="primary"
+              :to="\`/assessments/new?patient_id=\${patientId}\`"
+            >
+              Create assessment
+            </v-btn>
+          </EmptyState>
+        </template>
+
+        <template #[\`item.assessment_type\`]="{ item }">
+          {{ assessmentLabel(item.assessment_type) }}
+        </template>
+
+        <template #[\`item.performed_by\`]="{ item }">
+          {{ item.performed_by || 'Not provided' }}
+        </template>
+
+        <template #[\`item.status\`]="{ item }">
+          <StatusChip :status="item.status" />
+        </template>
+
+        <template #[\`item.actions\`]="{ item }">
+          <v-btn
+            icon="mdi-eye-outline"
+            variant="text"
+            :to="\`/assessments/\${item.id}\`"
+            aria-label="View assessment"
+          />
+          <v-btn
+            icon="mdi-pencil-outline"
+            variant="text"
+            :to="\`/assessments/\${item.id}/edit\`"
+            aria-label="Edit assessment"
+          />
+          <v-btn
+            icon="mdi-delete-outline"
+            variant="text"
+            color="error"
+            aria-label="Delete assessment"
+            @click="askDelete(item)"
+          />
+        </template>
+      </v-data-table>
+
+      <ConfirmDialog
+        v-model="confirmDelete"
+        title="Delete assessment"
+        :message="\`Delete this \${assessmentLabel(selectedAssessment?.assessment_type || '')} assessment?\`"
+        :loading="deleting"
+        @confirm="removeAssessment"
+      />
+    </SectionCard>
+  `,
+};

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -1,6 +1,8 @@
 import { createRouter, createWebHistory } from "vue-router";
 
 import DashboardView from "./views/DashboardView.js";
+import AssessmentDetailView from "./views/AssessmentDetailView.js";
+import AssessmentFormView from "./views/AssessmentFormView.js";
 import AideNoteDetailView from "./views/AideNoteDetailView.js";
 import AideNoteFormView from "./views/AideNoteFormView.js";
 import AideNoteListView from "./views/AideNoteListView.js";
@@ -41,6 +43,24 @@ const routes = [
     path: "/patients/:id/edit",
     name: "patient-edit",
     component: PatientFormView,
+    props: { mode: "edit" },
+  },
+  {
+    path: "/assessments/new",
+    name: "assessment-create",
+    component: AssessmentFormView,
+    props: { mode: "create" },
+  },
+  {
+    path: "/assessments/:id",
+    name: "assessment-detail",
+    component: AssessmentDetailView,
+    props: true,
+  },
+  {
+    path: "/assessments/:id/edit",
+    name: "assessment-edit",
+    component: AssessmentFormView,
     props: { mode: "edit" },
   },
   {

--- a/frontend/src/services/assessments.js
+++ b/frontend/src/services/assessments.js
@@ -1,0 +1,38 @@
+import { apiRequest } from "./http.js";
+
+
+export async function listAssessments() {
+  return apiRequest("/assessments");
+}
+
+export async function getAssessment(id) {
+  return apiRequest(`/assessments/${id}`);
+}
+
+export async function createAssessment(assessment) {
+  return apiRequest("/assessments", {
+    method: "POST",
+    body: JSON.stringify(assessment),
+  });
+}
+
+export async function updateAssessment(id, assessment) {
+  return apiRequest(`/assessments/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(assessment),
+  });
+}
+
+export async function deleteAssessment(id) {
+  return apiRequest(`/assessments/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export async function getPatientAssessments(patientId) {
+  return apiRequest(`/patients/${patientId}/assessments`);
+}
+
+export async function getVisitAssessments(visitId) {
+  return apiRequest(`/visits/${visitId}/assessments`);
+}

--- a/frontend/src/views/AssessmentDetailView.js
+++ b/frontend/src/views/AssessmentDetailView.js
@@ -1,0 +1,167 @@
+import { computed, onMounted, ref } from "vue";
+
+import { getAssessment } from "../services/assessments.js";
+import { getPatient } from "../services/patients.js";
+import { getVisit } from "../services/visits.js";
+
+
+const assessmentLabels = {
+  fall_risk: "Fall risk",
+  nutrition: "Nutrition",
+  mobility: "Mobility",
+  cognitive: "Cognitive",
+  general: "General",
+};
+
+export default {
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    const assessment = ref(null);
+    const patient = ref(null);
+    const visit = ref(null);
+    const loading = ref(true);
+    const error = ref("");
+
+    const patientName = computed(() =>
+      patient.value
+        ? `${patient.value.first_name} ${patient.value.last_name}`
+        : "Patient"
+    );
+    const title = computed(() =>
+      assessment.value
+        ? `${assessmentLabels[assessment.value.assessment_type] || assessment.value.assessment_type} assessment`
+        : "Assessment"
+    );
+    const findingRows = computed(() => {
+      const findings = assessment.value?.findings;
+      if (!findings) return [];
+      if (Array.isArray(findings)) {
+        return findings.map((value, index) => ({
+          label: `Item ${index + 1}`,
+          value: typeof value === "object" ? JSON.stringify(value) : String(value),
+        }));
+      }
+      return Object.entries(findings).map(([key, value]) => ({
+        label: key.replaceAll("_", " "),
+        value: typeof value === "object" ? JSON.stringify(value) : String(value),
+      }));
+    });
+
+    async function loadAssessment() {
+      loading.value = true;
+      error.value = "";
+      try {
+        const assessmentResponse = await getAssessment(props.id);
+        assessment.value = assessmentResponse.data;
+
+        const requests = [getPatient(assessment.value.patient_id)];
+        if (assessment.value.visit_id) {
+          requests.push(getVisit(assessment.value.visit_id));
+        }
+        const [patientResponse, visitResponse] = await Promise.all(requests);
+        patient.value = patientResponse.data;
+        visit.value = visitResponse?.data || null;
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    onMounted(loadAssessment);
+
+    return {
+      assessment,
+      error,
+      findingRows,
+      loading,
+      patientName,
+      title,
+      visit,
+    };
+  },
+  template: `
+    <div class="page-shell">
+      <v-btn
+        variant="text"
+        prepend-icon="mdi-arrow-left"
+        :to="assessment ? \`/patients/\${assessment.patient_id}\` : '/patients'"
+        class="mb-4"
+      >
+        Patient record
+      </v-btn>
+
+      <ErrorAlert :message="error" />
+      <LoadingState v-if="loading" label="Loading assessment" />
+
+      <template v-else-if="assessment">
+        <PageHeader
+          :title="title"
+          :subtitle="\`\${patientName} · \${assessment.assessment_date}\`"
+          icon="mdi-clipboard-text-search-outline"
+        >
+          <template #actions>
+            <v-btn
+              color="primary"
+              prepend-icon="mdi-pencil-outline"
+              :to="\`/assessments/\${assessment.id}/edit\`"
+            >
+              Edit assessment
+            </v-btn>
+          </template>
+        </PageHeader>
+
+        <v-row class="mb-5">
+          <v-col cols="12" md="6">
+            <SectionCard title="Assessment details" icon="mdi-information-outline">
+              <v-list>
+                <v-list-item title="Patient" :subtitle="patientName" :to="\`/patients/\${assessment.patient_id}\`" />
+                <v-list-item
+                  title="Related visit"
+                  :subtitle="visit ? \`\${visit.visit_date} · \${visit.visit_type}\` : 'Not linked to a visit'"
+                  :to="visit ? \`/visits/\${visit.id}\` : undefined"
+                />
+                <v-list-item title="Performed by" :subtitle="assessment.performed_by || 'Not provided'" />
+                <v-list-item title="Assessment date" :subtitle="assessment.assessment_date" />
+              </v-list>
+              <StatusChip :status="assessment.status" class="ma-4 mt-0" />
+            </SectionCard>
+          </v-col>
+          <v-col cols="12" md="6">
+            <SectionCard title="Summary" icon="mdi-text-box-outline">
+              <div class="text-body-1 mb-5">
+                {{ assessment.summary || 'No summary provided.' }}
+              </div>
+              <div class="text-subtitle-1 font-weight-medium mb-2">Recommendations</div>
+              <div class="text-body-1">
+                {{ assessment.recommendations || 'No recommendations provided.' }}
+              </div>
+            </SectionCard>
+          </v-col>
+        </v-row>
+
+        <SectionCard title="Findings" icon="mdi-magnify-scan">
+          <EmptyState
+            v-if="!findingRows.length"
+            icon="mdi-clipboard-text-outline"
+            title="No findings recorded"
+            message="Edit this assessment to add structured findings."
+          />
+          <v-list v-else lines="two">
+            <v-list-item
+              v-for="finding in findingRows"
+              :key="finding.label"
+              :title="finding.label"
+              :subtitle="finding.value"
+            />
+          </v-list>
+        </SectionCard>
+      </template>
+    </div>
+  `,
+};

--- a/frontend/src/views/AssessmentFormView.js
+++ b/frontend/src/views/AssessmentFormView.js
@@ -1,0 +1,303 @@
+import { computed, onMounted, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+
+import {
+  createAssessment,
+  getAssessment,
+  updateAssessment,
+} from "../services/assessments.js";
+import { listPatients } from "../services/patients.js";
+import { getVisit, listVisits } from "../services/visits.js";
+
+
+const emptyForm = () => ({
+  patient_id: null,
+  visit_id: null,
+  assessment_type: "general",
+  assessment_date: new Date().toISOString().slice(0, 10),
+  performed_by: "",
+  summary: "",
+  findings: "{}",
+  recommendations: "",
+  status: "draft",
+});
+
+export default {
+  props: {
+    mode: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    const route = useRoute();
+    const router = useRouter();
+    const form = ref(emptyForm());
+    const patients = ref([]);
+    const visits = ref([]);
+    const loading = ref(true);
+    const saving = ref(false);
+    const error = ref("");
+    const errors = ref({});
+
+    const isEdit = computed(() => props.mode === "edit");
+    const title = computed(() =>
+      isEdit.value ? "Edit assessment" : "New assessment"
+    );
+    const patientOptions = computed(() =>
+      patients.value.map((patient) => ({
+        title: `${patient.first_name} ${patient.last_name}`,
+        value: patient.id,
+      }))
+    );
+    const visitOptions = computed(() =>
+      visits.value
+        .filter((visit) => visit.patient_id === Number(form.value.patient_id))
+        .map((visit) => ({
+          title: `${visit.visit_date} · ${visit.visit_type}`,
+          value: visit.id,
+        }))
+    );
+    const assessmentTypes = [
+      { title: "Fall risk", value: "fall_risk" },
+      { title: "Nutrition", value: "nutrition" },
+      { title: "Mobility", value: "mobility" },
+      { title: "Cognitive", value: "cognitive" },
+      { title: "General", value: "general" },
+    ];
+    const statusOptions = [
+      { title: "Draft", value: "draft" },
+      { title: "Completed", value: "completed" },
+    ];
+
+    function validate() {
+      const nextErrors = {};
+      if (!form.value.patient_id) nextErrors.patient_id = "Patient is required.";
+      if (!form.value.assessment_type) {
+        nextErrors.assessment_type = "Assessment type is required.";
+      }
+      if (!form.value.assessment_date) {
+        nextErrors.assessment_date = "Assessment date is required.";
+      }
+
+      try {
+        const findings = JSON.parse(form.value.findings || "{}");
+        if (
+          findings !== null &&
+          typeof findings !== "object"
+        ) {
+          nextErrors.findings = "Findings must be a JSON object or array.";
+        }
+      } catch {
+        nextErrors.findings = "Enter valid JSON findings.";
+      }
+
+      errors.value = nextErrors;
+      return Object.keys(nextErrors).length === 0;
+    }
+
+    function payload() {
+      return {
+        patient_id: Number(form.value.patient_id),
+        visit_id: form.value.visit_id ? Number(form.value.visit_id) : null,
+        assessment_type: form.value.assessment_type,
+        assessment_date: form.value.assessment_date,
+        performed_by: form.value.performed_by || null,
+        summary: form.value.summary || null,
+        findings: JSON.parse(form.value.findings || "{}"),
+        recommendations: form.value.recommendations || null,
+        status: form.value.status,
+      };
+    }
+
+    async function loadForm() {
+      loading.value = true;
+      error.value = "";
+      try {
+        const [patientResponse, visitResponse] = await Promise.all([
+          listPatients(),
+          listVisits(),
+        ]);
+        patients.value = patientResponse.data;
+        visits.value = visitResponse.data;
+
+        if (isEdit.value) {
+          const response = await getAssessment(route.params.id);
+          const assessment = response.data;
+          form.value = {
+            ...emptyForm(),
+            ...assessment,
+            findings: JSON.stringify(assessment.findings || {}, null, 2),
+          };
+        } else if (route.query.visit_id) {
+          const response = await getVisit(route.query.visit_id);
+          form.value.patient_id = response.data.patient_id;
+          form.value.visit_id = response.data.id;
+          form.value.assessment_date = response.data.visit_date;
+          form.value.performed_by = response.data.staff_name || "";
+        } else if (route.query.patient_id) {
+          form.value.patient_id = Number(route.query.patient_id);
+        }
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    async function submit() {
+      error.value = "";
+      if (!validate()) return;
+
+      saving.value = true;
+      try {
+        const response = isEdit.value
+          ? await updateAssessment(route.params.id, payload())
+          : await createAssessment(payload());
+        await router.push(`/assessments/${response.data.id}`);
+      } catch (err) {
+        error.value = err.message;
+        errors.value = err.payload?.errors || errors.value;
+      } finally {
+        saving.value = false;
+      }
+    }
+
+    watch(
+      () => form.value.patient_id,
+      (patientId, previousPatientId) => {
+        if (
+          previousPatientId &&
+          patientId !== previousPatientId &&
+          !visitOptions.value.some((visit) => visit.value === form.value.visit_id)
+        ) {
+          form.value.visit_id = null;
+        }
+      }
+    );
+
+    onMounted(loadForm);
+
+    return {
+      assessmentTypes,
+      error,
+      errors,
+      form,
+      isEdit,
+      loading,
+      patientOptions,
+      saving,
+      statusOptions,
+      submit,
+      title,
+      visitOptions,
+    };
+  },
+  template: `
+    <div class="page-shell">
+      <v-btn variant="text" prepend-icon="mdi-arrow-left" :to="form.patient_id ? \`/patients/\${form.patient_id}\` : '/patients'" class="mb-4">
+        Patient record
+      </v-btn>
+
+      <PageHeader
+        :title="title"
+        subtitle="Record structured findings and practical care recommendations."
+        icon="mdi-clipboard-text-search-outline"
+      />
+
+      <ErrorAlert :message="error" />
+      <LoadingState v-if="loading" label="Loading assessment" />
+
+      <v-form v-else @submit.prevent="submit">
+        <SectionCard title="Assessment details" icon="mdi-clipboard-outline" class="mb-5">
+          <v-row>
+            <v-col cols="12" md="6">
+              <v-select
+                v-model="form.patient_id"
+                label="Patient *"
+                :items="patientOptions"
+                :error-messages="errors.patient_id"
+                required
+              />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-select
+                v-model="form.visit_id"
+                label="Related visit"
+                :items="visitOptions"
+                clearable
+                hint="Optional. Only visits for the selected patient are shown."
+                persistent-hint
+                :error-messages="errors.visit_id"
+              />
+            </v-col>
+            <v-col cols="12" md="4">
+              <v-select
+                v-model="form.assessment_type"
+                label="Assessment type *"
+                :items="assessmentTypes"
+                :error-messages="errors.assessment_type"
+                required
+              />
+            </v-col>
+            <v-col cols="12" md="4">
+              <v-text-field
+                v-model="form.assessment_date"
+                label="Assessment date *"
+                type="date"
+                :error-messages="errors.assessment_date"
+                required
+              />
+            </v-col>
+            <v-col cols="12" md="4">
+              <v-select
+                v-model="form.status"
+                label="Status"
+                :items="statusOptions"
+                :error-messages="errors.status"
+              />
+            </v-col>
+            <v-col cols="12">
+              <v-text-field
+                v-model="form.performed_by"
+                label="Performed by"
+                placeholder="Name and role"
+              />
+            </v-col>
+          </v-row>
+        </SectionCard>
+
+        <SectionCard title="Clinical notes" icon="mdi-text-box-outline" class="mb-5">
+          <v-textarea
+            v-model="form.summary"
+            label="Summary"
+            rows="3"
+          />
+          <v-textarea
+            v-model="form.findings"
+            label="Findings (JSON)"
+            rows="8"
+            class="font-monospace"
+            hint='Use a flexible object, for example {"risk_level":"moderate","observations":["Uses walker"]}.'
+            persistent-hint
+            :error-messages="errors.findings"
+          />
+          <v-textarea
+            v-model="form.recommendations"
+            label="Recommendations"
+            rows="4"
+          />
+        </SectionCard>
+
+        <div class="d-flex flex-wrap justify-end ga-3">
+          <v-btn variant="text" :to="form.patient_id ? \`/patients/\${form.patient_id}\` : '/patients'">
+            Cancel
+          </v-btn>
+          <v-btn color="primary" type="submit" :loading="saving" prepend-icon="mdi-content-save-outline">
+            {{ isEdit ? 'Save changes' : 'Create assessment' }}
+          </v-btn>
+        </div>
+      </v-form>
+    </div>
+  `,
+};

--- a/frontend/src/views/PatientDetailView.js
+++ b/frontend/src/views/PatientDetailView.js
@@ -2,6 +2,7 @@ import { computed, onMounted, ref } from "vue";
 
 import MedicalRecordsSection from "../components/MedicalRecordsSection.js";
 import PatientAvatar from "../components/PatientAvatar.js";
+import PatientAssessmentsSection from "../components/PatientAssessmentsSection.js";
 import {
   deletePatientPhoto,
   getPatient,
@@ -14,6 +15,7 @@ export default {
   components: {
     MedicalRecordsSection,
     PatientAvatar,
+    PatientAssessmentsSection,
   },
   props: {
     id: {
@@ -282,6 +284,7 @@ export default {
         </v-row>
 
         <MedicalRecordsSection :patient-id="patient.id" />
+        <PatientAssessmentsSection :patient-id="patient.id" />
 
         <v-card>
           <v-card-title>Visits</v-card-title>

--- a/frontend/src/views/VisitDetailView.js
+++ b/frontend/src/views/VisitDetailView.js
@@ -1,10 +1,19 @@
 import { computed, onMounted, ref } from "vue";
 
 import PatientAvatar from "../components/PatientAvatar.js";
+import { getVisitAssessments } from "../services/assessments.js";
 import { getVisitAideNote } from "../services/aideNotes.js";
 import { getVisitNurseNote } from "../services/nurseNotes.js";
 import { listPatients } from "../services/patients.js";
 import { getVisit } from "../services/visits.js";
+
+const assessmentLabels = {
+  fall_risk: "Fall risk",
+  nutrition: "Nutrition",
+  mobility: "Mobility",
+  cognitive: "Cognitive",
+  general: "General",
+};
 
 export default {
   components: {
@@ -20,6 +29,7 @@ export default {
     const visit = ref(null);
     const aideNote = ref(null);
     const nurseNote = ref(null);
+    const assessments = ref([]);
     const patients = ref([]);
     const loading = ref(true);
     const error = ref("");
@@ -40,12 +50,15 @@ export default {
       error.value = "";
 
       try {
-        const [visitResponse, patientResponse] = await Promise.all([
+        const [visitResponse, patientResponse, assessmentResponse] =
+          await Promise.all([
           getVisit(props.id),
           listPatients(),
+          getVisitAssessments(props.id),
         ]);
         visit.value = visitResponse.data;
         patients.value = patientResponse.data;
+        assessments.value = assessmentResponse.data;
 
         try {
           const aideNoteResponse = await getVisitAideNote(props.id);
@@ -77,6 +90,8 @@ export default {
 
     return {
       aideNote,
+      assessments,
+      assessmentLabels,
       error,
       loading,
       nurseNote,
@@ -163,6 +178,14 @@ export default {
             >
               Edit Nurse Note
             </v-btn>
+            <v-btn
+              color="secondary"
+              variant="tonal"
+              prepend-icon="mdi-clipboard-text-search-outline"
+              :to="\`/assessments/new?visit_id=\${visit.id}\`"
+            >
+              New assessment
+            </v-btn>
             <v-btn color="primary" prepend-icon="mdi-pencil-outline" :to="\`/visits/\${visit.id}/edit\`">
               Edit visit
             </v-btn>
@@ -214,6 +237,40 @@ export default {
             </v-card>
           </v-col>
         </v-row>
+
+        <SectionCard
+          title="Visit assessments"
+          subtitle="Assessments linked directly to this visit."
+          icon="mdi-clipboard-text-search-outline"
+          class="mt-5"
+        >
+          <EmptyState
+            v-if="!assessments.length"
+            icon="mdi-clipboard-text-outline"
+            title="No linked assessments"
+            message="Create an assessment with this patient and visit already selected."
+          >
+            <v-btn
+              color="primary"
+              :to="\`/assessments/new?visit_id=\${visit.id}\`"
+            >
+              Create assessment
+            </v-btn>
+          </EmptyState>
+          <v-list v-else lines="two">
+            <v-list-item
+              v-for="assessment in assessments"
+              :key="assessment.id"
+              :title="assessmentLabels[assessment.assessment_type] || assessment.assessment_type"
+              :subtitle="\`\${assessment.assessment_date} · \${assessment.performed_by || 'Performer not provided'}\`"
+              :to="\`/assessments/\${assessment.id}\`"
+            >
+              <template #append>
+                <StatusChip :status="assessment.status" />
+              </template>
+            </v-list-item>
+          </v-list>
+        </SectionCard>
       </template>
     </div>
   `,


### PR DESCRIPTION
# Summary

- Add patient and optional visit-linked structured assessments.
- Provide assessment CRUD, patient/visit list endpoints, validation, migration, Swagger schemas, and backend tests.
- Add patient-detail assessment management plus create, view, edit, delete, and visit-preselection frontend workflows.
- Store flexible assessment findings as JSON while constraining the first supported assessment types and statuses.

## Related Issue / Task

- Feature: `18-patient-assessments`

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `docker-compose exec -T backend ruff check .`
- `docker-compose exec -T backend pytest` (86 passed)
- `npm run build`
- `docker-compose config --quiet`
- `docker-compose build backend frontend`
- `docker-compose exec -T backend flask --app run:app db upgrade`
- Browser verification for patient assessment list, create, detail, edit preload, and visit preselection

## Screenshots

- Patient Detail assessment section, populated assessment list, assessment form, and assessment detail views were captured during local browser verification.

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.
