### PR TITLE
fix: restore aide and nurse note list rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Aide Notes and Nurse Notes list routes failing to render and leaving subsequent navigation blank.
+
 ### Added
 
 - Added search, filtering, and pagination for patient, visit, aide note, and nurse note list workflows.

--- a/frontend/src/views/AideNoteListView.js
+++ b/frontend/src/views/AideNoteListView.js
@@ -44,6 +44,12 @@ export default {
         ])
       )
     );
+    const patientOptions = computed(() =>
+      patients.value.map((patient) => ({
+        title: `${patient.first_name} ${patient.last_name}`,
+        value: patient.id,
+      }))
+    );
     const visitDates = computed(() =>
       Object.fromEntries(visits.value.map((visit) => [visit.id, visit.visit_date]))
     );
@@ -138,6 +144,7 @@ export default {
       headers,
       loading,
       pagination,
+      patientOptions,
       removeAideNote,
       rows,
       selectedNote,
@@ -167,7 +174,7 @@ export default {
               <v-select
                 v-model="filters.patient_id"
                 label="Patient"
-                :items="patients.map((patient) => ({ title: patient.first_name + ' ' + patient.last_name, value: patient.id }))"
+                :items="patientOptions"
                 item-title="title"
                 item-value="value"
                 clearable

--- a/frontend/src/views/NurseNoteListView.js
+++ b/frontend/src/views/NurseNoteListView.js
@@ -42,6 +42,12 @@ export default {
         ])
       )
     );
+    const patientOptions = computed(() =>
+      patients.value.map((patient) => ({
+        title: `${patient.first_name} ${patient.last_name}`,
+        value: patient.id,
+      }))
+    );
     const visitDates = computed(() =>
       Object.fromEntries(visits.value.map((visit) => [visit.id, visit.visit_date]))
     );
@@ -136,6 +142,7 @@ export default {
       headers,
       loading,
       pagination,
+      patientOptions,
       removeNurseNote,
       rows,
       selectedNote,
@@ -165,7 +172,7 @@ export default {
               <v-select
                 v-model="filters.patient_id"
                 label="Patient"
-                :items="patients.map((patient) => ({ title: patient.first_name + ' ' + patient.last_name, value: patient.id }))"
+                :items="patientOptions"
                 item-title="title"
                 item-value="value"
                 clearable


### PR DESCRIPTION
# Summary

- Move patient selector option mapping out of runtime Vue templates and into computed values.
- Restore Aide Notes and Nurse Notes list rendering.
- Prevent failed note-route navigation from leaving subsequent router views blank.

## Related Issue / Task

- Reported blank Aide Notes and Nurse Notes navigation after merging PRs #15, #20, and #21.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `npm run build`
- `docker-compose exec -T backend pytest` (92 passed)
- Browser route sequence: Visits → Aide Notes → Nurse Notes → Patients → Dashboard

## Screenshots

N/A. Browser verification confirmed each affected route renders and subsequent navigation remains functional.

## Checklist

- [x] Changelog updated
- [ ] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.