### PR TITLE
feat: add printable reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added print-friendly patient, visit, aide note, nurse note, and assessment reports with reusable report components and browser print/PDF styling.
 - Added patient assessments with optional visit linkage, structured JSON findings, CRUD APIs, Swagger documentation, backend tests, and patient/visit frontend workflows.
 - Added private MinIO-backed patient profile photos with upload, preview, verification, deletion, safe API metadata, and initials fallback across patient and visit screens.
 - Added patient Medical Records with private MinIO file storage, PostgreSQL metadata, upload/download CRUD APIs, Swagger documentation, tests, and Patient Detail UI integration.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ GitHub Actions runs basic checks on pull requests and pushes to `main`:
 - Frontend CI installs Node dependencies from the lockfile and runs the Vite build.
 - Docker Build validates the Compose file and builds the backend and frontend images without pushing them.
 
+## Printable Reports
+
+Print-friendly reports are available from the detail pages for patients,
+visits, aide notes, nurse notes, and patient assessments. Use the report's
+`Print / Save PDF` action to open the browser print dialog, then select a
+printer or choose the browser's PDF destination.
+
+Printable patient summaries include recent visits, assessments, and medical
+record metadata. Uploaded medical record files are referenced by name and are
+not embedded in reports.
+
 ## Development Workflow
 
 - Start new work from an up-to-date `main` branch.

--- a/frontend/src/components/ChecklistSummary.js
+++ b/frontend/src/components/ChecklistSummary.js
@@ -1,0 +1,63 @@
+function titleize(value) {
+  return String(value)
+    .replaceAll("_", " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function formatValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => formatValue(item)).join(", ");
+  }
+  if (value && typeof value === "object") {
+    return Object.entries(value)
+      .map(([key, item]) => `${titleize(key)}: ${formatValue(item)}`)
+      .join("; ");
+  }
+  if (value === true) return "Yes";
+  if (value === false) return "No";
+  return value === null || value === undefined || value === ""
+    ? "Not documented"
+    : String(value);
+}
+
+export default {
+  props: {
+    data: {
+      type: [Object, Array],
+      default: null,
+    },
+    emptyText: {
+      type: String,
+      default: "Not documented",
+    },
+  },
+  computed: {
+    entries() {
+      if (!this.data) return [];
+      if (Array.isArray(this.data)) {
+        return this.data.map((value, index) => ({
+          label: `Item ${index + 1}`,
+          value: formatValue(value),
+        }));
+      }
+      return Object.entries(this.data)
+        .filter(([, value]) => value !== null && value !== "" && value !== undefined)
+        .map(([key, value]) => ({
+          label: titleize(key),
+          value: formatValue(value),
+        }));
+    },
+  },
+  template: `
+    <div v-if="entries.length" class="checklist-summary">
+      <div v-for="entry in entries" :key="entry.label" class="checklist-summary__item">
+        <span class="checklist-summary__check">[x]</span>
+        <div>
+          <strong>{{ entry.label }}</strong>
+          <span>{{ entry.value }}</span>
+        </div>
+      </div>
+    </div>
+    <p v-else class="print-empty">{{ emptyText }}</p>
+  `,
+};

--- a/frontend/src/components/PrintField.js
+++ b/frontend/src/components/PrintField.js
@@ -1,0 +1,25 @@
+export default {
+  props: {
+    label: {
+      type: String,
+      required: true,
+    },
+    value: {
+      type: [String, Number, Boolean],
+      default: "",
+    },
+  },
+  computed: {
+    displayValue() {
+      if (this.value === true) return "Yes";
+      if (this.value === false) return "No";
+      return this.value || "Not provided";
+    },
+  },
+  template: `
+    <div class="print-field">
+      <div class="print-field__label">{{ label }}</div>
+      <div class="print-field__value">{{ displayValue }}</div>
+    </div>
+  `,
+};

--- a/frontend/src/components/PrintPageLayout.js
+++ b/frontend/src/components/PrintPageLayout.js
@@ -1,0 +1,56 @@
+export default {
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    subtitle: {
+      type: String,
+      default: "",
+    },
+    backTo: {
+      type: String,
+      required: true,
+    },
+    documentLabel: {
+      type: String,
+      default: "SeniorMate",
+    },
+  },
+  methods: {
+    printReport() {
+      window.print();
+    },
+  },
+  template: `
+    <div class="print-page">
+      <div class="print-actions">
+        <v-btn variant="text" prepend-icon="mdi-arrow-left" :to="backTo">
+          Back
+        </v-btn>
+        <v-btn color="primary" prepend-icon="mdi-printer-outline" @click="printReport">
+          Print / Save PDF
+        </v-btn>
+      </div>
+
+      <article class="print-document">
+        <header class="print-document__header">
+          <div>
+            <div class="print-document__brand">{{ documentLabel }}</div>
+            <h1 class="print-document__title">{{ title }}</h1>
+            <p v-if="subtitle" class="print-document__subtitle">{{ subtitle }}</p>
+          </div>
+          <div class="print-document__mark">
+            <v-icon icon="mdi-heart-pulse" size="28" />
+          </div>
+        </header>
+
+        <slot />
+
+        <footer class="print-document__footer">
+          Generated from SeniorMate
+        </footer>
+      </article>
+    </div>
+  `,
+};

