### PR TITLE
feat: add Keycloak authentication and role-based authorization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ BACKEND_PORT=5001
 FRONTEND_HOST=127.0.0.1
 FRONTEND_PORT=5173
 VITE_API_BASE_URL=http://localhost:5001/api
+VITE_AUTH_ENABLED=false
+VITE_KEYCLOAK_URL=http://localhost:8080
+VITE_KEYCLOAK_REALM=seniormate
+VITE_KEYCLOAK_CLIENT_ID=seniormate-frontend
+VITE_KEYCLOAK_API_CLIENT_ID=seniormate-api
 
 DATABASE_URL=postgresql+psycopg://seniormate:change-me-local-only@postgres:5432/seniormate
 POSTGRES_DB=seniormate
@@ -18,10 +23,10 @@ POSTGRES_USER=seniormate
 POSTGRES_PASSWORD=change-me-local-only
 POSTGRES_PORT=5432
 
-KEYCLOAK_URL=http://localhost:8080
-KEYCLOAK_REALM=seniormate
-KEYCLOAK_CLIENT_ID=seniormate-local
-KEYCLOAK_CLIENT_SECRET=change-me-local-only
+AUTH_ENABLED=false
+KEYCLOAK_ISSUER=http://localhost:8080/realms/seniormate
+KEYCLOAK_JWKS_URL=http://keycloak:8080/realms/seniormate/protocol/openid-connect/certs
+KEYCLOAK_AUDIENCE=seniormate-api
 KEYCLOAK_ADMIN=admin
 KEYCLOAK_ADMIN_PASSWORD=change-me-local-only
 KEYCLOAK_PORT=8080

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added Keycloak/OIDC authentication with local realm configuration, frontend login/logout and token refresh, backend JWT validation, role-based API permissions, protected routes, Swagger bearer authorization, tests, and setup documentation.
 - Added authentication, authorization, organization branding, and default product identity design documentation with four original SeniorMate SVG logo concepts.
 - Added search, filtering, and pagination for patient, visit, aide note, and nurse note list workflows.
 - Added print-friendly patient, visit, aide note, nurse note, and assessment reports with reusable report components and browser print/PDF styling.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ SeniorMate/
 
 ## Local Development
 
-Docker Compose is the recommended way to run the local SeniorMate stack. It starts the Flask backend, Vue/Vite frontend, PostgreSQL, and MinIO with safe local defaults from `.env.example`.
+Docker Compose is the recommended way to run the local SeniorMate stack. It starts the Flask backend, Vue/Vite frontend, PostgreSQL, and MinIO with safe local defaults from `.env.example`. Keycloak can be enabled through the `auth` profile.
 
 ### Prerequisites
 
@@ -108,7 +108,19 @@ Docker Compose is the recommended way to run the local SeniorMate stack. It star
    - MinIO console: `http://localhost:9001`
    - PostgreSQL: `localhost:5432`
 
-Keycloak is included as an optional Compose profile for future authentication work. It is not required for local development yet.
+Authentication is disabled by default for quick local development and automated
+tests. To exercise the full Keycloak login and role-based authorization flow,
+set `AUTH_ENABLED=true` and `VITE_AUTH_ENABLED=true` in `.env`, then start:
+
+```bash
+docker compose --profile auth up --build
+```
+
+Keycloak runs at `http://localhost:8080`. SeniorMate uses Authorization Code
+with PKCE in the frontend and validates signed access tokens, issuer, audience,
+and expiry in the backend. See
+[docs/setup/keycloak-local-setup.md](docs/setup/keycloak-local-setup.md) for
+the imported realm, local demo users, roles, and Swagger testing workflow.
 
 ## CI Checks
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -4,6 +4,7 @@ from flasgger import Swagger, swag_from
 from sqlalchemy import text
 
 from app.config import Config
+from app.auth import protect_api_request
 from app.extensions import db, migrate
 from app.models import AideNote as AideNote
 from app.models import MedicalRecord as MedicalRecord
@@ -29,6 +30,7 @@ def create_app(config_object=Config):
 
     db.init_app(app)
     migrate.init_app(app, db)
