### PR TITLE
feat: polish SeniorMate for demo readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Polished the demo experience with clearer dashboard metrics, reusable detail headers, tabbed patient records, streamlined visit documentation actions, consistent forms and table actions, responsive refinements, and expanded UI guidelines.
 - Expanded the pull request template with related task, change type, testing, screenshots, documentation, changelog, and maintainer merge checks.
 - Expanded `.gitignore` coverage for Python, Flask, Node/Vue, Docker, editor, environment, and OS-generated files.
 

--- a/docs/design/ui-guidelines.md
+++ b/docs/design/ui-guidelines.md
@@ -6,8 +6,10 @@ SeniorMate uses Vuetify with a restrained healthcare administration theme. These
 
 - Use the shared `page-shell` class for page width and responsive padding.
 - Use `PageHeader` for list and dashboard page titles, descriptions, and primary actions.
+- Use `DetailHeader` for patient, visit, note, and assessment identity, status, and record actions.
 - Keep page-level actions in the header and record-level actions in the relevant table row or detail section.
 - Use `SectionCard` for clearly bounded groups of related information.
+- Use tabs when a detail page contains several independent record collections. Keep overview information first and operational records in a predictable order.
 
 ## Color and Status
 
@@ -29,8 +31,9 @@ SeniorMate uses Vuetify with a restrained healthcare administration theme. These
 ## Tables
 
 - Keep action icons together at the end of each row.
-- Every icon-only action must have an accessible label.
+- Every icon-only action must have an accessible label and a visible browser tooltip.
 - Prefer comfortable density and avoid adding low-priority columns that make the table difficult to scan.
+- Use `StatusChip` for record state and `EmptyState` inside the table when no rows exist.
 
 ## Forms
 
@@ -38,3 +41,18 @@ SeniorMate uses Vuetify with a restrained healthcare administration theme. These
 - Keep required fields visibly labelled and show field-level validation messages near the input.
 - Use two-column layouts only where they collapse cleanly at narrow widths.
 - Keep cancel and save actions together at the end of the form.
+- Put cancel before the primary save action and use the same `form-actions` layout across forms.
+
+## Detail Pages
+
+- Lead with identity and care context before metadata.
+- Keep the most common action visible and move secondary actions into the relevant section.
+- Group visit documentation actions together so note and assessment status can be scanned quickly.
+- Avoid stacking unrelated data sections into one continuous page when tabs provide clearer navigation.
+
+## Print Views
+
+- Print reports should use a dedicated print layout with navigation and interactive controls hidden.
+- Use plain white backgrounds, dark text, restrained borders, and page-safe spacing.
+- Render checklist and JSON-backed clinical data as readable labels rather than raw JSON.
+- Use the patient photo when available and the shared initials fallback otherwise.