--- a/frontend/src/components/PrintSection.js
+++ b/frontend/src/components/PrintSection.js
@@ -1,0 +1,23 @@
+export default {
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    subtitle: {
+      type: String,
+      default: "",
+    },
+  },
+  template: `
+    <section class="print-section">
+      <div class="print-section__heading">
+        <h2>{{ title }}</h2>
+        <p v-if="subtitle">{{ subtitle }}</p>
+      </div>
+      <div class="print-section__body">
+        <slot />
+      </div>
+    </section>
+  `,
+};

--- a/frontend/src/components/SignatureBlock.js
+++ b/frontend/src/components/SignatureBlock.js
@@ -1,0 +1,29 @@
+export default {
+  props: {
+    name: {
+      type: String,
+      default: "",
+    },
+    date: {
+      type: String,
+      default: "",
+    },
+    signatureData: {
+      type: String,
+      default: "",
+    },
+    roleLabel: {
+      type: String,
+      default: "Staff name",
+    },
+  },
+  template: `
+    <div class="signature-block">
+      <PrintField :label="roleLabel" :value="name" />
+      <PrintField label="Signature date" :value="date" />
+      <div class="signature-block__line">
+        {{ signatureData || 'Signature on file: not provided' }}
+      </div>
+    </div>
+  `,
+};

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -9,12 +9,17 @@ import * as directives from "vuetify/directives";
 import { aliases, mdi } from "vuetify/iconsets/mdi";
 
 import App from "./views/App.js";
+import ChecklistSummary from "./components/ChecklistSummary.js";
 import ConfirmDialog from "./components/ConfirmDialog.js";
 import EmptyState from "./components/EmptyState.js";
 import ErrorAlert from "./components/ErrorAlert.js";
 import LoadingState from "./components/LoadingState.js";
 import PageHeader from "./components/PageHeader.js";
+import PrintField from "./components/PrintField.js";
+import PrintPageLayout from "./components/PrintPageLayout.js";
+import PrintSection from "./components/PrintSection.js";
 import SectionCard from "./components/SectionCard.js";
+import SignatureBlock from "./components/SignatureBlock.js";
 import StatusChip from "./components/StatusChip.js";
 import router from "./router.js";
 
@@ -77,12 +82,17 @@ const vuetify = createVuetify({
 });
 
 createApp(App)
+  .component("ChecklistSummary", ChecklistSummary)
   .component("ConfirmDialog", ConfirmDialog)
   .component("EmptyState", EmptyState)
   .component("ErrorAlert", ErrorAlert)
   .component("LoadingState", LoadingState)
   .component("PageHeader", PageHeader)
+  .component("PrintField", PrintField)
+  .component("PrintPageLayout", PrintPageLayout)
+  .component("PrintSection", PrintSection)
   .component("SectionCard", SectionCard)
+  .component("SignatureBlock", SignatureBlock)
   .component("StatusChip", StatusChip)
   .use(router)
   .use(vuetify)

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -3,18 +3,23 @@ import { createRouter, createWebHistory } from "vue-router";
 import DashboardView from "./views/DashboardView.js";
 import AssessmentDetailView from "./views/AssessmentDetailView.js";
 import AssessmentFormView from "./views/AssessmentFormView.js";
+import AssessmentPrintView from "./views/AssessmentPrintView.js";
 import AideNoteDetailView from "./views/AideNoteDetailView.js";
 import AideNoteFormView from "./views/AideNoteFormView.js";
 import AideNoteListView from "./views/AideNoteListView.js";
+import AideNotePrintView from "./views/AideNotePrintView.js";
+import NurseNotePrintView from "./views/NurseNotePrintView.js";
 import PatientDetailView from "./views/PatientDetailView.js";
 import PatientFormView from "./views/PatientFormView.js";
 import PatientListView from "./views/PatientListView.js";
+import PatientPrintView from "./views/PatientPrintView.js";
 import NurseNoteDetailView from "./views/NurseNoteDetailView.js";
 import NurseNoteFormView from "./views/NurseNoteFormView.js";
 import NurseNoteListView from "./views/NurseNoteListView.js";
 import VisitDetailView from "./views/VisitDetailView.js";
 import VisitFormView from "./views/VisitFormView.js";
 import VisitListView from "./views/VisitListView.js";