+    app.before_request(protect_api_request)
     app.register_blueprint(assessments_bp)
     app.register_blueprint(aide_notes_bp)
     app.register_blueprint(dashboard_bp)

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,237 @@
+from functools import wraps
+
+import jwt
+from flask import current_app, g, jsonify, request
+
+
+ROLE_PERMISSIONS = {
+    "admin": {"*"},
+    "manager": {
+        "patients.read",
+        "patients.write",
+        "visits.read",
+        "visits.write",
+        "aide_notes.read",
+        "aide_notes.write",
+        "nurse_notes.read",
+        "nurse_notes.write",
+        "assessments.read",
+        "assessments.write",
+        "medical_records.read",
+        "medical_records.write",
+        "patient_photos.read",
+        "patient_photos.write",
+        "patient_photos.verify",
+        "dashboard.read",
+        "reports.read",
+    },
+    "nurse": {
+        "patients.read",
+        "visits.read",
+        "visits.write",
+        "aide_notes.read",
+        "nurse_notes.read",
+        "nurse_notes.write",
+        "assessments.read",
+        "assessments.write",
+        "medical_records.read",
+        "medical_records.write",
+        "patient_photos.read",
+        "dashboard.read",
+        "reports.read",
+    },
+    "caregiver": {
+        "patients.read",
+        "visits.read",
+        "aide_notes.read",
+        "aide_notes.write",
+        "nurse_notes.read",
+        "assessments.read",
+        "medical_records.read",
+        "patient_photos.read",
+        "reports.read",
+    },
+    "viewer": {
+        "patients.read",
+        "visits.read",
+        "aide_notes.read",
+        "nurse_notes.read",
+        "assessments.read",
+        "medical_records.read",
+        "patient_photos.read",
+        "dashboard.read",
+        "reports.read",
+    },
+}
+
+PUBLIC_API_PATHS = {
+    "/api/health",
+    "/api/docs",
+    "/api/openapi.json",
+}
+
+_jwks_clients = {}
+
+
+def extract_roles(claims):
+    roles = set(claims.get("realm_access", {}).get("roles", []))
+    audience = current_app.config.get("KEYCLOAK_AUDIENCE", "seniormate-api")
+    roles.update(
+        claims.get("resource_access", {}).get(audience, {}).get("roles", [])
+    )
+    return sorted(role for role in roles if role in ROLE_PERMISSIONS)
+
+
+def decode_access_token(token):
+    jwks_url = current_app.config["KEYCLOAK_JWKS_URL"]
+    client = _jwks_clients.setdefault(jwks_url, jwt.PyJWKClient(jwks_url))
+    signing_key = client.get_signing_key_from_jwt(token)
+    return jwt.decode(
+        token,
+        signing_key.key,
+        algorithms=["RS256"],
+        audience=current_app.config["KEYCLOAK_AUDIENCE"],
+        issuer=current_app.config["KEYCLOAK_ISSUER"],
+    )
+
+
+def get_current_user():
+    return getattr(g, "current_user", None)
+
+
+def _development_user():
+    return {
+        "id": "development-user",
+        "username": "development",
+        "name": "Development User",
+        "email": None,
+        "roles": ["admin"],
+        "claims": {},
+    }
+
+
+def _user_from_claims(claims):
+    return {
+        "id": claims.get("sub"),
+        "username": claims.get("preferred_username"),
+        "name": claims.get("name") or claims.get("preferred_username"),
+        "email": claims.get("email"),
+        "roles": extract_roles(claims),
+        "claims": claims,
+    }
+
+
+def _authentication_error(message):
+    return jsonify({"message": message}), 401
+
+
+def authenticate_request():
+    if get_current_user():
+        return None
+
+    if not current_app.config.get("AUTH_ENABLED", False):
+        g.current_user = _development_user()
+        return None
+
+    authorization = request.headers.get("Authorization", "")
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        return _authentication_error("Authentication required")
+
+    try:
+        claims = decode_access_token(token)
+    except (
+        jwt.PyJWTError,
+        jwt.PyJWKClientError,
+        ValueError,
+        TypeError,
+    ):
+        return _authentication_error("Invalid or expired access token")
+
+    g.current_user = _user_from_claims(claims)
+    return None
+
+
+def _resource_for_path(path):
+    if path.startswith("/api/dashboard"):
+        return "dashboard"
+    if "/medical-records" in path:
+        return "medical_records"
+    if "/aide-notes" in path or "/aide-note" in path:
+        return "aide_notes"
+    if "/nurse-notes" in path or "/nurse-note" in path:
+        return "nurse_notes"
+    if "/assessments" in path:
+        return "assessments"
+    if "/visits" in path:
+        return "visits"
+    if path.startswith("/api/patients") and "/photo" in path:
+        return "patient_photos"
+    if path.startswith("/api/patients"):
+        return "patients"
+    return None
+
+
+def _required_permission(path, method):
+    resource = _resource_for_path(path)
+    if not resource:
+        return None
+    if resource == "patient_photos" and path.endswith("/verify"):
+        return "patient_photos.verify"
+    action = "read" if method in {"GET", "HEAD"} else "write"
+    return f"{resource}.{action}"
+
+
+def user_has_permission(user, permission):
+    if not permission:
+        return False
+    permissions = set()
+    for role in user.get("roles", []):
+        permissions.update(ROLE_PERMISSIONS.get(role, set()))
+    return "*" in permissions or permission in permissions
+
+
+def protect_api_request():
+    if not request.path.startswith("/api/"):
+        return None
+    if request.method == "OPTIONS" or request.path in PUBLIC_API_PATHS:
+        return None
+
+    error = authenticate_request()
+    if error:
+        return error
+    if not current_app.config.get("AUTH_ENABLED", False):
+        return None
+
+    permission = _required_permission(request.path, request.method)
+    if not user_has_permission(get_current_user(), permission):
+        return jsonify({"message": "Insufficient permissions"}), 403
+    return None
+
+
+def login_required(view):
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        error = authenticate_request()
+        if error:
+            return error
+        return view(*args, **kwargs)
+
+    return wrapped
+
+
+def roles_required(*allowed_roles):
+    def decorator(view):
+        @wraps(view)
+        def wrapped(*args, **kwargs):
+            error = authenticate_request()
+            if error:
+                return error
+            roles = set(get_current_user().get("roles", []))
+            if not roles.intersection(allowed_roles):
+                return jsonify({"message": "Insufficient permissions"}), 403
+            return view(*args, **kwargs)
+
+        return wrapped
+
+    return decorator

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,6 +9,16 @@ class Config:
         "postgresql+psycopg://seniormate:change-me-local-only@localhost:5432/seniormate",
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+    AUTH_ENABLED = os.getenv("AUTH_ENABLED", "false").lower() == "true"
+    KEYCLOAK_ISSUER = os.getenv(
+        "KEYCLOAK_ISSUER",
+        "http://localhost:8080/realms/seniormate",
+    )
+    KEYCLOAK_JWKS_URL = os.getenv(
+        "KEYCLOAK_JWKS_URL",
+        f"{KEYCLOAK_ISSUER}/protocol/openid-connect/certs",
+    )
+    KEYCLOAK_AUDIENCE = os.getenv("KEYCLOAK_AUDIENCE", "seniormate-api")
     MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "http://localhost:9000")
     MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "local-access-key")
     MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "change-me-local-only")