--- a/frontend/src/components/DetailHeader.js
+++ b/frontend/src/components/DetailHeader.js
@@ -1,0 +1,34 @@
+export default {
+  props: {
+    eyebrow: {
+      type: String,
+      default: "",
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+    subtitle: {
+      type: String,
+      default: "",
+    },
+  },
+  template: `
+    <div class="detail-header">
+      <div class="detail-header__identity">
+        <slot name="avatar" />
+        <div class="detail-header__copy">
+          <div v-if="eyebrow" class="detail-header__eyebrow">{{ eyebrow }}</div>
+          <h1 class="detail-header__title">{{ title }}</h1>
+          <div v-if="subtitle" class="detail-header__subtitle">{{ subtitle }}</div>
+          <div class="detail-header__meta">
+            <slot name="meta" />
+          </div>
+        </div>
+      </div>
+      <div class="detail-header__actions">
+        <slot name="actions" />
+      </div>
+    </div>
+  `,
+};

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -10,6 +10,7 @@ import { aliases, mdi } from "vuetify/iconsets/mdi";
 
 import App from "./views/App.js";
 import ConfirmDialog from "./components/ConfirmDialog.js";
+import DetailHeader from "./components/DetailHeader.js";
 import EmptyState from "./components/EmptyState.js";
 import ErrorAlert from "./components/ErrorAlert.js";
 import LoadingState from "./components/LoadingState.js";
@@ -78,6 +79,7 @@ const vuetify = createVuetify({
 
 createApp(App)
   .component("ConfirmDialog", ConfirmDialog)
+  .component("DetailHeader", DetailHeader)
   .component("EmptyState", EmptyState)
   .component("ErrorAlert", ErrorAlert)
   .component("LoadingState", LoadingState)

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -80,6 +80,69 @@ body {
   height: 100%;
 }
 
+.detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 28px;
+  margin-bottom: 24px;
+  padding: 22px 24px;
+  background: #ffffff;
+  border: 1px solid rgba(31, 111, 104, 0.16);
+  border-left: 4px solid #1f6f68;
+  border-radius: 8px;
+}
+
+.detail-header__identity {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  min-width: 0;
+}
+
+.detail-header__copy {
+  min-width: 0;
+}
+
+.detail-header__eyebrow {
+  margin-bottom: 4px;
+  color: #647675;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.detail-header__title {
+  margin: 0;
+  color: #1f302f;
+  font-size: 1.7rem;
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+
+.detail-header__subtitle {
+  margin-top: 5px;
+  color: #647675;
+  font-size: 0.9rem;
+}
+
+.detail-header__meta,
+.detail-header__actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.detail-header__meta {
+  margin-top: 10px;
+}
+
+.detail-header__actions {
+  justify-content: flex-end;
+  flex: 0 1 520px;
+}
+
 .page-shell .v-card-title {
   padding: 18px 20px;
   color: #263938;
@@ -129,8 +192,49 @@ body {
 }
 
 .metric-card {
-  min-height: 142px;
-  border-top: 3px solid rgb(var(--v-theme-primary));
+  min-height: 158px;
+  overflow: hidden;
+  position: relative;
+}
+
+.metric-card::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: rgb(var(--v-theme-primary));
+  content: "";
+}
+
+.metric-card--success::before {
+  background: rgb(var(--v-theme-success));
+}
+
+.metric-card--secondary::before {
+  background: rgb(var(--v-theme-secondary));
+}
+
+.metric-card--teal::before {
+  background: #32817a;
+}
+
+.metric-card--indigo::before {
+  background: #536a91;
+}
+
+.metric-card__topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+
+.metric-card__icon {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  background: #eef5f4;
+  border-radius: 8px;
 }
 
 .metric-card__value {
@@ -138,6 +242,34 @@ body {
   font-size: 2rem;
   line-height: 1;
   font-weight: 700;
+}
+
+.metric-card__title {
+  color: #324543;
+  font-size: 0.9rem;
+  font-weight: 650;
+}
+
+.metric-card__caption {
+  margin-top: 4px;
+  color: #71817f;
+  font-size: 0.75rem;
+}
+
+.chart-row {
+  margin-bottom: 18px;
+}
+
+.chart-row:last-child {
+  margin-bottom: 0;
+}
+
+.chart-row__label {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 7px;
+  color: #405351;
+  font-size: 0.86rem;
 }
 
 .data-card .v-data-table-header__content {
@@ -156,6 +288,46 @@ body {
   align-items: center;
   gap: 2px;
   white-space: nowrap;
+}
+
+.form-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  padding-top: 4px;
+}
+
+.record-tabs {
+  margin-bottom: 22px;
+  background: #ffffff;
+  border: 1px solid rgba(31, 111, 104, 0.14);
+  border-radius: 8px;
+}
+
+.record-tabs .v-tab {
+  min-width: 112px;
+  text-transform: none;
+}
+
+.detail-grid .v-list-item {
+  min-height: 58px;
+}
+
+.documentation-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.documentation-action {
+  min-height: 82px;
+  justify-content: flex-start;
+}
+
+.documentation-action .v-btn__content {
+  white-space: normal;
+  text-align: left;
 }
 
 .patient-avatar {
@@ -234,5 +406,39 @@ body {
 
   .page-header__actions .v-btn {
     flex: 1 1 auto;
+  }
+
+  .detail-header {
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 18px;
+  }
+
+  .detail-header__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .detail-header__actions .v-btn {
+    flex: 1 1 auto;
+  }
+
+  .detail-header__title {
+    font-size: 1.4rem;
+  }
+
+  .documentation-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .form-actions {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+}
+
+@media (min-width: 701px) and (max-width: 1080px) {
+  .documentation-actions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/frontend/src/views/AideNoteListView.js
+++ b/frontend/src/views/AideNoteListView.js
@@ -138,9 +138,9 @@ export default {
 
           <template #[\`item.actions\`]="{ item }">
             <div class="table-actions">
-              <v-btn icon="mdi-eye-outline" variant="text" :to="\`/aide-notes/\${item.id}\`" aria-label="View aide note" />
-              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/aide-notes/\${item.id}/edit\`" aria-label="Edit aide note" />
-              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete aide note" @click="askDelete(item)" />
+              <v-btn icon="mdi-eye-outline" variant="text" :to="\`/aide-notes/\${item.id}\`" aria-label="View aide note" title="View aide note" />
+              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/aide-notes/\${item.id}/edit\`" aria-label="Edit aide note" title="Edit aide note" />
+              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete aide note" title="Delete aide note" @click="askDelete(item)" />
             </div>
           </template>
         </v-data-table>

--- a/frontend/src/views/DashboardView.js
+++ b/frontend/src/views/DashboardView.js
@@ -14,30 +14,35 @@ export default {
         value: stats.value?.total_patients ?? 0,
         icon: "mdi-account-heart-outline",
         color: "primary",
+        caption: `${stats.value?.inactive_patients ?? 0} inactive`,
       },
       {
         title: "Active Patients",
         value: stats.value?.active_patients ?? 0,
         icon: "mdi-account-check-outline",
         color: "success",
+        caption: "Currently receiving care",
       },
       {
         title: "Visits This Month",
         value: stats.value?.visits_this_month ?? 0,
         icon: "mdi-calendar-clock-outline",
         color: "secondary",
+        caption: `${stats.value?.total_visits ?? 0} visits overall`,
       },
       {
         title: "Aide Notes This Month",
         value: stats.value?.aide_notes_this_month ?? 0,
         icon: "mdi-clipboard-check-outline",
         color: "teal",
+        caption: "Home health aide records",
       },
       {
         title: "Nurse Notes This Month",
         value: stats.value?.nurse_notes_this_month ?? 0,
         icon: "mdi-clipboard-pulse-outline",
         color: "indigo",
+        caption: "Clinical progress records",
       },
     ]);
     const chartSections = computed(() => [
@@ -143,15 +148,18 @@ export default {
           class="mb-6"
         />
 
-        <v-row class="mb-7">
+        <v-row class="dashboard-metrics mb-7">
           <v-col v-for="card in cards" :key="card.title" cols="12" sm="6" lg>
-            <v-card class="metric-card">
+            <v-card class="metric-card" :class="\`metric-card--\${card.color}\`">
               <v-card-text class="pa-5">
-                <div class="d-flex align-center justify-space-between mb-4">
-                  <v-icon :icon="card.icon" :color="card.color" size="28" />
+                <div class="metric-card__topline">
+                  <div class="metric-card__icon">
+                    <v-icon :icon="card.icon" :color="card.color" size="24" />
+                  </div>
                   <div class="metric-card__value">{{ card.value }}</div>
                 </div>
-                <div class="text-body-2 font-weight-medium">{{ card.title }}</div>
+                <div class="metric-card__title">{{ card.title }}</div>
+                <div class="metric-card__caption">{{ card.caption }}</div>
               </v-card-text>
             </v-card>
           </v-col>
@@ -163,15 +171,15 @@ export default {
                 <div v-if="!section.items.length" class="text-medium-emphasis">
                   No data available.
                 </div>
-                <div v-for="item in section.items" :key="item.label" class="mb-4">
-                  <div class="d-flex justify-space-between mb-1">
+                <div v-for="item in section.items" :key="item.label" class="chart-row">
+                  <div class="chart-row__label">
                     <span>{{ item.label }}</span>
                     <strong>{{ item.count }}</strong>
                   </div>
                   <v-progress-linear
                     :model-value="percentage(item, section.items)"
                     :color="section.color"
-                    height="10"
+                    height="8"
                     rounded
                   />
                 </div>
@@ -209,7 +217,13 @@ export default {
 
               <template #[\`item.actions\`]="{ item }">
                 <div class="table-actions">
-                  <v-btn icon="mdi-eye-outline" variant="text" :to="\`/visits/\${item.id}\`" aria-label="View visit" />
+                  <v-btn
+                    icon="mdi-arrow-right"
+                    variant="text"
+                    :to="\`/visits/\${item.id}\`"
+                    aria-label="Open visit"
+                    title="Open visit"
+                  />
                 </div>
               </template>
             </v-data-table>

--- a/frontend/src/views/NurseNoteListView.js
+++ b/frontend/src/views/NurseNoteListView.js
@@ -136,9 +136,9 @@ export default {
 
           <template #[\`item.actions\`]="{ item }">
             <div class="table-actions">
-              <v-btn icon="mdi-eye-outline" variant="text" :to="\`/nurse-notes/\${item.id}\`" aria-label="View nurse note" />
-              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/nurse-notes/\${item.id}/edit\`" aria-label="Edit nurse note" />
-              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete nurse note" @click="askDelete(item)" />
+              <v-btn icon="mdi-eye-outline" variant="text" :to="\`/nurse-notes/\${item.id}\`" aria-label="View nurse note" title="View nurse note" />
+              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/nurse-notes/\${item.id}/edit\`" aria-label="Edit nurse note" title="Edit nurse note" />
+              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete nurse note" title="Delete nurse note" @click="askDelete(item)" />
             </div>
           </template>
         </v-data-table>

--- a/frontend/src/views/PatientDetailView.js
+++ b/frontend/src/views/PatientDetailView.js
@@ -3,6 +3,8 @@ import { computed, onMounted, ref } from "vue";
 import MedicalRecordsSection from "../components/MedicalRecordsSection.js";
 import PatientAvatar from "../components/PatientAvatar.js";
 import PatientAssessmentsSection from "../components/PatientAssessmentsSection.js";
+import { getPatientAideNotes } from "../services/aideNotes.js";
+import { getPatientNurseNotes } from "../services/nurseNotes.js";
 import {
   deletePatientPhoto,
   getPatient,
@@ -26,6 +28,9 @@ export default {
   setup(props) {
     const patient = ref(null);
     const visits = ref([]);
+    const aideNotes = ref([]);
+    const nurseNotes = ref([]);
+    const activeTab = ref("overview");
     const loading = ref(true);
     const error = ref("");
     const success = ref("");
@@ -57,12 +62,21 @@ export default {
       error.value = "";
 
       try {
-        const [patientResponse, visitResponse] = await Promise.all([
+        const [
+          patientResponse,
+          visitResponse,
+          aideNoteResponse,
+          nurseNoteResponse,
+        ] = await Promise.all([
           getPatient(props.id),
           listPatientVisits(props.id),
+          getPatientAideNotes(props.id),
+          getPatientNurseNotes(props.id),
         ]);
         patient.value = patientResponse.data;
         visits.value = visitResponse.data;
+        aideNotes.value = aideNoteResponse.data;
+        nurseNotes.value = nurseNoteResponse.data;
       } catch (err) {
         error.value = err.message;
       } finally {
@@ -162,6 +176,8 @@ export default {
 
     return {
       error,
+      activeTab,
+      aideNotes,
       askDelete,
       confirmDelete,
       confirmPhotoDelete,
@@ -169,6 +185,7 @@ export default {
       deletingPhoto,
       fullName,
       loading,
+      nurseNotes,
       openPhotoDialog,
       patient,
       photoDialog,
@@ -201,29 +218,30 @@ export default {
       <v-skeleton-loader v-if="loading" type="heading, paragraph, card" />
 
       <template v-else-if="patient">
-        <v-row align="center" class="mb-5">
-          <v-col cols="12" md="8">
-            <div class="d-flex align-center ga-4">
-              <PatientAvatar :patient="patient" :size="88" show-verification />
-              <div>
-                <h1 class="text-h4 font-weight-bold mb-2">{{ fullName }}</h1>
-                <div class="d-flex flex-wrap align-center ga-2">
-                  <StatusChip :status="patient.status" />
-                  <v-chip
-                    v-if="patient.has_photo"
-                    :color="patient.photo_verified ? 'success' : 'warning'"
-                    size="small"
-                    variant="tonal"
-                    :prepend-icon="patient.photo_verified ? 'mdi-check-decagram' : 'mdi-alert-circle-outline'"
-                  >
-                    {{ patient.photo_verified ? 'Photo verified' : 'Photo not verified' }}
-                  </v-chip>
-                </div>
-              </div>
-            </div>
-          </v-col>
-          <v-col cols="12" md="4" class="text-md-right">
-            <div class="d-flex flex-wrap justify-md-end ga-2">
+        <DetailHeader
+          eyebrow="Patient record"
+          :title="fullName"
+          :subtitle="patient.phone || patient.email || 'Contact information not provided'"
+        >
+          <template #avatar>
+            <PatientAvatar :patient="patient" :size="84" show-verification />
+          </template>
+          <template #meta>
+            <StatusChip :status="patient.status" />
+            <v-chip
+              v-if="patient.has_photo"
+              :color="patient.photo_verified ? 'success' : 'warning'"
+              size="small"
+              variant="tonal"
+              :prepend-icon="patient.photo_verified ? 'mdi-check-decagram' : 'mdi-alert-circle-outline'"
+            >
+              {{ patient.photo_verified ? 'Photo verified' : 'Photo review needed' }}
+            </v-chip>
+            <v-chip size="small" variant="outlined" prepend-icon="mdi-calendar-clock-outline">
+              {{ visits.length }} {{ visits.length === 1 ? 'visit' : 'visits' }}
+            </v-chip>
+          </template>
+          <template #actions>
               <v-btn color="primary" prepend-icon="mdi-calendar-plus-outline" :to="\`/visits/new?patient_id=\${patient.id}\`">
                 New visit
               </v-btn>
@@ -251,69 +269,137 @@ export default {
               >
                 Delete photo
               </v-btn>
-            </div>
-          </v-col>
-        </v-row>
+          </template>
+        </DetailHeader>
 
-        <v-row class="mb-5">
-          <v-col cols="12" md="6">
-            <v-card>
-              <v-card-title>Demographics</v-card-title>
-              <v-list>
-                <v-list-item title="Date of birth" :subtitle="patient.date_of_birth || 'Not provided'" />
-                <v-list-item title="Gender" :subtitle="patient.gender || 'Not provided'" />
-                <v-list-item title="Phone" :subtitle="patient.phone || 'Not provided'" />
-                <v-list-item title="Email" :subtitle="patient.email || 'Not provided'" />
-                <v-list-item title="Address" :subtitle="patient.address || 'Not provided'" />
-              </v-list>
-            </v-card>
-          </v-col>
+        <v-tabs v-model="activeTab" color="primary" class="record-tabs" show-arrows>
+          <v-tab value="overview" prepend-icon="mdi-account-outline">Overview</v-tab>
+          <v-tab value="visits" prepend-icon="mdi-calendar-clock-outline">Visits</v-tab>
+          <v-tab value="records" prepend-icon="mdi-file-document-multiple-outline">Medical records</v-tab>
+          <v-tab value="assessments" prepend-icon="mdi-clipboard-text-search-outline">Assessments</v-tab>
+          <v-tab value="notes" prepend-icon="mdi-clipboard-pulse-outline">Care notes</v-tab>
+        </v-tabs>
 
-          <v-col cols="12" md="6">
-            <v-card>
-              <v-card-title>Emergency contact</v-card-title>
-              <v-list>
-                <v-list-item title="Name" :subtitle="patient.emergency_contact_name || 'Not provided'" />
-                <v-list-item title="Phone" :subtitle="patient.emergency_contact_phone || 'Not provided'" />
-              </v-list>
-              <v-divider />
-              <v-card-title>Diagnosis summary</v-card-title>
-              <v-card-text>{{ patient.diagnosis_summary || 'Not provided' }}</v-card-text>
-            </v-card>
-          </v-col>
-        </v-row>
+        <v-window v-model="activeTab">
+          <v-window-item value="overview">
+            <v-row class="detail-grid">
+              <v-col cols="12" md="6">
+                <SectionCard title="Demographics" icon="mdi-card-account-details-outline">
+                  <v-list>
+                    <v-list-item title="Date of birth" :subtitle="patient.date_of_birth || 'Not provided'" />
+                    <v-list-item title="Gender" :subtitle="patient.gender || 'Not provided'" />
+                    <v-list-item title="Phone" :subtitle="patient.phone || 'Not provided'" />
+                    <v-list-item title="Email" :subtitle="patient.email || 'Not provided'" />
+                    <v-list-item title="Address" :subtitle="patient.address || 'Not provided'" />
+                  </v-list>
+                </SectionCard>
+              </v-col>
 
-        <MedicalRecordsSection :patient-id="patient.id" />
-        <PatientAssessmentsSection :patient-id="patient.id" />
+              <v-col cols="12" md="6">
+                <SectionCard title="Care context" icon="mdi-heart-pulse">
+                  <v-list>
+                    <v-list-item title="Emergency contact" :subtitle="patient.emergency_contact_name || 'Not provided'" />
+                    <v-list-item title="Emergency phone" :subtitle="patient.emergency_contact_phone || 'Not provided'" />
+                  </v-list>
+                  <v-divider class="my-3" />
+                  <div class="text-subtitle-2 mb-2">Diagnosis summary</div>
+                  <div class="text-body-2 text-medium-emphasis">
+                    {{ patient.diagnosis_summary || 'Not provided' }}
+                  </div>
+                </SectionCard>
+              </v-col>
+            </v-row>
+          </v-window-item>
 
-        <v-card>
-          <v-card-title>Visits</v-card-title>
-          <v-data-table
-            :headers="visitHeaders"
-            :items="visits"
-            item-value="id"
-          >
-            <template #no-data>
-              <div class="pa-8 text-center">
-                <v-icon icon="mdi-calendar-clock-outline" size="40" class="mb-3" />
-                <div class="text-h6 mb-2">No visits yet</div>
-                <v-btn color="primary" variant="flat" :to="\`/visits/new?patient_id=\${patient.id}\`">Create visit</v-btn>
+          <v-window-item value="visits">
+            <SectionCard
+              title="Visits"
+              subtitle="Scheduled and completed care for this patient."
+              icon="mdi-calendar-clock-outline"
+              class="data-card"
+            >
+              <div class="d-flex justify-end mb-4">
+                <v-btn color="primary" prepend-icon="mdi-plus" :to="\`/visits/new?patient_id=\${patient.id}\`">
+                  New visit
+                </v-btn>
               </div>
-            </template>
+              <v-data-table :headers="visitHeaders" :items="visits" item-value="id">
+                <template #no-data>
+                  <EmptyState
+                    icon="mdi-calendar-plus-outline"
+                    title="No visits yet"
+                    description="Create the first visit for this patient."
+                    action-label="Create visit"
+                    :action-to="\`/visits/new?patient_id=\${patient.id}\`"
+                  />
+                </template>
+                <template #[\`item.status\`]="{ item }">
+                  <StatusChip :status="item.status" />
+                </template>
+                <template #[\`item.actions\`]="{ item }">
+                  <div class="table-actions">
+                    <v-btn icon="mdi-eye-outline" variant="text" :to="\`/visits/\${item.id}\`" aria-label="View visit" title="View visit" />
+                    <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/visits/\${item.id}/edit\`" aria-label="Edit visit" title="Edit visit" />
+                    <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete visit" title="Delete visit" @click="askDelete(item)" />
+                  </div>
+                </template>
+              </v-data-table>
+            </SectionCard>
+          </v-window-item>
 
-            <template #[\`item.status\`]="{ item }">
-              <v-chip :color="item.status === 'completed' ? 'success' : item.status === 'cancelled' ? 'grey' : 'primary'" size="small">
-                {{ item.status }}
-              </v-chip>
-            </template>
+          <v-window-item value="records">
+            <MedicalRecordsSection :patient-id="patient.id" />
+          </v-window-item>
 
-            <template #[\`item.actions\`]="{ item }">
-              <v-btn icon="mdi-eye-outline" variant="text" :to="\`/visits/\${item.id}\`" aria-label="View visit" />
-              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/visits/\${item.id}/edit\`" aria-label="Edit visit" />
-              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete visit" @click="askDelete(item)" />
-            </template>
-          </v-data-table>
-        </v-card>
+          <v-window-item value="assessments">
+            <PatientAssessmentsSection :patient-id="patient.id" />
+          </v-window-item>
+
+          <v-window-item value="notes">
+            <v-row>
+              <v-col cols="12" md="6">
+                <SectionCard title="Aide notes" icon="mdi-clipboard-check-outline">
+                  <EmptyState
+                    v-if="!aideNotes.length"
+                    icon="mdi-clipboard-text-outline"
+                    title="No aide notes"
+                    description="Aide notes linked to patient visits will appear here."
+                  />
+                  <v-list v-else lines="two">
+                    <v-list-item
+                      v-for="note in aideNotes"
+                      :key="note.id"
+                      :title="note.aide_name || 'Aide note'"
+                      :subtitle="note.signature_date || 'Signature date not provided'"
+                      :to="\`/aide-notes/\${note.id}\`"
+                      append-icon="mdi-chevron-right"
+                    />
+                  </v-list>
+                </SectionCard>
+              </v-col>
+              <v-col cols="12" md="6">
+                <SectionCard title="Nurse notes" icon="mdi-clipboard-pulse-outline">
+                  <EmptyState
+                    v-if="!nurseNotes.length"
+                    icon="mdi-clipboard-text-outline"
+                    title="No nurse notes"
+                    description="Nurse notes linked to patient visits will appear here."
+                  />
+                  <v-list v-else lines="two">
+                    <v-list-item
+                      v-for="note in nurseNotes"
+                      :key="note.id"
+                      :title="note.diagnosis || 'Nurse note'"
+                      :subtitle="note.signature_date || 'Signature date not provided'"
+                      :to="\`/nurse-notes/\${note.id}\`"
+                      append-icon="mdi-chevron-right"
+                    />
+                  </v-list>
+                </SectionCard>
+              </v-col>
+            </v-row>
+          </v-window-item>
+        </v-window>
       </template>
 
       <v-dialog v-model="photoDialog" max-width="560">

--- a/frontend/src/views/PatientFormView.js
+++ b/frontend/src/views/PatientFormView.js
@@ -125,7 +125,11 @@ export default {
         Patients
       </v-btn>
 
-      <h1 class="text-h4 font-weight-bold mb-5">{{ title }}</h1>
+      <PageHeader
+        :title="title"
+        subtitle="Patient identity, contact, emergency, and care information."
+        icon="mdi-account-edit-outline"
+      />
 
       <v-alert v-if="error" type="error" variant="tonal" class="mb-4">
         {{ error }}
@@ -134,9 +138,12 @@ export default {
       <v-skeleton-loader v-if="loading" type="heading, paragraph, card" />
 
       <v-form v-else @submit.prevent="submit">
-        <v-card class="mb-5">
-          <v-card-title>Demographics</v-card-title>
-          <v-card-text>
+        <SectionCard
+          title="Demographics"
+          subtitle="Required names and core patient contact details."
+          icon="mdi-card-account-details-outline"
+          class="mb-5"
+        >
             <v-row>
               <v-col cols="12" md="6">
                 <v-text-field
@@ -177,12 +184,14 @@ export default {
                 <v-textarea v-model="form.address" label="Address" rows="2" />
               </v-col>
             </v-row>
-          </v-card-text>
-        </v-card>
+        </SectionCard>
 
-        <v-card class="mb-5">
-          <v-card-title>Emergency and clinical details</v-card-title>
-          <v-card-text>
+        <SectionCard
+          title="Emergency and clinical details"
+          subtitle="Care context used across the patient record."
+          icon="mdi-heart-pulse"
+          class="mb-5"
+        >
             <v-row>
               <v-col cols="12" md="6">
                 <v-text-field v-model="form.emergency_contact_name" label="Emergency contact name" />
@@ -194,12 +203,11 @@ export default {
                 <v-textarea v-model="form.diagnosis_summary" label="Diagnosis summary" rows="3" />
               </v-col>
             </v-row>
-          </v-card-text>
-        </v-card>
+        </SectionCard>
 
-        <div class="d-flex justify-end ga-3">
+        <div class="form-actions">
           <v-btn variant="text" to="/patients">Cancel</v-btn>
-          <v-btn color="primary" type="submit" :loading="saving">
+          <v-btn color="primary" prepend-icon="mdi-content-save-outline" type="submit" :loading="saving">
             Save patient
           </v-btn>
         </div>

--- a/frontend/src/views/PatientListView.js
+++ b/frontend/src/views/PatientListView.js
@@ -141,9 +141,9 @@ export default {
 
           <template #[\`item.actions\`]="{ item }">
             <div class="table-actions">
-              <v-btn icon="mdi-eye-outline" variant="text" :to="\`/patients/\${item.id}\`" aria-label="View patient" />
-              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/patients/\${item.id}/edit\`" aria-label="Edit patient" />
-              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete patient" @click="askDelete(item)" />
+              <v-btn icon="mdi-eye-outline" variant="text" :to="\`/patients/\${item.id}\`" aria-label="View patient" title="View patient" />
+              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/patients/\${item.id}/edit\`" aria-label="Edit patient" title="Edit patient" />
+              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete patient" title="Delete patient" @click="askDelete(item)" />
             </div>
           </template>
         </v-data-table>

--- a/frontend/src/views/VisitDetailView.js
+++ b/frontend/src/views/VisitDetailView.js
@@ -113,72 +113,82 @@ export default {
       <v-skeleton-loader v-if="loading" type="heading, paragraph, card" />
 
       <template v-else-if="visit">
-        <v-row align="center" class="mb-5">
-          <v-col cols="12" md="8">
-            <div class="d-flex align-center ga-4">
-              <PatientAvatar v-if="patient" :patient="patient" :size="60" show-verification />
-              <div>
-                <h1 class="text-h4 font-weight-bold mb-2">{{ visit.visit_type }}</h1>
-                <div class="text-body-1 text-medium-emphasis mb-2">{{ visit.visit_date }} · {{ patientName }}</div>
-                <v-chip :color="visit.status === 'completed' ? 'success' : visit.status === 'cancelled' ? 'grey' : 'primary'" size="small">
-                  {{ visit.status }}
-                </v-chip>
-              </div>
-            </div>
-          </v-col>
-          <v-col cols="12" md="4">
-            <div class="d-flex flex-wrap justify-md-end ga-2">
+        <DetailHeader
+          eyebrow="Visit record"
+          :title="visit.visit_type"
+          :subtitle="\`\${visit.visit_date} · \${patientName}\`"
+        >
+          <template #avatar>
+            <PatientAvatar v-if="patient" :patient="patient" :size="68" show-verification />
+          </template>
+          <template #meta>
+            <StatusChip :status="visit.status" />
+            <v-chip size="small" variant="outlined" prepend-icon="mdi-account-badge-outline">
+              {{ visit.staff_role || 'Staff role not provided' }}
+            </v-chip>
+            <v-chip v-if="visit.time_in || visit.time_out" size="small" variant="outlined" prepend-icon="mdi-clock-outline">
+              {{ visit.time_in || '—' }} – {{ visit.time_out || '—' }}
+            </v-chip>
+          </template>
+          <template #actions>
+            <v-btn variant="outlined" prepend-icon="mdi-account-outline" :to="\`/patients/\${visit.patient_id}\`">
+              Patient
+            </v-btn>
+            <v-btn color="primary" prepend-icon="mdi-pencil-outline" :to="\`/visits/\${visit.id}/edit\`">
+              Edit visit
+            </v-btn>
+          </template>
+        </DetailHeader>
+
+        <SectionCard
+          title="Care documentation"
+          subtitle="Complete or review the clinical records linked to this visit."
+          icon="mdi-clipboard-text-multiple-outline"
+          class="mb-5"
+        >
+          <div class="documentation-actions">
             <v-btn
               v-if="!aideNote"
+              class="documentation-action"
               color="primary"
+              variant="tonal"
               prepend-icon="mdi-clipboard-plus-outline"
               :to="\`/aide-notes/new?visit_id=\${visit.id}\`"
             >
-              Create Aide Note
+              Create aide note
             </v-btn>
             <v-btn
               v-if="!nurseNote"
+              class="documentation-action"
               color="secondary"
+              variant="tonal"
               prepend-icon="mdi-clipboard-pulse-outline"
               :to="\`/nurse-notes/new?visit_id=\${visit.id}\`"
             >
-              Create Nurse Note
+              Create nurse note
             </v-btn>
             <v-btn
               v-if="aideNote"
+              class="documentation-action"
               color="primary"
+              variant="tonal"
               prepend-icon="mdi-clipboard-check-outline"
               :to="\`/aide-notes/\${aideNote.id}\`"
             >
-              View Aide Note
-            </v-btn>
-            <v-btn
-              v-if="aideNote"
-              color="primary"
-              variant="tonal"
-              prepend-icon="mdi-pencil-outline"
-              :to="\`/aide-notes/\${aideNote.id}/edit\`"
-            >
-              Edit Aide Note
+              View aide note
             </v-btn>
             <v-btn
               v-if="nurseNote"
+              class="documentation-action"
               color="secondary"
+              variant="tonal"
               prepend-icon="mdi-clipboard-pulse-outline"
               :to="\`/nurse-notes/\${nurseNote.id}\`"
             >
-              View Nurse Note
+              View nurse note
             </v-btn>
             <v-btn
-              v-if="nurseNote"
-              color="secondary"
-              variant="tonal"
-              prepend-icon="mdi-pencil-outline"
-              :to="\`/nurse-notes/\${nurseNote.id}/edit\`"
-            >
-              Edit Nurse Note
-            </v-btn>
-            <v-btn
+              class="documentation-action"
               color="secondary"
               variant="tonal"
               prepend-icon="mdi-clipboard-text-search-outline"
@@ -186,45 +196,41 @@ export default {
             >
               New assessment
             </v-btn>
-            <v-btn color="primary" prepend-icon="mdi-pencil-outline" :to="\`/visits/\${visit.id}/edit\`">
-              Edit visit
+            <v-btn
+              v-if="aideNote"
+              class="documentation-action"
+              variant="outlined"
+              prepend-icon="mdi-pencil-outline"
+              :to="\`/aide-notes/\${aideNote.id}/edit\`"
+            >
+              Edit aide note
             </v-btn>
-            </div>
-          </v-col>
-        </v-row>
+            <v-btn
+              v-if="nurseNote"
+              class="documentation-action"
+              variant="outlined"
+              prepend-icon="mdi-pencil-outline"
+              :to="\`/nurse-notes/\${nurseNote.id}/edit\`"
+            >
+              Edit nurse note
+            </v-btn>
+          </div>
+        </SectionCard>
 
-        <v-alert
-          :type="aideNote ? 'success' : 'info'"
-          variant="tonal"
-          class="mb-5"
-        >
-          {{ aideNote ? 'Aide note completed for this visit.' : 'No aide note has been created for this visit yet.' }}
-        </v-alert>
-
-        <v-alert
-          :type="nurseNote ? 'success' : 'info'"
-          variant="tonal"
-          class="mb-5"
-        >
-          {{ nurseNote ? 'Nurse note completed for this visit.' : 'No nurse note has been created for this visit yet.' }}
-        </v-alert>
-
-        <v-row>
+        <v-row class="detail-grid">
           <v-col cols="12" md="6">
-            <v-card>
-              <v-card-title>Visit metadata</v-card-title>
+            <SectionCard title="Visit details" icon="mdi-calendar-text-outline">
               <v-list>
                 <v-list-item title="Patient" :subtitle="patientName" :to="\`/patients/\${visit.patient_id}\`" />
                 <v-list-item title="Visit date" :subtitle="visit.visit_date || 'Not provided'" />
                 <v-list-item title="Visit type" :subtitle="visit.visit_type || 'Not provided'" />
                 <v-list-item title="Status" :subtitle="visit.status || 'Not provided'" />
               </v-list>
-            </v-card>
+            </SectionCard>
           </v-col>
 
           <v-col cols="12" md="6">
-            <v-card>
-              <v-card-title>Staff details</v-card-title>
+            <SectionCard title="Staff and notes" icon="mdi-account-badge-outline">
               <v-list>
                 <v-list-item title="Staff name" :subtitle="visit.staff_name || 'Not provided'" />
                 <v-list-item title="Staff role" :subtitle="visit.staff_role || 'Not provided'" />
@@ -232,9 +238,9 @@ export default {
                 <v-list-item title="Time out" :subtitle="visit.time_out || 'Not provided'" />
               </v-list>
               <v-divider />
-              <v-card-title>Notes</v-card-title>
-              <v-card-text>{{ visit.notes || 'Not provided' }}</v-card-text>
-            </v-card>
+              <div class="text-subtitle-2 mt-4 mb-2">Visit notes</div>
+              <div class="text-body-2 text-medium-emphasis">{{ visit.notes || 'Not provided' }}</div>
+            </SectionCard>
           </v-col>
         </v-row>
 

--- a/frontend/src/views/VisitFormView.js
+++ b/frontend/src/views/VisitFormView.js
@@ -144,7 +144,11 @@ export default {
         Visits
       </v-btn>
 
-      <h1 class="text-h4 font-weight-bold mb-5">{{ title }}</h1>
+      <PageHeader
+        :title="title"
+        subtitle="Schedule care, assign staff, and capture visit timing."
+        icon="mdi-calendar-edit-outline"
+      />
 
       <v-alert v-if="error" type="error" variant="tonal" class="mb-4">
         {{ error }}
@@ -153,9 +157,12 @@ export default {
       <v-skeleton-loader v-if="loading" type="heading, paragraph, card" />
 
       <v-form v-else @submit.prevent="submit">
-        <v-card class="mb-5">
-          <v-card-title>Visit details</v-card-title>
-          <v-card-text>
+        <SectionCard
+          title="Visit details"
+          subtitle="Patient, date, service type, and current status."
+          icon="mdi-calendar-text-outline"
+          class="mb-5"
+        >
             <v-row>
               <v-col cols="12" md="6">
                 <v-select
@@ -194,12 +201,14 @@ export default {
                 />
               </v-col>
             </v-row>
-          </v-card-text>
-        </v-card>
+        </SectionCard>
 
-        <v-card class="mb-5">
-          <v-card-title>Staff and time</v-card-title>
-          <v-card-text>
+        <SectionCard
+          title="Staff and time"
+          subtitle="Caregiver assignment, visit window, and operational notes."
+          icon="mdi-account-clock-outline"
+          class="mb-5"
+        >
             <v-row>
               <v-col cols="12" md="6">
                 <v-text-field v-model="form.staff_name" label="Staff name" />
@@ -222,12 +231,11 @@ export default {
                 <v-textarea v-model="form.notes" label="Notes" rows="4" />
               </v-col>
             </v-row>
-          </v-card-text>
-        </v-card>
+        </SectionCard>
 
-        <div class="d-flex justify-end ga-3">
+        <div class="form-actions">
           <v-btn variant="text" to="/visits">Cancel</v-btn>
-          <v-btn color="primary" type="submit" :loading="saving">
+          <v-btn color="primary" prepend-icon="mdi-content-save-outline" type="submit" :loading="saving">
             Save visit
           </v-btn>
         </div>

--- a/frontend/src/views/VisitListView.js
+++ b/frontend/src/views/VisitListView.js
@@ -150,9 +150,9 @@ export default {
 
           <template #[\`item.actions\`]="{ item }">
             <div class="table-actions">
-              <v-btn icon="mdi-eye-outline" variant="text" :to="\`/visits/\${item.id}\`" aria-label="View visit" />
-              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/visits/\${item.id}/edit\`" aria-label="Edit visit" />
-              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete visit" @click="askDelete(item)" />
+              <v-btn icon="mdi-eye-outline" variant="text" :to="\`/visits/\${item.id}\`" aria-label="View visit" title="View visit" />
+              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/visits/\${item.id}/edit\`" aria-label="Edit visit" title="Edit visit" />
+              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete visit" title="Delete visit" @click="askDelete(item)" />
             </div>
           </template>
         </v-data-table>


### PR DESCRIPTION
# Summary

- Polish dashboard metrics, chart spacing, and recent activity presentation.
- Add a reusable detail header and reorganize Patient Detail into Overview, Visits, Medical Records, Assessments, and Care Notes tabs.
- Clarify Visit Detail documentation actions and standardize patient/visit forms and table actions.
- Expand UI guidelines and record the feature in the changelog.
- Keep printable-report implementation isolated in open PR #20; this branch is based on current `main` and documents print conventions without duplicating that unmerged work.

## Related Issue / Task

- Feature: 20-ui-polish-demo-ready
- Sequential dependency: #20 (printable reports)

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [x] Refactor

## Testing Performed

- `npm run build` (frontend)
- `docker-compose build frontend`
- `docker-compose config --quiet`
- `docker-compose exec -T backend pytest` (86 passed)
- Browser QA on Dashboard, Patient Detail, Visit Detail, and Patient Detail tabs

## Screenshots

Dashboard, Patient Detail, and Visit Detail screenshots were captured during browser QA and are included in the completion summary. No screenshot binaries were added to the repository.

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.