+import VisitPrintView from "./views/VisitPrintView.js";
 
 const routes = [
   {
@@ -46,6 +51,12 @@ const routes = [
     props: { mode: "edit" },
   },
   {
+    path: "/patients/:id/print",
+    name: "patient-print",
+    component: PatientPrintView,
+    props: true,
+  },
+  {
     path: "/assessments/new",
     name: "assessment-create",
     component: AssessmentFormView,
@@ -62,6 +73,12 @@ const routes = [
     name: "assessment-edit",
     component: AssessmentFormView,
     props: { mode: "edit" },
+  },
+  {
+    path: "/assessments/:id/print",
+    name: "assessment-print",
+    component: AssessmentPrintView,
+    props: true,
   },
   {
     path: "/visits",
@@ -87,6 +104,12 @@ const routes = [
     props: { mode: "edit" },
   },
   {
+    path: "/visits/:id/print",
+    name: "visit-print",
+    component: VisitPrintView,
+    props: true,
+  },
+  {
     path: "/aide-notes",
     name: "aide-notes",
     component: AideNoteListView,
@@ -110,6 +133,12 @@ const routes = [
     props: { mode: "edit" },
   },
   {
+    path: "/aide-notes/:id/print",
+    name: "aide-note-print",
+    component: AideNotePrintView,
+    props: true,
+  },
+  {
     path: "/nurse-notes",
     name: "nurse-notes",
     component: NurseNoteListView,
@@ -131,6 +160,12 @@ const routes = [
     name: "nurse-note-edit",
     component: NurseNoteFormView,
     props: { mode: "edit" },
+  },
+  {
+    path: "/nurse-notes/:id/print",
+    name: "nurse-note-print",
+    component: NurseNotePrintView,
+    props: true,
   },
 ];
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -217,6 +217,249 @@ body {
   font-size: 0.72rem;
 }
 
+.print-route {
+  max-width: 1040px;
+}
+
+.print-page {
+  width: 100%;
+}
+
+.print-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.print-document {
+  color: #182322;
+  background: #ffffff;
+  border: 1px solid #cbd7d5;
+  box-shadow: 0 12px 32px rgba(32, 48, 47, 0.08);
+  padding: 42px 48px 32px;
+}
+
+.print-document__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  padding-bottom: 22px;
+  margin-bottom: 26px;
+  border-bottom: 3px solid #1f6f68;
+}
+
+.print-document__brand {
+  margin-bottom: 8px;
+  color: #1f6f68;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.print-document__title {
+  margin: 0;
+  font-size: 1.9rem;
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+
+.print-document__subtitle {
+  margin: 7px 0 0;
+  color: #586b69;
+  font-size: 0.95rem;
+}
+
+.print-document__mark {
+  display: grid;
+  place-items: center;
+  width: 52px;
+  height: 52px;
+  color: #ffffff;
+  background: #1f6f68;
+  border-radius: 8px;
+}
+
+.print-document__footer {
+  margin-top: 28px;
+  padding-top: 14px;
+  color: #71817f;
+  border-top: 1px solid #dbe4e2;
+  font-size: 0.72rem;
+  text-align: right;
+}
+
+.print-profile {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  margin-bottom: 24px;
+}
+
+.print-profile h2,
+.print-profile p {
+  margin: 0;
+}
+
+.print-profile p {
+  margin-top: 5px;
+  color: #647675;
+}
+
+.print-status {
+  display: inline-block;
+  margin-top: 7px;
+  padding: 3px 9px;
+  color: #225944;
+  background: #e6f2ea;
+  border: 1px solid #bcd6c5;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.print-section {
+  margin-bottom: 22px;
+  break-inside: avoid;
+  border: 1px solid #d7e1df;
+}
+
+.print-section__heading {
+  padding: 10px 14px;
+  background: #edf4f3;
+  border-bottom: 1px solid #d7e1df;
+}
+
+.print-section__heading h2 {
+  margin: 0;
+  color: #263938;
+  font-size: 0.95rem;
+  letter-spacing: 0;
+}
+
+.print-section__heading p {
+  margin: 3px 0 0;
+  color: #647675;
+  font-size: 0.72rem;
+}
+
+.print-section__body {
+  padding: 14px;
+}
+
+.print-section__body > p {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.print-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.print-grid--2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.print-grid--3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.print-field {
+  min-width: 0;
+}
+
+.print-field + .print-field {
+  margin-top: 10px;
+}
+
+.print-grid > .print-field + .print-field {
+  margin-top: 0;
+}
+
+.print-field__label {
+  color: #667876;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.print-field__value {
+  margin-top: 3px;
+  overflow-wrap: anywhere;
+  font-size: 0.88rem;
+}
+
+.print-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+}
+
+.print-table th,
+.print-table td {
+  padding: 8px 9px;
+  border: 1px solid #d7e1df;
+  text-align: left;
+  vertical-align: top;
+}
+
+.print-table th {
+  color: #415452;
+  background: #f4f7f7;
+  font-weight: 700;
+}
+
+.print-empty {
+  margin: 0;
+  color: #71817f;
+  font-style: italic;
+}
+
+.checklist-summary {
+  display: grid;
+  gap: 8px;
+}
+
+.checklist-summary__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 0.8rem;
+}
+
+.checklist-summary__check {
+  color: #1f6f68;
+  font-weight: 800;
+}
+
+.checklist-summary__item strong {
+  display: block;
+  color: #324442;
+}
+
+.checklist-summary__item span {
+  color: #5d6f6d;
+}
+
+.signature-block {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.signature-block__line {
+  grid-column: 1 / -1;
+  min-height: 42px;
+  padding-top: 18px;
+  color: #596b69;
+  border-bottom: 1px solid #536563;
+  font-size: 0.78rem;
+}
+
 @media (max-width: 700px) {
   .page-shell {
     padding: 24px 16px 36px;
@@ -234,5 +477,84 @@ body {
 
   .page-header__actions .v-btn {
     flex: 1 1 auto;
+  }
+
+  .print-document {
+    padding: 28px 20px;
+  }
+
+  .print-grid--2,
+  .print-grid--3 {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media print {
+  @page {
+    size: auto;
+    margin: 12mm;
+  }
+
+  html,
+  body,
+  .v-application,
+  .app-surface {
+    color: #000000 !important;
+    background: #ffffff !important;
+  }
+
+  .v-navigation-drawer,
+  .v-app-bar,
+  .print-actions {
+    display: none !important;
+  }
+
+  .v-main {
+    --v-layout-left: 0px !important;
+    --v-layout-top: 0px !important;
+    padding: 0 !important;
+  }
+
+  .page-shell.print-route {
+    max-width: none;
+    padding: 0;
+  }
+
+  .print-document {
+    border: 0;
+    box-shadow: none;
+    padding: 0;
+  }
+
+  .print-document__mark {
+    color: #000000;
+    background: transparent;
+    border: 1px solid #000000;
+  }
+
+  .print-document__header {
+    border-color: #000000;
+  }
+
+  .print-section,
+  .print-section__heading,
+  .print-table th,
+  .print-table td {
+    border-color: #777777;
+  }
+
+  .print-section__heading,
+  .print-table th,
+  .print-status {
+    color: #000000;
+    background: #eeeeee;
+  }
+
+  .print-section {
+    break-inside: avoid-page;
+  }
+
+  .print-table tr {
+    break-inside: avoid;
   }
 }

--- a/frontend/src/views/AideNoteDetailView.js
+++ b/frontend/src/views/AideNoteDetailView.js
@@ -110,9 +110,14 @@ export default {
             </div>
           </v-col>
           <v-col cols="12" md="4" class="text-md-right">
-            <v-btn color="primary" prepend-icon="mdi-pencil-outline" :to="\`/aide-notes/\${aideNote.id}/edit\`">
-              Edit aide note
-            </v-btn>
+            <div class="d-flex flex-wrap justify-md-end ga-2">
+              <v-btn variant="outlined" prepend-icon="mdi-printer-outline" :to="\`/aide-notes/\${aideNote.id}/print\`">
+                Print note
+              </v-btn>
+              <v-btn color="primary" prepend-icon="mdi-pencil-outline" :to="\`/aide-notes/\${aideNote.id}/edit\`">
+                Edit aide note
+              </v-btn>
+            </div>
           </v-col>
         </v-row>
 

--- a/frontend/src/views/AideNotePrintView.js
+++ b/frontend/src/views/AideNotePrintView.js
@@ -1,0 +1,98 @@
+import { computed, onMounted, ref } from "vue";
+
+import { getAideNote } from "../services/aideNotes.js";
+import { getPatient } from "../services/patients.js";
+import { getVisit } from "../services/visits.js";
+
+
+const sections = [
+  ["personal_care", "Personal Care"],
+  ["nutrition", "Nutrition"],
+  ["mental_status", "Mental Status"],
+  ["elimination", "Elimination"],
+  ["activity", "Activity"],
+  ["assistive_devices", "Assistive Devices"],
+  ["housekeeping", "Housekeeping"],
+];
+
+export default {
+  props: {
+    id: { type: String, required: true },
+  },
+  setup(props) {
+    const note = ref(null);
+    const patient = ref(null);
+    const visit = ref(null);
+    const loading = ref(true);
+    const error = ref("");
+    const patientName = computed(() =>
+      patient.value
+        ? `${patient.value.first_name} ${patient.value.last_name}`
+        : "Patient"
+    );
+
+    async function loadReport() {
+      loading.value = true;
+      error.value = "";
+      try {
+        const noteResponse = await getAideNote(props.id);
+        note.value = noteResponse.data;
+        const [patientResponse, visitResponse] = await Promise.all([
+          getPatient(note.value.patient_id),
+          getVisit(note.value.visit_id),
+        ]);
+        patient.value = patientResponse.data;
+        visit.value = visitResponse.data;
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    onMounted(loadReport);
+    return { error, loading, note, patientName, sections, visit };
+  },
+  template: `
+    <div class="page-shell print-route">
+      <ErrorAlert :message="error" />
+      <LoadingState v-if="loading" label="Loading aide note" />
+      <PrintPageLayout
+        v-else-if="note && visit"
+        title="Home Health Aide Note"
+        :subtitle="\`\${patientName} · \${visit.visit_date}\`"
+        :back-to="\`/aide-notes/\${note.id}\`"
+      >
+        <PrintSection title="Patient and Visit">
+          <div class="print-grid print-grid--3">
+            <PrintField label="Patient" :value="patientName" />
+            <PrintField label="Visit date" :value="visit.visit_date" />
+            <PrintField label="Visit type" :value="visit.visit_type" />
+            <PrintField label="Aide name" :value="note.aide_name" />
+            <PrintField label="Time in" :value="note.time_in" />
+            <PrintField label="Time out" :value="note.time_out" />
+          </div>
+        </PrintSection>
+
+        <div class="print-grid print-grid--2">
+          <PrintSection v-for="[key, title] in sections" :key="key" :title="title">
+            <ChecklistSummary :data="note[key]" />
+          </PrintSection>
+        </div>
+
+        <PrintSection title="Additional Notes">
+          <p>{{ note.additional_notes || 'No additional notes recorded.' }}</p>
+        </PrintSection>
+
+        <PrintSection title="Signature / Staff Details">
+          <SignatureBlock
+            :name="note.aide_name"
+            :date="note.signature_date"
+            :signature-data="note.signature_data"
+            role-label="Aide name"
+          />
+        </PrintSection>
+      </PrintPageLayout>
+    </div>
+  `,
+};

--- a/frontend/src/views/AssessmentDetailView.js
+++ b/frontend/src/views/AssessmentDetailView.js
@@ -107,6 +107,13 @@ export default {
         >
           <template #actions>
             <v-btn
+              variant="outlined"
+              prepend-icon="mdi-printer-outline"
+              :to="\`/assessments/\${assessment.id}/print\`"
+            >
+              Print assessment
+            </v-btn>
+            <v-btn
               color="primary"
               prepend-icon="mdi-pencil-outline"
               :to="\`/assessments/\${assessment.id}/edit\`"

--- a/frontend/src/views/AssessmentPrintView.js
+++ b/frontend/src/views/AssessmentPrintView.js
@@ -1,0 +1,106 @@
+import { computed, onMounted, ref } from "vue";
+
+import { getAssessment } from "../services/assessments.js";
+import { getPatient } from "../services/patients.js";
+import { getVisit } from "../services/visits.js";
+
+
+const assessmentLabels = {
+  fall_risk: "Fall Risk",
+  nutrition: "Nutrition",
+  mobility: "Mobility",
+  cognitive: "Cognitive",
+  general: "General",
+};
+
+export default {
+  props: {
+    id: { type: String, required: true },
+  },
+  setup(props) {
+    const assessment = ref(null);
+    const patient = ref(null);
+    const visit = ref(null);
+    const loading = ref(true);
+    const error = ref("");
+    const patientName = computed(() =>
+      patient.value
+        ? `${patient.value.first_name} ${patient.value.last_name}`
+        : "Patient"
+    );
+    const assessmentName = computed(() =>
+      assessment.value
+        ? assessmentLabels[assessment.value.assessment_type] ||
+          assessment.value.assessment_type
+        : "Assessment"
+    );
+
+    async function loadReport() {
+      loading.value = true;
+      error.value = "";
+      try {
+        const response = await getAssessment(props.id);
+        assessment.value = response.data;
+        const requests = [getPatient(assessment.value.patient_id)];
+        if (assessment.value.visit_id) {
+          requests.push(getVisit(assessment.value.visit_id));
+        }
+        const [patientResponse, visitResponse] = await Promise.all(requests);
+        patient.value = patientResponse.data;
+        visit.value = visitResponse?.data || null;
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    onMounted(loadReport);
+    return {
+      assessment,
+      assessmentName,
+      error,
+      loading,
+      patientName,
+      visit,
+    };
+  },
+  template: `
+    <div class="page-shell print-route">
+      <ErrorAlert :message="error" />
+      <LoadingState v-if="loading" label="Loading assessment report" />
+      <PrintPageLayout
+        v-else-if="assessment"
+        :title="\`\${assessmentName} Assessment\`"
+        :subtitle="patientName"
+        :back-to="\`/assessments/\${assessment.id}\`"
+      >
+        <PrintSection title="Assessment Details">
+          <div class="print-grid print-grid--3">
+            <PrintField label="Patient" :value="patientName" />
+            <PrintField label="Assessment type" :value="assessmentName" />
+            <PrintField label="Assessment date" :value="assessment.assessment_date" />
+            <PrintField label="Performed by" :value="assessment.performed_by" />
+            <PrintField label="Status" :value="assessment.status" />
+            <PrintField
+              label="Related visit"
+              :value="visit ? \`\${visit.visit_date} · \${visit.visit_type}\` : 'Not linked'"
+            />
+          </div>
+        </PrintSection>
+
+        <PrintSection title="Summary">
+          <p>{{ assessment.summary || 'No summary provided.' }}</p>
+        </PrintSection>
+
+        <PrintSection title="Findings">
+          <ChecklistSummary :data="assessment.findings" empty-text="No findings recorded." />
+        </PrintSection>
+
+        <PrintSection title="Recommendations">
+          <p>{{ assessment.recommendations || 'No recommendations provided.' }}</p>
+        </PrintSection>
+      </PrintPageLayout>
+    </div>
+  `,
+};

--- a/frontend/src/views/NurseNoteDetailView.js
+++ b/frontend/src/views/NurseNoteDetailView.js
@@ -139,9 +139,14 @@ export default {
             </div>
           </v-col>
           <v-col cols="12" md="4" class="text-md-right">
-            <v-btn color="primary" prepend-icon="mdi-pencil-outline" :to="\`/nurse-notes/\${nurseNote.id}/edit\`">
-              Edit nurse note
-            </v-btn>
+            <div class="d-flex flex-wrap justify-md-end ga-2">
+              <v-btn variant="outlined" prepend-icon="mdi-printer-outline" :to="\`/nurse-notes/\${nurseNote.id}/print\`">
+                Print note
+              </v-btn>
+              <v-btn color="primary" prepend-icon="mdi-pencil-outline" :to="\`/nurse-notes/\${nurseNote.id}/edit\`">
+                Edit nurse note
+              </v-btn>
+            </div>
           </v-col>
         </v-row>
 

--- a/frontend/src/views/NurseNotePrintView.js
+++ b/frontend/src/views/NurseNotePrintView.js
@@ -1,0 +1,135 @@
+import { computed, onMounted, ref } from "vue";
+
+import { getNurseNote } from "../services/nurseNotes.js";
+import { getPatient } from "../services/patients.js";
+import { getVisit } from "../services/visits.js";
+
+
+const clinicalSections = [
+  ["living_arrangements", "Living Arrangements"],
+  ["visit_type", "Visit Type"],
+  ["vital_signs", "Vital Signs"],
+  ["diet", "Diet"],
+  ["pain_assessment", "Pain Assessment"],
+  ["sensory", "Sensory"],
+  ["neuro", "Neurological"],
+  ["respiratory", "Respiratory"],
+  ["cardiac", "Cardiac"],
+  ["peripheral_circulation", "Peripheral / Circulation"],
+  ["genitourinary", "Genitourinary"],
+  ["gastrointestinal", "Gastrointestinal"],
+  ["endocrine", "Endocrine"],
+  ["skin_integrity", "Skin Integrity"],
+  ["wound_evaluation", "Wound Evaluation"],
+  ["mental_status", "Mental Status"],
+  ["functional_status", "Functional Status"],
+  ["homebound_status", "Homebound Status"],
+  ["patient_caregiver_understanding", "Patient / Caregiver Understanding"],
+  ["md_contact", "MD Contact"],
+];
+
+const narrativeSections = [
+  ["skilled_nursing", "Skilled Nursing"],
+  ["response_to_intervention", "Response to Intervention"],
+  ["discharge_planning", "Discharge Planning"],
+  ["patient_feedback", "Patient / Family Feedback"],
+  ["narrative", "Narrative"],
+];
+
+export default {
+  props: {
+    id: { type: String, required: true },
+  },
+  setup(props) {
+    const note = ref(null);
+    const patient = ref(null);
+    const visit = ref(null);
+    const loading = ref(true);
+    const error = ref("");
+    const patientName = computed(() =>
+      patient.value
+        ? `${patient.value.first_name} ${patient.value.last_name}`
+        : "Patient"
+    );
+
+    async function loadReport() {
+      loading.value = true;
+      error.value = "";
+      try {
+        const noteResponse = await getNurseNote(props.id);
+        note.value = noteResponse.data;
+        const [patientResponse, visitResponse] = await Promise.all([
+          getPatient(note.value.patient_id),
+          getVisit(note.value.visit_id),
+        ]);
+        patient.value = patientResponse.data;
+        visit.value = visitResponse.data;
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    onMounted(loadReport);
+    return {
+      clinicalSections,
+      error,
+      loading,
+      narrativeSections,
+      note,
+      patientName,
+      visit,
+    };
+  },
+  template: `
+    <div class="page-shell print-route">
+      <ErrorAlert :message="error" />
+      <LoadingState v-if="loading" label="Loading nurse note" />
+      <PrintPageLayout
+        v-else-if="note && visit"
+        title="Nurses Progress Note"
+        :subtitle="\`\${patientName} · \${visit.visit_date}\`"
+        :back-to="\`/nurse-notes/\${note.id}\`"
+      >
+        <PrintSection title="Patient / Visit Information">
+          <div class="print-grid print-grid--3">
+            <PrintField label="Patient" :value="patientName" />
+            <PrintField label="Visit date" :value="visit.visit_date" />
+            <PrintField label="Visit type" :value="visit.visit_type" />
+            <PrintField label="Diagnosis" :value="note.diagnosis" />
+            <PrintField label="Staff" :value="visit.staff_name" />
+            <PrintField label="Staff role" :value="visit.staff_role" />
+          </div>
+        </PrintSection>
+
+        <div class="print-grid print-grid--2">
+          <PrintSection
+            v-for="[key, title] in clinicalSections"
+            :key="key"
+            :title="title"
+          >
+            <ChecklistSummary :data="note[key]" />
+          </PrintSection>
+        </div>
+
+        <PrintSection
+          v-for="[key, title] in narrativeSections"
+          :key="key"
+          :title="title"
+        >
+          <p>{{ note[key] || 'Not documented' }}</p>
+        </PrintSection>
+
+        <PrintSection title="Signature">
+          <SignatureBlock
+            :name="visit.staff_name"
+            :date="note.signature_date"
+            :signature-data="note.signature_data"
+            role-label="RN / LPN"
+          />
+        </PrintSection>
+      </PrintPageLayout>
+    </div>
+  `,
+};

--- a/frontend/src/views/PatientDetailView.js
+++ b/frontend/src/views/PatientDetailView.js
@@ -230,6 +230,9 @@ export default {
               <v-btn color="primary" variant="tonal" prepend-icon="mdi-pencil-outline" :to="\`/patients/\${patient.id}/edit\`">
                 Edit patient
               </v-btn>
+              <v-btn variant="outlined" prepend-icon="mdi-printer-outline" :to="\`/patients/\${patient.id}/print\`">
+                Print summary
+              </v-btn>
               <v-btn variant="outlined" prepend-icon="mdi-camera-outline" @click="openPhotoDialog">
                 {{ patient.has_photo ? 'Replace photo' : 'Upload photo' }}
               </v-btn>

--- a/frontend/src/views/PatientPrintView.js
+++ b/frontend/src/views/PatientPrintView.js
@@ -1,0 +1,171 @@
+import { computed, onMounted, ref } from "vue";
+
+import PatientAvatar from "../components/PatientAvatar.js";
+import { getPatientAssessments } from "../services/assessments.js";
+import { getPatientMedicalRecords } from "../services/medicalRecords.js";
+import { getPatient } from "../services/patients.js";
+import { listPatientVisits } from "../services/visits.js";
+
+
+const assessmentLabels = {
+  fall_risk: "Fall risk",
+  nutrition: "Nutrition",
+  mobility: "Mobility",
+  cognitive: "Cognitive",
+  general: "General",
+};
+
+export default {
+  components: { PatientAvatar },
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    const patient = ref(null);
+    const visits = ref([]);
+    const assessments = ref([]);
+    const medicalRecords = ref([]);
+    const loading = ref(true);
+    const error = ref("");
+
+    const patientName = computed(() =>
+      patient.value
+        ? `${patient.value.first_name} ${patient.value.last_name}`
+        : "Patient"
+    );
+    const recentVisits = computed(() => visits.value.slice(0, 5));
+    const recentAssessments = computed(() => assessments.value.slice(0, 5));
+    const recentRecords = computed(() => medicalRecords.value.slice(0, 5));
+
+    async function loadReport() {
+      loading.value = true;
+      error.value = "";
+      try {
+        const [patientResponse, visitResponse, assessmentResponse, recordResponse] =
+          await Promise.all([
+            getPatient(props.id),
+            listPatientVisits(props.id),
+            getPatientAssessments(props.id),
+            getPatientMedicalRecords(props.id),
+          ]);
+        patient.value = patientResponse.data;
+        visits.value = visitResponse.data;
+        assessments.value = assessmentResponse.data;
+        medicalRecords.value = recordResponse.data;
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    onMounted(loadReport);
+
+    return {
+      assessmentLabels,
+      error,
+      loading,
+      patient,
+      patientName,
+      recentAssessments,
+      recentRecords,
+      recentVisits,
+    };
+  },
+  template: `
+    <div class="page-shell print-route">
+      <ErrorAlert :message="error" />
+      <LoadingState v-if="loading" label="Loading patient summary" />
+
+      <PrintPageLayout
+        v-else-if="patient"
+        title="Patient Summary"
+        :subtitle="patientName"
+        :back-to="\`/patients/\${patient.id}\`"
+      >
+        <div class="print-profile">
+          <PatientAvatar :patient="patient" :size="84" />
+          <div>
+            <h2>{{ patientName }}</h2>
+            <div class="print-status">{{ patient.status }}</div>
+          </div>
+        </div>
+
+        <PrintSection title="Demographics">
+          <div class="print-grid print-grid--3">
+            <PrintField label="Date of birth" :value="patient.date_of_birth" />
+            <PrintField label="Gender" :value="patient.gender" />
+            <PrintField label="Phone" :value="patient.phone" />
+            <PrintField label="Email" :value="patient.email" />
+            <PrintField label="Address" :value="patient.address" />
+            <PrintField label="Status" :value="patient.status" />
+          </div>
+        </PrintSection>
+
+        <div class="print-grid print-grid--2">
+          <PrintSection title="Emergency Contact">
+            <PrintField label="Name" :value="patient.emergency_contact_name" />
+            <PrintField label="Phone" :value="patient.emergency_contact_phone" />
+          </PrintSection>
+          <PrintSection title="Diagnosis Summary">
+            <p>{{ patient.diagnosis_summary || 'Not provided' }}</p>
+          </PrintSection>
+        </div>
+
+        <PrintSection title="Recent Visits" subtitle="Up to five most recent visits">
+          <table v-if="recentVisits.length" class="print-table">
+            <thead>
+              <tr><th>Date</th><th>Visit type</th><th>Staff</th><th>Status</th></tr>
+            </thead>
+            <tbody>
+              <tr v-for="visit in recentVisits" :key="visit.id">
+                <td>{{ visit.visit_date }}</td>
+                <td>{{ visit.visit_type }}</td>
+                <td>{{ visit.staff_name || 'Not provided' }}</td>
+                <td>{{ visit.status }}</td>
+              </tr>
+            </tbody>
+          </table>
+          <p v-else class="print-empty">No visits recorded.</p>
+        </PrintSection>
+
+        <PrintSection title="Recent Assessments" subtitle="Up to five most recent assessments">
+          <table v-if="recentAssessments.length" class="print-table">
+            <thead>
+              <tr><th>Date</th><th>Type</th><th>Performed by</th><th>Status</th></tr>
+            </thead>
+            <tbody>
+              <tr v-for="assessment in recentAssessments" :key="assessment.id">
+                <td>{{ assessment.assessment_date }}</td>
+                <td>{{ assessmentLabels[assessment.assessment_type] || assessment.assessment_type }}</td>
+                <td>{{ assessment.performed_by || 'Not provided' }}</td>
+                <td>{{ assessment.status }}</td>
+              </tr>
+            </tbody>
+          </table>
+          <p v-else class="print-empty">No assessments recorded.</p>
+        </PrintSection>
+
+        <PrintSection title="Recent Medical Records" subtitle="Metadata only; uploaded files are not embedded">
+          <table v-if="recentRecords.length" class="print-table">
+            <thead>
+              <tr><th>Title</th><th>Record type</th><th>File name</th><th>Uploaded</th></tr>
+            </thead>
+            <tbody>
+              <tr v-for="record in recentRecords" :key="record.id">
+                <td>{{ record.title }}</td>
+                <td>{{ record.record_type || 'Not provided' }}</td>
+                <td>{{ record.file_name }}</td>
+                <td>{{ record.uploaded_at?.slice(0, 10) || 'Not provided' }}</td>
+              </tr>
+            </tbody>
+          </table>
+          <p v-else class="print-empty">No medical records uploaded.</p>
+        </PrintSection>
+      </PrintPageLayout>
+    </div>
+  `,
+};

--- a/frontend/src/views/VisitDetailView.js
+++ b/frontend/src/views/VisitDetailView.js
@@ -189,6 +189,9 @@ export default {
             <v-btn color="primary" prepend-icon="mdi-pencil-outline" :to="\`/visits/\${visit.id}/edit\`">
               Edit visit
             </v-btn>
+            <v-btn variant="outlined" prepend-icon="mdi-printer-outline" :to="\`/visits/\${visit.id}/print\`">
+              Print summary
+            </v-btn>
             </div>
           </v-col>
         </v-row>

--- a/frontend/src/views/VisitPrintView.js
+++ b/frontend/src/views/VisitPrintView.js
@@ -1,0 +1,143 @@
+import { computed, onMounted, ref } from "vue";
+
+import PatientAvatar from "../components/PatientAvatar.js";
+import { getVisitAssessments } from "../services/assessments.js";
+import { getVisitAideNote } from "../services/aideNotes.js";
+import { getVisitNurseNote } from "../services/nurseNotes.js";
+import { getPatient } from "../services/patients.js";
+import { getVisit } from "../services/visits.js";
+
+
+const assessmentLabels = {
+  fall_risk: "Fall risk",
+  nutrition: "Nutrition",
+  mobility: "Mobility",
+  cognitive: "Cognitive",
+  general: "General",
+};
+
+async function optionalRequest(request) {
+  try {
+    return (await request()).data;
+  } catch (err) {
+    if (err.message.toLowerCase().includes("not found")) return null;
+    throw err;
+  }
+}
+
+export default {
+  components: { PatientAvatar },
+  props: {
+    id: { type: String, required: true },
+  },
+  setup(props) {
+    const visit = ref(null);
+    const patient = ref(null);
+    const aideNote = ref(null);
+    const nurseNote = ref(null);
+    const assessments = ref([]);
+    const loading = ref(true);
+    const error = ref("");
+    const patientName = computed(() =>
+      patient.value
+        ? `${patient.value.first_name} ${patient.value.last_name}`
+        : "Patient"
+    );
+
+    async function loadReport() {
+      loading.value = true;
+      error.value = "";
+      try {
+        const visitResponse = await getVisit(props.id);
+        visit.value = visitResponse.data;
+        const [patientResponse, assessmentResponse, aide, nurse] =
+          await Promise.all([
+            getPatient(visit.value.patient_id),
+            getVisitAssessments(props.id),
+            optionalRequest(() => getVisitAideNote(props.id)),
+            optionalRequest(() => getVisitNurseNote(props.id)),
+          ]);
+        patient.value = patientResponse.data;
+        assessments.value = assessmentResponse.data;
+        aideNote.value = aide;
+        nurseNote.value = nurse;
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    onMounted(loadReport);
+    return {
+      aideNote,
+      assessments,
+      assessmentLabels,
+      error,
+      loading,
+      nurseNote,
+      patient,
+      patientName,
+      visit,
+    };
+  },
+  template: `
+    <div class="page-shell print-route">
+      <ErrorAlert :message="error" />
+      <LoadingState v-if="loading" label="Loading visit summary" />
+      <PrintPageLayout
+        v-else-if="visit && patient"
+        title="Visit Summary"
+        :subtitle="\`\${visit.visit_date} · \${visit.visit_type}\`"
+        :back-to="\`/visits/\${visit.id}\`"
+      >
+        <div class="print-profile">
+          <PatientAvatar :patient="patient" :size="72" />
+          <div>
+            <h2>{{ patientName }}</h2>
+            <p>{{ patient.date_of_birth || 'Date of birth not provided' }}</p>
+          </div>
+        </div>
+
+        <PrintSection title="Visit Details">
+          <div class="print-grid print-grid--3">
+            <PrintField label="Visit date" :value="visit.visit_date" />
+            <PrintField label="Visit type" :value="visit.visit_type" />
+            <PrintField label="Status" :value="visit.status" />
+            <PrintField label="Staff name" :value="visit.staff_name" />
+            <PrintField label="Staff role" :value="visit.staff_role" />
+            <PrintField label="Time" :value="\`\${visit.time_in || 'Not set'} – \${visit.time_out || 'Not set'}\`" />
+          </div>
+        </PrintSection>
+
+        <PrintSection title="Visit Notes">
+          <p>{{ visit.notes || 'No visit notes recorded.' }}</p>
+        </PrintSection>
+
+        <PrintSection title="Care Note Status">
+          <div class="print-grid print-grid--2">
+            <PrintField label="Aide note" :value="aideNote ? 'Completed' : 'Not recorded'" />
+            <PrintField label="Nurse note" :value="nurseNote ? 'Completed' : 'Not recorded'" />
+          </div>
+        </PrintSection>
+
+        <PrintSection title="Linked Assessments">
+          <table v-if="assessments.length" class="print-table">
+            <thead>
+              <tr><th>Date</th><th>Type</th><th>Performed by</th><th>Status</th></tr>
+            </thead>
+            <tbody>
+              <tr v-for="assessment in assessments" :key="assessment.id">
+                <td>{{ assessment.assessment_date }}</td>
+                <td>{{ assessmentLabels[assessment.assessment_type] || assessment.assessment_type }}</td>
+                <td>{{ assessment.performed_by || 'Not provided' }}</td>
+                <td>{{ assessment.status }}</td>
+              </tr>
+            </tbody>
+          </table>
+          <p v-else class="print-empty">No assessments linked to this visit.</p>
+        </PrintSection>
+      </PrintPageLayout>
+    </div>
+  `,
+};


### PR DESCRIPTION
# Summary

- Add print-friendly patient, visit, aide note, nurse note, and assessment reports.
- Add reusable report layout, field, section, checklist, and signature components.
- Add print CSS that removes application navigation and actions while preserving readable page sections and tables.
- Add print actions to each corresponding detail page and document browser print/PDF usage.

## Related Issue / Task

- Feature: `19-printable-reports`

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `docker-compose exec -T backend ruff check .`
- `docker-compose exec -T backend pytest` (86 passed)
- `npm run build`
- `docker-compose config --quiet`
- `docker-compose build frontend`
- Browser verification of all five print routes and detail-page print actions
- Browser console verification with no errors

## Screenshots

- Captured local report previews for patient summary, visit summary, aide note, nurse note, and assessment reports.

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.