--- a/backend/app/swagger.py
+++ b/backend/app/swagger.py
@@ -473,6 +473,17 @@ swagger_template = {
     "schemes": ["http"],
     "consumes": ["application/json"],
     "produces": ["application/json"],
+    "securityDefinitions": {
+        "BearerAuth": {
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header",
+            "description": (
+                "Keycloak access token. Enter the value as: Bearer <token>"
+            ),
+        }
+    },
+    "security": [{"BearerAuth": []}],
     "definitions": {
         "Patient": {
             "type": "object",
@@ -758,6 +769,7 @@ swagger_template = {
 health_spec = {
     "tags": ["Health"],
     "summary": "Check backend and database health",
+    "security": [],
     "responses": {
         200: {
             "description": "Backend and database are available.",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ flasgger==0.9.7b2
 gunicorn==23.0.0
 minio==7.2.20
 psycopg[binary]==3.2.9
+PyJWT[crypto]==2.10.1

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,6 +9,7 @@ from app.extensions import db
 
 class TestConfig(Config):
     TESTING = True
+    AUTH_ENABLED = False
     SQLALCHEMY_DATABASE_URI = "sqlite+pysqlite:///:memory:"
     CORS_ORIGINS = ["http://localhost:5173"]
     MEDICAL_RECORD_MAX_FILE_SIZE = 1024 * 1024

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,94 @@
+from app.auth import extract_roles
+
+
+def token_claims(*roles):
+    return {
+        "sub": "user-123",
+        "preferred_username": "sam",
+        "name": "Sam Care",
+        "email": "sam@example.com",
+        "realm_access": {"roles": list(roles)},
+    }
+
+
+def enable_auth(app, monkeypatch, claims=None, error=None):
+    app.config["AUTH_ENABLED"] = True
+
+    def decode(_token):
+        if error:
+            raise error
+        return claims or token_claims("viewer")
+
+    monkeypatch.setattr("app.auth.decode_access_token", decode)
+
+
+def test_health_remains_public_when_auth_is_enabled(app, client):
+    app.config["AUTH_ENABLED"] = True
+
+    response = client.get("/api/health")
+
+    assert response.status_code == 200
+
+
+def test_protected_endpoint_requires_token(app, client):
+    app.config["AUTH_ENABLED"] = True
+
+    response = client.get("/api/patients")
+
+    assert response.status_code == 401
+    assert response.get_json()["message"] == "Authentication required"
+
+
+def test_invalid_token_returns_unauthorized(app, client, monkeypatch):
+    enable_auth(app, monkeypatch, error=ValueError("invalid token"))
+
+    response = client.get(
+        "/api/patients",
+        headers={"Authorization": "Bearer invalid"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["message"] == "Invalid or expired access token"
+
+
+def test_insufficient_role_returns_forbidden(app, client, monkeypatch):
+    enable_auth(app, monkeypatch, token_claims("viewer"))
+
+    response = client.post(
+        "/api/patients",
+        json={"first_name": "Maria", "last_name": "Santos"},
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+    assert response.status_code == 403
+    assert response.get_json()["message"] == "Insufficient permissions"
+
+
+def test_allowed_role_can_create_patient(app, client, monkeypatch):
+    enable_auth(app, monkeypatch, token_claims("manager"))
+
+    response = client.post(
+        "/api/patients",
+        json={"first_name": "Maria", "last_name": "Santos"},
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+    assert response.status_code == 201
+
+
+def test_auth_disabled_preserves_local_development_behavior(client):
+    response = client.get("/api/patients")
+
+    assert response.status_code == 200
+
+
+def test_extract_roles_combines_realm_and_api_client_roles(app):
+    claims = {
+        "realm_access": {"roles": ["viewer", "offline_access"]},
+        "resource_access": {
+            "seniormate-api": {"roles": ["nurse"]},
+        },
+    }
+
+    with app.app_context():
+        assert extract_roles(claims) == ["nurse", "viewer"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,10 @@ services:
       MINIO_SECURE: ${MINIO_SECURE:-false}
       MEDICAL_RECORD_MAX_FILE_SIZE: ${MEDICAL_RECORD_MAX_FILE_SIZE:-10485760}
       PATIENT_PHOTO_MAX_FILE_SIZE: ${PATIENT_PHOTO_MAX_FILE_SIZE:-5242880}
+      AUTH_ENABLED: ${AUTH_ENABLED:-false}
+      KEYCLOAK_ISSUER: ${KEYCLOAK_ISSUER:-http://localhost:8080/realms/seniormate}
+      KEYCLOAK_JWKS_URL: ${KEYCLOAK_JWKS_URL:-http://keycloak:8080/realms/seniormate/protocol/openid-connect/certs}
+      KEYCLOAK_AUDIENCE: ${KEYCLOAK_AUDIENCE:-seniormate-api}
     ports:
       - "${BACKEND_PORT:-5001}:5000"
     volumes:
@@ -66,8 +70,14 @@ services:
       context: ./frontend
     container_name: seniormate-frontend
     restart: unless-stopped
+    command: sh -c "npm install && npm run dev"
     environment:
       VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:5001/api}
+      VITE_AUTH_ENABLED: ${VITE_AUTH_ENABLED:-false}
+      VITE_KEYCLOAK_URL: ${VITE_KEYCLOAK_URL:-http://localhost:8080}
+      VITE_KEYCLOAK_REALM: ${VITE_KEYCLOAK_REALM:-seniormate}
+      VITE_KEYCLOAK_CLIENT_ID: ${VITE_KEYCLOAK_CLIENT_ID:-seniormate-frontend}
+      VITE_KEYCLOAK_API_CLIENT_ID: ${VITE_KEYCLOAK_API_CLIENT_ID:-seniormate-api}
     ports:
       - "${FRONTEND_PORT:-5173}:5173"
     volumes:
@@ -81,14 +91,18 @@ services:
     container_name: seniormate-keycloak
     profiles:
       - auth
-    command: start-dev
+    command: start-dev --import-realm
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-admin}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-change-me-local-only}
     ports:
       - "${KEYCLOAK_PORT:-8080}:8080"
+    volumes:
+      - ./keycloak/seniormate-realm.json:/opt/keycloak/data/import/seniormate-realm.json:ro
+      - keycloak_data:/opt/keycloak/data
 
 volumes:
   postgres_data:
   minio_data:
   frontend_node_modules:
+  keycloak_data:

--- a/docs/architecture/auth-design.md
+++ b/docs/architecture/auth-design.md
@@ -2,7 +2,10 @@
 
 ## Status
 
-This document defines the intended authentication and authorization architecture for SeniorMate. It is a design reference only. Authentication, login UI, token validation, and permission enforcement are not implemented by this feature.
+SeniorMate now implements the first authentication and authorization layer
+described here. The Vue application uses the official Keycloak JavaScript
+adapter, while the Flask backend validates JWTs against the realm JWKS and
+enforces centralized role-to-permission mappings.
 
 ## Architecture Overview
 
@@ -76,7 +79,10 @@ Realm roles may identify broad SeniorMate access. Client roles on `seniormate-ap
 
 ## Permission Model
 
-The first implementation should translate roles into named permissions rather than scattering role-name checks throughout routes. Example permissions include `patients.read`, `patients.write`, `nurse_notes.write`, and `branding.manage`.
+The implementation translates roles into named permissions in the backend auth
+module rather than scattering role-name checks throughout routes. Example
+permissions include `patients.read`, `patients.write`, and
+`nurse_notes.write`.
 
 Legend:
 
@@ -137,14 +143,18 @@ The exact token shape may use Keycloak's `realm_access`, `resource_access`, and 
 
 ## Frontend Behavior
 
-Future frontend authentication should:
+The frontend authentication layer:
 
-- Redirect unauthenticated users to Keycloak.
-- Restore the intended route after successful login.
-- Keep access tokens in memory where practical.
-- Refresh sessions through the OIDC client without storing long-lived secrets.
-- Use route metadata and permission helpers to hide unavailable actions.
-- Treat backend `401` and `403` responses as authoritative.
+- Redirects unauthenticated users to Keycloak with Authorization Code and PKCE.
+- Keeps access tokens in the Keycloak adapter's in-memory state.
+- Refreshes short-lived access tokens before API requests and on expiry.
+- Adds bearer tokens to JSON, multipart, photo, and document requests.
+- Uses route metadata for write-screen navigation.
+- Treats backend `401` and `403` responses as authoritative.
+
+`AUTH_ENABLED=false` and `VITE_AUTH_ENABLED=false` provide an explicit local
+development and test bypass. Both flags should be enabled together when
+testing real authentication.
 
 ## Multi-Organization Direction
 
@@ -162,10 +172,9 @@ Cross-organization access should be explicit, rare, and audited.
 
 ## Implementation Sequence
 
-1. Add Keycloak local configuration and OIDC client settings.
-2. Add backend JWT validation and normalized identity context.
-3. Add permission mapping and protected API decorators/services.
-4. Add frontend login, logout, session restoration, and route guards.
-5. Add organization scoping to domain records.
-6. Add audit logging for sensitive actions.
-
+1. Completed: Keycloak local configuration and OIDC client settings.
+2. Completed: backend JWT validation and normalized identity context.
+3. Completed: permission mapping and protected API helpers.
+4. Completed: frontend login, logout, token refresh, and route guards.
+5. Future: organization scoping for domain records.
+6. Future: audit logging for sensitive actions.

--- a/docs/setup/keycloak-local-setup.md
+++ b/docs/setup/keycloak-local-setup.md
@@ -1,0 +1,92 @@
+# Local Keycloak Setup
+
+SeniorMate includes a development-only Keycloak realm import for testing login,
+logout, token refresh, and role-based permissions. Authentication remains
+disabled unless both the backend and frontend feature flags are enabled.
+
+## Start the Authenticated Stack
+
+Create `.env` from the example and set:
+
+```bash
+AUTH_ENABLED=true
+VITE_AUTH_ENABLED=true
+```
+
+Start the Compose profile:
+
+```bash
+docker compose --profile auth up --build
+```
+
+Open:
+
+- SeniorMate: `http://localhost:5173`
+- Keycloak: `http://localhost:8080`
+- Keycloak admin console: `http://localhost:8080/admin`
+- Swagger UI: `http://localhost:5001/api/docs`
+
+The local admin username is `admin` and its placeholder password is
+`change-me-local-only`. These credentials are for local development only.
+
+## Imported Realm
+
+The file `keycloak/seniormate-realm.json` creates:
+
+- Realm: `seniormate`
+- Public PKCE client: `seniormate-frontend`
+- Bearer-only API audience: `seniormate-api`
+- Roles: `admin`, `manager`, `nurse`, `caregiver`, `viewer`
+- Groups under `/seniormate-admins` and `/orgs/default/*`
+
+The frontend client adds `seniormate-api` to access-token audiences and includes
+group membership in tokens. It has no client secret.
+
+## Development Users
+
+Each local user uses the placeholder password `change-me-local-only`:
+
+| Username | Role |
+| --- | --- |
+| `admin.demo` | admin |
+| `manager.demo` | manager |
+| `nurse.demo` | nurse |
+| `caregiver.demo` | caregiver |
+| `viewer.demo` | viewer |
+
+Delete or replace these users in any non-local environment.
+
+## Authorization Behavior
+
+- `/api/health`, Swagger UI, and the OpenAPI JSON remain public.
+- Other `/api/*` routes require a bearer token when `AUTH_ENABLED=true`.
+- The backend validates signature, issuer, audience, and expiry using the
+  Keycloak realm JWKS.
+- Frontend route guards improve navigation UX; backend permission checks remain
+  authoritative.
+- With `AUTH_ENABLED=false`, the backend uses a local development identity and
+  existing tests do not contact Keycloak.
+
+## Swagger Authorization
+
+1. Sign in to SeniorMate.
+2. In browser developer tools, inspect a request to `/api/*`.
+3. Copy its `Authorization` request header value.
+4. Open Swagger UI and select **Authorize**.
+5. Paste the complete `Bearer <token>` value.
+
+Tokens are short-lived. Repeat these steps after expiry if Swagger returns
+`401`.
+
+## Reset the Realm
+
+Keycloak imports the realm when its data volume is empty. To recreate the local
+realm from the checked-in import:
+
+```bash
+docker compose --profile auth down
+docker volume rm seniormate_keycloak_data
+docker compose --profile auth up --build
+```
+
+Removing the Keycloak volume deletes local users and realm changes.

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -1,6 +1,6 @@
 # Local Development
 
-SeniorMate runs locally with Docker Compose. The default stack includes the Flask backend, Vue/Vite frontend, PostgreSQL, and MinIO. Keycloak is documented as an optional future authentication service and is not required for normal local development yet.
+SeniorMate runs locally with Docker Compose. The default stack includes the Flask backend, Vue/Vite frontend, PostgreSQL, and MinIO. Keycloak is available through the optional `auth` profile.
 
 ## Prerequisites
 
@@ -136,19 +136,44 @@ Docker Compose uses named volumes for persistent local data:
 
 ## Keycloak
 
-Authentication is not implemented yet. A Keycloak service placeholder is available behind the `auth` profile for future work:
+Authentication is disabled by default so local development and tests do not
+depend on a live identity provider. To run the authenticated stack, set these
+values in `.env`:
 
 ```bash
-docker compose --profile auth up keycloak
+AUTH_ENABLED=true
+VITE_AUTH_ENABLED=true
 ```
 
-The main app remains usable without login for now.
+Then start all services with:
+
+```bash
+docker compose --profile auth up --build
+```
+
+- Keycloak: `http://localhost:8080`
+- Keycloak admin console: `http://localhost:8080/admin`
+- Realm: `seniormate`
+- Frontend client: `seniormate-frontend`
+- API audience: `seniormate-api`
+
+The imported realm and development accounts are described in
+[keycloak-local-setup.md](keycloak-local-setup.md). The credentials in that
+document are local placeholders and must never be reused outside development.
 
 ## Troubleshooting
 
 - If ports are already in use, adjust `BACKEND_PORT`, `FRONTEND_PORT`, `POSTGRES_PORT`, `MINIO_API_PORT`, or `MINIO_CONSOLE_PORT` in `.env`.
 - If the backend health endpoint reports `database: unavailable`, wait for PostgreSQL to finish starting or restart the backend container.
-- If frontend dependencies behave oddly, rebuild the frontend container with `docker compose build frontend`.
+- The frontend container synchronizes npm dependencies on startup so the
+  persistent `frontend_node_modules` volume stays current after package changes.
+  If dependencies still behave oddly, recreate the frontend container with
+  `docker compose up -d --force-recreate frontend`.
+- If login cannot reach Keycloak, confirm the stack was started with
+  `--profile auth` and that both auth feature flags have the same value.
+- If an authenticated API request returns `401`, confirm the token issuer is
+  `http://localhost:8080/realms/seniormate` and includes the
+  `seniormate-api` audience.
 - If medical record uploads fail, confirm MinIO is running and that the backend
   `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` match the local MinIO root
   credentials.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,12 +10,12 @@
       "dependencies": {
         "@mdi/font": "7.4.47",
         "@vitejs/plugin-vue": "5.2.4",
+        "keycloak-js": "26.2.1",
         "vite": "6.4.2",
         "vue": "3.5.16",
         "vue-router": "4.5.1",
         "vuetify": "3.8.8"
-      },
-      "devDependencies": {}
+      }
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
@@ -1036,6 +1036,15 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/keycloak-js": {
+      "version": "26.2.1",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.2.1.tgz",
+      "integrity": "sha512-bZt6fQj/TLBAmivXSxSlqAJxBx/knNZDQGJIW4ensGYGN4N6tUKV8Zj3Y7/LOV8eIpvWsvqV70fbACihK8Ze0Q==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "test"
+      ]
     },
     "node_modules/magic-string": {
       "version": "0.30.21",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,10 +11,10 @@
   "dependencies": {
     "@mdi/font": "7.4.47",
     "@vitejs/plugin-vue": "5.2.4",
+    "keycloak-js": "26.2.1",
     "vite": "6.4.2",
     "vue": "3.5.16",
     "vue-router": "4.5.1",
     "vuetify": "3.8.8"
-  },
-  "devDependencies": {}
+  }
 }

--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -1,0 +1,141 @@
+import Keycloak from "keycloak-js";
+import { reactive } from "vue";
+
+import { authConfig } from "./config.js";
+
+let keycloak;
+let refreshTimer;
+
+export const authState = reactive({
+  ready: false,
+  enabled: authConfig.enabled,
+  authenticated: false,
+  profile: null,
+  roles: [],
+  tokenAvailable: false,
+  error: "",
+});
+
+function rolesFromToken(tokenParsed = {}) {
+  const roles = new Set(tokenParsed.realm_access?.roles || []);
+  const clientRoles =
+    tokenParsed.resource_access?.[authConfig.apiClientId]?.roles || [];
+  clientRoles.forEach((role) => roles.add(role));
+  return [...roles].filter((role) =>
+    ["admin", "manager", "nurse", "caregiver", "viewer"].includes(role),
+  );
+}
+
+function syncState() {
+  const token = keycloak?.tokenParsed || {};
+  authState.authenticated = Boolean(keycloak?.authenticated);
+  authState.tokenAvailable = Boolean(keycloak?.token);
+  authState.roles = rolesFromToken(token);
+  authState.profile = authState.authenticated
+    ? {
+        id: token.sub,
+        username: token.preferred_username,
+        name: token.name || token.preferred_username || "SeniorMate user",
+        email: token.email,
+      }
+    : null;
+}
+
+function clearOidcCallbackParameters() {
+  const url = new URL(window.location.href);
+  const callbackParameters = [
+    "code",
+    "error",
+    "error_description",
+    "iss",
+    "session_state",
+    "state",
+  ];
+  const hadCallback = callbackParameters.some((key) => url.searchParams.has(key));
+  callbackParameters.forEach((key) => url.searchParams.delete(key));
+  if (hadCallback) {
+    window.history.replaceState(
+      window.history.state,
+      document.title,
+      `${url.pathname}${url.search}${url.hash}`,
+    );
+  }
+}
+
+async function refreshToken(minValidity = 30) {
+  if (!authConfig.enabled || !keycloak?.authenticated) {
+    return null;
+  }
+  await keycloak.updateToken(minValidity);
+  syncState();
+  return keycloak.token;
+}
+
+export async function initializeAuth() {
+  if (!authConfig.enabled) {
+    authState.authenticated = true;
+    authState.profile = {
+      id: "development-user",
+      username: "development",
+      name: "Development User",
+      email: null,
+    };
+    authState.roles = ["admin"];
+    authState.ready = true;
+    return;
+  }
+
+  try {
+    keycloak = new Keycloak({
+      url: authConfig.url,
+      realm: authConfig.realm,
+      clientId: authConfig.clientId,
+    });
+    await keycloak.init({
+      onLoad: "login-required",
+      pkceMethod: "S256",
+      responseMode: "query",
+      checkLoginIframe: false,
+    });
+    clearOidcCallbackParameters();
+    syncState();
+    keycloak.onTokenExpired = () => {
+      refreshToken(30).catch(() => keycloak.login());
+    };
+    keycloak.onAuthLogout = syncState;
+    refreshTimer = window.setInterval(() => {
+      refreshToken(60).catch(() => keycloak.login());
+    }, 30000);
+  } catch (error) {
+    authState.error =
+      "Authentication is unavailable. Check the Keycloak service and configuration.";
+    throw error;
+  } finally {
+    authState.ready = true;
+  }
+}
+
+export async function getAccessToken() {
+  return refreshToken();
+}
+
+export function hasAnyRole(roles = []) {
+  return roles.length === 0 || roles.some((role) => authState.roles.includes(role));
+}
+
+export function login() {
+  if (keycloak) {
+    return keycloak.login();
+  }
+  return Promise.resolve();
+}
+
+export function logout() {
+  if (refreshTimer) {
+    window.clearInterval(refreshTimer);
+  }
+  if (keycloak) {
+    return keycloak.logout({ redirectUri: window.location.origin });
+  }
+  return Promise.resolve();
+}

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,2 +1,12 @@
 export const apiBaseUrl =
   import.meta.env.VITE_API_BASE_URL || "http://localhost:5001/api";
+
+export const authConfig = {
+  enabled: import.meta.env.VITE_AUTH_ENABLED === "true",
+  url: import.meta.env.VITE_KEYCLOAK_URL || "http://localhost:8080",
+  realm: import.meta.env.VITE_KEYCLOAK_REALM || "seniormate",
+  clientId:
+    import.meta.env.VITE_KEYCLOAK_CLIENT_ID || "seniormate-frontend",
+  apiClientId:
+    import.meta.env.VITE_KEYCLOAK_API_CLIENT_ID || "seniormate-api",
+};

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -22,7 +22,7 @@ import PrintSection from "./components/PrintSection.js";
 import SectionCard from "./components/SectionCard.js";
 import SignatureBlock from "./components/SignatureBlock.js";
 import StatusChip from "./components/StatusChip.js";
-import router from "./router.js";
+import { initializeAuth } from "./auth.js";
 
 const vuetify = createVuetify({
   components,
@@ -82,20 +82,31 @@ const vuetify = createVuetify({
   },
 });
 
-createApp(App)
-  .component("ChecklistSummary", ChecklistSummary)
-  .component("ConfirmDialog", ConfirmDialog)
-  .component("DetailHeader", DetailHeader)
-  .component("EmptyState", EmptyState)
-  .component("ErrorAlert", ErrorAlert)
-  .component("LoadingState", LoadingState)
-  .component("PageHeader", PageHeader)
-  .component("PrintField", PrintField)
-  .component("PrintPageLayout", PrintPageLayout)
-  .component("PrintSection", PrintSection)
-  .component("SectionCard", SectionCard)
-  .component("SignatureBlock", SignatureBlock)
-  .component("StatusChip", StatusChip)
-  .use(router)
-  .use(vuetify)
-  .mount("#app");
+async function bootstrap() {
+  try {
+    await initializeAuth();
+  } catch (error) {
+    console.error("SeniorMate authentication initialization failed.", error);
+  }
+  const { default: router } = await import("./router.js");
+
+  createApp(App)
+    .component("ChecklistSummary", ChecklistSummary)
+    .component("ConfirmDialog", ConfirmDialog)
+    .component("DetailHeader", DetailHeader)
+    .component("EmptyState", EmptyState)
+    .component("ErrorAlert", ErrorAlert)
+    .component("LoadingState", LoadingState)
+    .component("PageHeader", PageHeader)
+    .component("PrintField", PrintField)
+    .component("PrintPageLayout", PrintPageLayout)
+    .component("PrintSection", PrintSection)
+    .component("SectionCard", SectionCard)
+    .component("SignatureBlock", SignatureBlock)
+    .component("StatusChip", StatusChip)
+    .use(router)
+    .use(vuetify)
+    .mount("#app");
+}
+
+bootstrap();

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from "vue-router";
+import { authState, hasAnyRole, login } from "./auth.js";
 
 import DashboardView from "./views/DashboardView.js";
 import AssessmentDetailView from "./views/AssessmentDetailView.js";
@@ -26,6 +27,7 @@ const routes = [
     path: "/",
     name: "dashboard",
     component: DashboardView,
+    meta: { roles: ["admin", "manager", "nurse", "viewer"] },
   },
   {
     path: "/patients",
@@ -37,6 +39,7 @@ const routes = [
     name: "patient-create",
     component: PatientFormView,
     props: { mode: "create" },
+    meta: { roles: ["admin", "manager"] },
   },
   {
     path: "/patients/:id",
@@ -49,6 +52,7 @@ const routes = [
     name: "patient-edit",
     component: PatientFormView,
     props: { mode: "edit" },
+    meta: { roles: ["admin", "manager"] },
   },
   {
     path: "/patients/:id/print",
@@ -61,6 +65,7 @@ const routes = [
     name: "assessment-create",
     component: AssessmentFormView,
     props: { mode: "create" },
+    meta: { roles: ["admin", "manager", "nurse"] },
   },
   {
     path: "/assessments/:id",
@@ -73,6 +78,7 @@ const routes = [
     name: "assessment-edit",
     component: AssessmentFormView,
     props: { mode: "edit" },
+    meta: { roles: ["admin", "manager", "nurse"] },
   },
   {
     path: "/assessments/:id/print",
@@ -90,6 +96,7 @@ const routes = [
     name: "visit-create",
     component: VisitFormView,
     props: { mode: "create" },
+    meta: { roles: ["admin", "manager", "nurse"] },
   },
   {
     path: "/visits/:id",
@@ -102,6 +109,7 @@ const routes = [
     name: "visit-edit",
     component: VisitFormView,
     props: { mode: "edit" },
+    meta: { roles: ["admin", "manager", "nurse"] },
   },
   {
     path: "/visits/:id/print",
@@ -119,6 +127,7 @@ const routes = [
     name: "aide-note-create",
     component: AideNoteFormView,
     props: { mode: "create" },
+    meta: { roles: ["admin", "manager", "caregiver"] },
   },
   {
     path: "/aide-notes/:id",
@@ -131,6 +140,7 @@ const routes = [
     name: "aide-note-edit",
     component: AideNoteFormView,
     props: { mode: "edit" },
+    meta: { roles: ["admin", "manager", "caregiver"] },
   },
   {
     path: "/aide-notes/:id/print",
@@ -148,6 +158,7 @@ const routes = [
     name: "nurse-note-create",
     component: NurseNoteFormView,
     props: { mode: "create" },
+    meta: { roles: ["admin", "manager", "nurse"] },
   },
   {
     path: "/nurse-notes/:id",
@@ -160,6 +171,7 @@ const routes = [
     name: "nurse-note-edit",
     component: NurseNoteFormView,
     props: { mode: "edit" },
+    meta: { roles: ["admin", "manager", "nurse"] },
   },
   {
     path: "/nurse-notes/:id/print",
@@ -172,6 +184,22 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(),
   routes,
+});
+
+router.beforeEach(async (to) => {
+  if (authState.error) {
+    return true;
+  }
+  if (!authState.authenticated) {
+    await login();
+    return false;
+  }
+  if (!hasAnyRole(to.meta.roles || [])) {
+    return to.name === "dashboard"
+      ? { name: "patients" }
+      : { name: "dashboard" };
+  }
+  return true;
 });
 
 export default router;

--- a/frontend/src/services/http.js
+++ b/frontend/src/services/http.js
@@ -1,4 +1,5 @@
 import { apiBaseUrl } from "../config.js";
+import { getAccessToken } from "../auth.js";
 
 export async function parseResponse(response) {
   const payload = await response.json().catch(() => ({}));
@@ -15,13 +16,30 @@ export async function parseResponse(response) {
 
 export async function apiRequest(path, options = {}) {
   const isFormData = options.body instanceof FormData;
+  const token = await getAccessToken();
   const response = await fetch(`${apiBaseUrl}${path}`, {
     ...options,
     headers: {
       ...(!isFormData ? { "Content-Type": "application/json" } : {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
       ...(options.headers || {}),
     },
   });
 
   return parseResponse(response);
+}
+
+export async function apiBlobRequest(path, options = {}) {
+  const token = await getAccessToken();
+  const response = await fetch(`${apiBaseUrl}${path}`, {
+    ...options,
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(options.headers || {}),
+    },
+  });
+  if (!response.ok) {
+    await parseResponse(response);
+  }
+  return response.blob();
 }

--- a/frontend/src/services/medicalRecords.js
+++ b/frontend/src/services/medicalRecords.js
@@ -1,5 +1,4 @@
-import { apiBaseUrl } from "../config.js";
-import { apiRequest, parseResponse } from "./http.js";
+import { apiBlobRequest, apiRequest } from "./http.js";
 
 
 export async function listMedicalRecords() {
@@ -42,9 +41,5 @@ export async function getPatientMedicalRecords(patientId) {
 }
 
 export async function downloadMedicalRecord(id) {
-  const response = await fetch(`${apiBaseUrl}/medical-records/${id}/download`);
-  if (!response.ok) {
-    await parseResponse(response);
-  }
-  return response.blob();
+  return apiBlobRequest(`/medical-records/${id}/download`);
 }

--- a/frontend/src/services/patients.js
+++ b/frontend/src/services/patients.js
@@ -1,6 +1,5 @@
 import { apiRequest } from "./http.js";
-import { apiBaseUrl } from "../config.js";
-import { parseResponse } from "./http.js";
+import { apiBlobRequest } from "./http.js";
 import { withQuery } from "./query.js";
 
 export async function listPatients(params = {}) {
@@ -41,11 +40,7 @@ export async function uploadPatientPhoto(patientId, file) {
 }
 
 export async function getPatientPhoto(patientId) {
-  const response = await fetch(`${apiBaseUrl}/patients/${patientId}/photo`);
-  if (!response.ok) {
-    await parseResponse(response);
-  }
-  return response.blob();
+  return apiBlobRequest(`/patients/${patientId}/photo`);
 }
 
 export async function verifyPatientPhoto(patientId, verified) {

--- a/frontend/src/views/App.js
+++ b/frontend/src/views/App.js
@@ -1,4 +1,5 @@
-import { ref } from "vue";
+import { computed, ref } from "vue";
+import { authState, login, logout } from "../auth.js";
 
 const navItems = [
   { title: "Dashboard", icon: "mdi-view-dashboard-outline", to: "/" },
@@ -11,10 +12,28 @@ const navItems = [
 export default {
   setup() {
     const drawer = ref(true);
+    const displayRole = computed(() => authState.roles[0] || "user");
+    const userInitials = computed(() => {
+      const name = authState.profile?.name || "";
+      return (
+        name
+          .split(/\s+/)
+          .filter(Boolean)
+          .slice(0, 2)
+          .map((part) => part[0])
+          .join("")
+          .toUpperCase() || "SM"
+      );
+    });
 
     return {
+      authState,
+      displayRole,
       drawer,
+      login,
+      logout,
       navItems,
+      userInitials,
     };
   },
   template: `
@@ -47,8 +66,29 @@ export default {
         </v-list>
 
         <template #append>
-          <div class="pa-4 text-caption text-medium-emphasis">
-            SeniorMate development
+          <div class="pa-3">
+            <v-list-item
+              :title="authState.profile?.name || 'SeniorMate user'"
+              :subtitle="displayRole"
+              rounded="lg"
+            >
+              <template #prepend>
+                <v-avatar color="primary" size="36">
+                  <span class="text-caption font-weight-bold">{{ userInitials }}</span>
+                </v-avatar>
+              </template>
+            </v-list-item>
+            <v-btn
+              v-if="authState.enabled"
+              block
+              variant="text"
+              color="secondary"
+              prepend-icon="mdi-logout"
+              class="mt-2"
+              @click="logout"
+            >
+              Log out
+            </v-btn>
           </div>
         </template>
       </v-navigation-drawer>
@@ -61,7 +101,15 @@ export default {
       </v-app-bar>
 
       <v-main class="app-surface">
-        <router-view />
+        <v-container v-if="authState.error" class="py-12" max-width="720">
+          <v-alert type="error" variant="tonal" title="Sign-in unavailable">
+            {{ authState.error }}
+            <template #append>
+              <v-btn variant="text" @click="login">Retry</v-btn>
+            </template>
+          </v-alert>
+        </v-container>
+        <router-view v-else />
       </v-main>
     </v-app>
   `,

--- a/keycloak/seniormate-realm.json
+++ b/keycloak/seniormate-realm.json
@@ -1,0 +1,175 @@
+{
+  "realm": "seniormate",
+  "displayName": "SeniorMate",
+  "enabled": true,
+  "registrationAllowed": false,
+  "resetPasswordAllowed": true,
+  "rememberMe": true,
+  "roles": {
+    "realm": [
+      { "name": "admin", "description": "Full SeniorMate access" },
+      { "name": "manager", "description": "Operational record management" },
+      { "name": "nurse", "description": "Clinical care workflows" },
+      { "name": "caregiver", "description": "Aide care workflows" },
+      { "name": "viewer", "description": "Read-only access" }
+    ]
+  },
+  "groups": [
+    {
+      "name": "seniormate-admins",
+      "realmRoles": ["admin"]
+    },
+    {
+      "name": "orgs",
+      "subGroups": [
+        {
+          "name": "default",
+          "subGroups": [
+            { "name": "admins", "realmRoles": ["admin"] },
+            { "name": "managers", "realmRoles": ["manager"] },
+            { "name": "nurses", "realmRoles": ["nurse"] },
+            { "name": "caregivers", "realmRoles": ["caregiver"] },
+            { "name": "viewers", "realmRoles": ["viewer"] }
+          ]
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "seniormate-frontend",
+      "name": "SeniorMate Frontend",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": ["http://localhost:5173/*"],
+      "webOrigins": ["http://localhost:5173"],
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "http://localhost:5173/*"
+      },
+      "protocolMappers": [
+        {
+          "name": "seniormate-api-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "seniormate-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "true",
+            "claim.name": "groups",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "seniormate-api",
+      "name": "SeniorMate API",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "bearerOnly": true
+    }
+  ],
+  "users": [
+    {
+      "username": "admin.demo",
+      "firstName": "Admin",
+      "lastName": "Demo",
+      "email": "admin.demo@example.test",
+      "emailVerified": true,
+      "enabled": true,
+      "realmRoles": ["admin"],
+      "groups": ["/seniormate-admins", "/orgs/default/admins"],
+      "credentials": [
+        {
+          "type": "password",
+          "value": "change-me-local-only",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "username": "manager.demo",
+      "firstName": "Manager",
+      "lastName": "Demo",
+      "email": "manager.demo@example.test",
+      "emailVerified": true,
+      "enabled": true,
+      "realmRoles": ["manager"],
+      "groups": ["/orgs/default/managers"],
+      "credentials": [
+        {
+          "type": "password",
+          "value": "change-me-local-only",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "username": "nurse.demo",
+      "firstName": "Nurse",
+      "lastName": "Demo",
+      "email": "nurse.demo@example.test",
+      "emailVerified": true,
+      "enabled": true,
+      "realmRoles": ["nurse"],
+      "groups": ["/orgs/default/nurses"],
+      "credentials": [
+        {
+          "type": "password",
+          "value": "change-me-local-only",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "username": "caregiver.demo",
+      "firstName": "Caregiver",
+      "lastName": "Demo",
+      "email": "caregiver.demo@example.test",
+      "emailVerified": true,
+      "enabled": true,
+      "realmRoles": ["caregiver"],
+      "groups": ["/orgs/default/caregivers"],
+      "credentials": [
+        {
+          "type": "password",
+          "value": "change-me-local-only",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "username": "viewer.demo",
+      "firstName": "Viewer",
+      "lastName": "Demo",
+      "email": "viewer.demo@example.test",
+      "emailVerified": true,
+      "enabled": true,
+      "realmRoles": ["viewer"],
+      "groups": ["/orgs/default/viewers"],
+      "credentials": [
+        {
+          "type": "password",
+          "value": "change-me-local-only",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

- Added an importable local Keycloak realm with the `seniormate-frontend` PKCE client, `seniormate-api` audience, documented groups, roles, and development-only users.
- Integrated the official `keycloak-js` adapter for login, logout, in-memory auth state, token refresh, protected routes, role-aware navigation, authenticated API calls, and user profile display.
- Added centralized Flask JWT validation using Keycloak JWKS plus role-to-permission enforcement for patients, visits, care notes, assessments, medical records, patient photos, dashboard data, and reports.
- Kept `/api/health`, Swagger UI, and OpenAPI JSON public, and retained explicit `AUTH_ENABLED=false` / `VITE_AUTH_ENABLED=false` development and test modes.
- Added Swagger bearer authentication, backend authorization tests, Compose dependency synchronization, Keycloak setup documentation, and a changelog entry.

The official Keycloak JavaScript adapter was chosen because it directly supports Authorization Code with PKCE, token refresh, and Keycloak session/logout behavior without an additional Vue wrapper dependency.

## Related Issue / Task

- Feature: `22-keycloak-auth`

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [x] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `backend/.venv/bin/ruff check .`
- `backend/.venv/bin/pytest -q` (99 passed)
- `npm run build`
- `docker-compose --profile auth config --quiet`
- `docker-compose --profile auth up -d --build`
- Verified Keycloak realm import and OIDC discovery.
- Verified login/logout with `manager.demo`, clean callback handling, user/role display, protected navigation, and authenticated patient/dashboard requests.
- Verified protected APIs return `401` without a token when authentication is enabled.
- Verified health, Swagger UI, and OpenAPI remain public and OpenAPI includes `BearerAuth`.

## Screenshots

N/A. Browser behavior was validated manually against the local Keycloak and SeniorMate stack.

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.