### PR TITLE
feat: harden frontend role permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added centralized frontend role permissions, permission-aware navigation and actions, restricted-route handling, an Access Denied page, permission tests, and a user-facing roles guide.
 - Added admin-only Keycloak user management with a dedicated Admin API client, user and role endpoints, temporary password resets, Swagger documentation, mocked backend tests, and an Admin → Users interface.
 - Added organization branding settings with a singleton database model, private MinIO logo storage, safe public branding delivery, admin/manager APIs, Swagger documentation, dynamic frontend theming, and a Settings → Branding page with live preview and default fallback.
 - Added Keycloak/OIDC authentication with local realm configuration, frontend login/logout and token refresh, backend JWT validation, role-based API permissions, protected routes, Swagger bearer authorization, tests, and setup documentation.

--- a/docs/architecture/auth-design.md
+++ b/docs/architecture/auth-design.md
@@ -85,28 +85,23 @@ module rather than scattering role-name checks throughout routes. Example
 permissions include `patients.read`, `patients.write`, and
 `nurse_notes.write`.
 
-Legend:
-
-- **Manage**: create, read, update, and delete.
-- **Clinical manage**: create, read, and update clinical records; deletion may require an additional policy or audit action.
-- **Assigned manage**: act only on patients or visits assigned to the user.
-- **Read**: view only.
-- **None**: no access.
-
 | Area | Admin | Manager | Nurse | Caregiver | Viewer |
 | --- | --- | --- | --- | --- | --- |
-| Dashboard | Read all organization data | Read all organization data | Read permitted clinical data | Read assigned activity | Read permitted summaries |
-| Patients | Manage | Manage | Read and update clinical context | Read assigned patients | Read |
-| Visits | Manage | Manage | Manage nursing visits | Assigned manage | Read |
-| Aide notes | Manage | Manage | Read | Assigned manage | Read |
-| Nurse notes | Manage | Read | Clinical manage | None | Read |
-| Assessments | Manage | Read | Clinical manage | Create/read assigned basic assessments | Read |
-| Medical records | Manage | Manage | Clinical manage | Read assigned records when permitted | Read |
-| Patient photos | Manage and verify | Manage and verify | Upload and verify | Upload assigned patients | Read |
-| Printable reports | Generate all | Generate all | Generate permitted clinical reports | Generate assigned care reports | Generate read-only reports |
-| Branding/settings | Manage | Read | None | None | None |
+| Dashboard | Read | Read | Read | No access | Read |
+| Patients | Manage | Manage | Read | Read | Read |
+| Visits | Manage | Manage | Manage | Read | Read |
+| Aide notes | Manage | Manage | Read | Manage | Read |
+| Nurse notes | Manage | Manage | Manage | Read | Read |
+| Assessments | Manage | Manage | Manage | Read | Read |
+| Medical records | Manage | Manage | Manage | Read/download | Read/download |
+| Patient photos | Manage and verify | Manage and verify | Read | Read | Read |
+| Printable reports | Read/print | Read/print | Read/print | Read/print | Read/print |
+| Branding/settings | Manage | Manage | Read applied branding | Read applied branding | Read applied branding |
+| User management | Manage | No access | No access | No access | No access |
 
-This matrix is the initial policy proposal. Before implementation, the maintainer should confirm whether viewers may access clinical narrative fields and whether clinical record deletion should be restricted to administrators.
+This table reflects the permissions currently enforced by the backend. Future
+assignment and organization scoping will narrow record visibility without
+making frontend checks authoritative.
 
 ## Token and Claim Design
 
@@ -150,12 +145,23 @@ The frontend authentication layer:
 - Keeps access tokens in the Keycloak adapter's in-memory state.
 - Refreshes short-lived access tokens before API requests and on expiry.
 - Adds bearer tokens to JSON, multipart, photo, and document requests.
-- Uses route metadata for write-screen navigation.
+- Uses a centralized permission policy that mirrors backend permission names.
+- Filters navigation using read permissions and hides unavailable actions.
+- Uses permission-based route metadata for read, write, report, settings, and
+  administration screens.
+- Redirects direct navigation to a restricted route to a dedicated Access
+  Denied page.
 - Treats backend `401` and `403` responses as authoritative.
 
 `AUTH_ENABLED=false` and `VITE_AUTH_ENABLED=false` provide an explicit local
-development and test bypass. Both flags should be enabled together when
-testing real authentication.
+development and test bypass. The frontend assumes the `admin` role in this
+mode so existing local workflows remain available. Both flags should be
+enabled together when testing real authentication.
+
+Hidden actions and route guards are usability controls only. They reduce
+predictable `403` responses but must never replace backend permission checks.
+See [Roles and Permissions](../user-guide/roles-and-permissions.md) for the
+user-facing behavior.
 
 Branding settings are readable by authenticated roles. Only `admin` and
 `manager` roles receive `branding.write`; the public branding and logo preview

--- a/docs/user-guide/roles-and-permissions.md
+++ b/docs/user-guide/roles-and-permissions.md
@@ -1,0 +1,51 @@
+# Roles and Permissions
+
+SeniorMate adapts its navigation, routes, and actions to the roles included in
+the signed-in user's Keycloak access token. Backend authorization remains the
+security boundary; frontend controls only prevent confusing or predictably
+forbidden actions.
+
+## Role Summary
+
+| Role | Typical access |
+| --- | --- |
+| `admin` | Full application access, branding settings, and user management. |
+| `manager` | Manages operational and clinical records plus branding settings. |
+| `nurse` | Manages visits, nurse notes, assessments, and medical records. |
+| `caregiver` | Reads core records and manages aide notes. |
+| `viewer` | Read-only access to records and printable reports. |
+
+## Application Access
+
+| Area | Admin | Manager | Nurse | Caregiver | Viewer |
+| --- | --- | --- | --- | --- | --- |
+| Dashboard | View | View | View | Hidden | View |
+| Patients | Manage | Manage | View | View | View |
+| Visits | Manage | Manage | Manage | View | View |
+| Aide notes | Manage | Manage | View | Manage | View |
+| Nurse notes | Manage | Manage | Manage | View | View |
+| Assessments | Manage | Manage | Manage | View | View |
+| Medical records | Manage | Manage | Manage | View/download | View/download |
+| Patient photos | Manage/verify | Manage/verify | View | View | View |
+| Printable reports | View/print | View/print | View/print | View/print | View/print |
+| Branding settings | Manage | Manage | Hidden | Hidden | Hidden |
+| Admin users | Manage | Hidden | Hidden | Hidden | Hidden |
+
+“Manage” includes the create, edit, and delete actions currently supported by
+that screen.
+
+## Restricted Routes
+
+SeniorMate hides navigation links and action buttons when the current user
+lacks the required permission. Directly opening a restricted URL displays an
+Access Denied page with a link back to an available workspace page.
+
+The API independently validates the access token and permission for every
+protected request. A hidden button or frontend route guard is not a security
+control.
+
+## Local Development
+
+When `VITE_AUTH_ENABLED=false`, the frontend uses admin-like access so all
+workflows remain available without a Keycloak login. Set frontend and backend
+auth flags to `true` together when manually testing real roles.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite --host 0.0.0.0",
     "build": "vite build",
-    "preview": "vite preview --host 0.0.0.0"
+    "preview": "vite preview --host 0.0.0.0",
+    "test:permissions": "node --test tests/permissions.test.js"
   },
   "dependencies": {
     "@mdi/font": "7.4.47",

--- a/frontend/src/components/MedicalRecordsSection.js
+++ b/frontend/src/components/MedicalRecordsSection.js
@@ -7,6 +7,7 @@ import {
   updateMedicalRecord,
   uploadMedicalRecord,
 } from "../services/medicalRecords.js";
+import { canManageMedicalRecords } from "../permissions.js";
 
 
 const emptyUploadForm = () => ({
@@ -213,6 +214,7 @@ export default {
 
     return {
       askDelete,
+      canManageMedicalRecords,
       confirmDelete,
       deleting,
       downloadRecord,
@@ -251,7 +253,7 @@ export default {
           <div class="text-body-2 text-medium-emphasis">
             PDFs, images, Word documents, care plans, prescriptions, and assessments.
           </div>
-          <v-btn color="primary" prepend-icon="mdi-upload-outline" @click="openUpload">
+          <v-btn v-if="canManageMedicalRecords()" color="primary" prepend-icon="mdi-upload-outline" @click="openUpload">
             Upload record
           </v-btn>
         </div>
@@ -313,12 +315,14 @@ export default {
                 @click="downloadRecord(item)"
               />
               <v-btn
+                v-if="canManageMedicalRecords()"
                 icon="mdi-pencil-outline"
                 variant="text"
                 aria-label="Edit medical record details"
                 @click="openEdit(item)"
               />
               <v-btn
+                v-if="canManageMedicalRecords()"
                 icon="mdi-delete-outline"
                 variant="text"
                 color="error"
@@ -331,7 +335,7 @@ export default {
       </template>
     </SectionCard>
 
-    <v-dialog v-model="uploadDialog" max-width="680">
+    <v-dialog v-if="canManageMedicalRecords()" v-model="uploadDialog" max-width="680">
       <v-card>
         <v-card-title class="d-flex align-center ga-2">
           <v-icon icon="mdi-upload-outline" color="primary" />
@@ -385,7 +389,7 @@ export default {
       </v-card>
     </v-dialog>
 
-    <v-dialog v-model="editDialog" max-width="640">
+    <v-dialog v-if="canManageMedicalRecords()" v-model="editDialog" max-width="640">
       <v-card>
         <v-card-title class="d-flex align-center ga-2">
           <v-icon icon="mdi-file-edit-outline" color="primary" />
@@ -423,6 +427,7 @@ export default {
     </v-dialog>
 
     <ConfirmDialog
+      v-if="canManageMedicalRecords()"
       v-model="confirmDelete"
       title="Delete medical record"
       :message="\`Delete \${selectedRecord?.title || 'this medical record'} and its stored file? This cannot be undone.\`"

--- a/frontend/src/components/PatientAssessmentsSection.js
+++ b/frontend/src/components/PatientAssessmentsSection.js
@@ -4,6 +4,7 @@ import {
   deleteAssessment,
   getPatientAssessments,
 } from "../services/assessments.js";
+import { canManageAssessments } from "../permissions.js";
 
 
 const assessmentLabels = {
@@ -85,6 +86,7 @@ export default {
       assessmentLabel,
       assessments,
       askDelete,
+      canManageAssessments,
       confirmDelete,
       deleting,
       error,
@@ -102,7 +104,7 @@ export default {
       icon="mdi-clipboard-text-search-outline"
       class="data-card mb-6"
     >
-      <div class="d-flex flex-wrap justify-end ga-3 mb-4">
+      <div v-if="canManageAssessments()" class="d-flex flex-wrap justify-end ga-3 mb-4">
         <v-btn
           color="primary"
           prepend-icon="mdi-clipboard-plus-outline"
@@ -132,6 +134,7 @@ export default {
             message="Create the first structured assessment for this patient."
           >
             <v-btn
+              v-if="canManageAssessments()"
               color="primary"
               :to="\`/assessments/new?patient_id=\${patientId}\`"
             >
@@ -160,12 +163,14 @@ export default {
             aria-label="View assessment"
           />
           <v-btn
+            v-if="canManageAssessments()"
             icon="mdi-pencil-outline"
             variant="text"
             :to="\`/assessments/\${item.id}/edit\`"
             aria-label="Edit assessment"
           />
           <v-btn
+            v-if="canManageAssessments()"
             icon="mdi-delete-outline"
             variant="text"
             color="error"
@@ -176,6 +181,7 @@ export default {
       </v-data-table>
 
       <ConfirmDialog
+        v-if="canManageAssessments()"
         v-model="confirmDelete"
         title="Delete assessment"
         :message="\`Delete this \${assessmentLabel(selectedAssessment?.assessment_type || '')} assessment?\`"

--- a/frontend/src/permission-policy.js
+++ b/frontend/src/permission-policy.js
@@ -1,0 +1,79 @@
+export const ROLE_PERMISSIONS = {
+  admin: ["*"],
+  manager: [
+    "patients.read",
+    "patients.write",
+    "visits.read",
+    "visits.write",
+    "aide_notes.read",
+    "aide_notes.write",
+    "nurse_notes.read",
+    "nurse_notes.write",
+    "assessments.read",
+    "assessments.write",
+    "medical_records.read",
+    "medical_records.write",
+    "patient_photos.read",
+    "patient_photos.write",
+    "patient_photos.verify",
+    "dashboard.read",
+    "reports.read",
+    "branding.read",
+    "branding.write",
+  ],
+  nurse: [
+    "patients.read",
+    "visits.read",
+    "visits.write",
+    "aide_notes.read",
+    "nurse_notes.read",
+    "nurse_notes.write",
+    "assessments.read",
+    "assessments.write",
+    "medical_records.read",
+    "medical_records.write",
+    "patient_photos.read",
+    "dashboard.read",
+    "reports.read",
+    "branding.read",
+  ],
+  caregiver: [
+    "patients.read",
+    "visits.read",
+    "aide_notes.read",
+    "aide_notes.write",
+    "nurse_notes.read",
+    "assessments.read",
+    "medical_records.read",
+    "patient_photos.read",
+    "reports.read",
+    "branding.read",
+  ],
+  viewer: [
+    "patients.read",
+    "visits.read",
+    "aide_notes.read",
+    "nurse_notes.read",
+    "assessments.read",
+    "medical_records.read",
+    "patient_photos.read",
+    "dashboard.read",
+    "reports.read",
+    "branding.read",
+  ],
+};
+
+export function permissionsForRoles(roles = []) {
+  const permissions = new Set();
+  for (const role of roles) {
+    for (const permission of ROLE_PERMISSIONS[role] || []) {
+      permissions.add(permission);
+    }
+  }
+  return permissions;
+}
+
+export function rolesCan(roles, permission) {
+  const permissions = permissionsForRoles(roles);
+  return permissions.has("*") || permissions.has(permission);
+}

--- a/frontend/src/permissions.js
+++ b/frontend/src/permissions.js
@@ -1,0 +1,47 @@
+import { authState } from "./auth.js";
+import {
+  permissionsForRoles,
+  rolesCan,
+} from "./permission-policy.js";
+
+export { ROLE_PERMISSIONS, permissionsForRoles } from "./permission-policy.js";
+
+function activeRoles(roles) {
+  return roles || authState.roles;
+}
+
+export function hasRole(role, roles) {
+  return activeRoles(roles).includes(role);
+}
+
+export function hasAnyRole(roles, userRoles) {
+  return roles.length === 0
+    || roles.some((role) => activeRoles(userRoles).includes(role));
+}
+
+export function can(permission, roles) {
+  return rolesCan(activeRoles(roles), permission);
+}
+
+export function canAny(permissions, roles) {
+  return permissions.some((permission) => can(permission, roles));
+}
+
+export const canManagePatients = (roles) => can("patients.write", roles);
+export const canCreatePatient = canManagePatients;
+export const canEditPatient = canManagePatients;
+export const canDeletePatient = canManagePatients;
+export const canManageVisits = (roles) => can("visits.write", roles);
+export const canCreateAideNote = (roles) => can("aide_notes.write", roles);
+export const canCreateNurseNote = (roles) => can("nurse_notes.write", roles);
+export const canManageAssessments = (roles) => can("assessments.write", roles);
+export const canManageMedicalRecords = (roles) =>
+  can("medical_records.write", roles);
+export const canManagePatientPhotos = (roles) =>
+  can("patient_photos.write", roles);
+export const canVerifyPatientPhoto = (roles) =>
+  can("patient_photos.verify", roles);
+export const canManageBranding = (roles) => can("branding.write", roles);
+export const canManageUsers = (roles) => can("user_admin.manage", roles);
+export const canViewReports = (roles) => can("reports.read", roles);
+export const canViewDashboard = (roles) => can("dashboard.read", roles);

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -1,6 +1,8 @@
 import { createRouter, createWebHistory } from "vue-router";
-import { authState, hasAnyRole, login } from "./auth.js";
+import { authState, login } from "./auth.js";
+import { can } from "./permissions.js";
 
+import AccessDeniedView from "./views/AccessDeniedView.js";
 import DashboardView from "./views/DashboardView.js";
 import AssessmentDetailView from "./views/AssessmentDetailView.js";
 import AssessmentFormView from "./views/AssessmentFormView.js";
@@ -29,169 +31,188 @@ const routes = [
     path: "/",
     name: "dashboard",
     component: DashboardView,
-    meta: { roles: ["admin", "manager", "nurse", "viewer"] },
+    meta: { permission: "dashboard.read" },
   },
   {
     path: "/patients",
     name: "patients",
     component: PatientListView,
+    meta: { permission: "patients.read" },
   },
   {
     path: "/patients/new",
     name: "patient-create",
     component: PatientFormView,
     props: { mode: "create" },
-    meta: { roles: ["admin", "manager"] },
+    meta: { permission: "patients.write" },
   },
   {
     path: "/patients/:id",
     name: "patient-detail",
     component: PatientDetailView,
     props: true,
+    meta: { permission: "patients.read" },
   },
   {
     path: "/patients/:id/edit",
     name: "patient-edit",
     component: PatientFormView,
     props: { mode: "edit" },
-    meta: { roles: ["admin", "manager"] },
+    meta: { permission: "patients.write" },
   },
   {
     path: "/patients/:id/print",
     name: "patient-print",
     component: PatientPrintView,
     props: true,
+    meta: { permission: "reports.read" },
   },
   {
     path: "/assessments/new",
     name: "assessment-create",
     component: AssessmentFormView,
     props: { mode: "create" },
-    meta: { roles: ["admin", "manager", "nurse"] },
+    meta: { permission: "assessments.write" },
   },
   {
     path: "/assessments/:id",
     name: "assessment-detail",
     component: AssessmentDetailView,
     props: true,
+    meta: { permission: "assessments.read" },
   },
   {
     path: "/assessments/:id/edit",
     name: "assessment-edit",
     component: AssessmentFormView,
     props: { mode: "edit" },
-    meta: { roles: ["admin", "manager", "nurse"] },
+    meta: { permission: "assessments.write" },
   },
   {
     path: "/assessments/:id/print",
     name: "assessment-print",
     component: AssessmentPrintView,
     props: true,
+    meta: { permission: "reports.read" },
   },
   {
     path: "/visits",
     name: "visits",
     component: VisitListView,
+    meta: { permission: "visits.read" },
   },
   {
     path: "/visits/new",
     name: "visit-create",
     component: VisitFormView,
     props: { mode: "create" },
-    meta: { roles: ["admin", "manager", "nurse"] },
+    meta: { permission: "visits.write" },
   },
   {
     path: "/visits/:id",
     name: "visit-detail",
     component: VisitDetailView,
     props: true,
+    meta: { permission: "visits.read" },
   },
   {
     path: "/visits/:id/edit",
     name: "visit-edit",
     component: VisitFormView,
     props: { mode: "edit" },
-    meta: { roles: ["admin", "manager", "nurse"] },
+    meta: { permission: "visits.write" },
   },
   {
     path: "/visits/:id/print",
     name: "visit-print",
     component: VisitPrintView,
     props: true,
+    meta: { permission: "reports.read" },
   },
   {
     path: "/aide-notes",
     name: "aide-notes",
     component: AideNoteListView,
+    meta: { permission: "aide_notes.read" },
   },
   {
     path: "/aide-notes/new",
     name: "aide-note-create",
     component: AideNoteFormView,
     props: { mode: "create" },
-    meta: { roles: ["admin", "manager", "caregiver"] },
+    meta: { permission: "aide_notes.write" },
   },
   {
     path: "/aide-notes/:id",
     name: "aide-note-detail",
     component: AideNoteDetailView,
     props: true,
+    meta: { permission: "aide_notes.read" },
   },
   {
     path: "/aide-notes/:id/edit",
     name: "aide-note-edit",
     component: AideNoteFormView,
     props: { mode: "edit" },
-    meta: { roles: ["admin", "manager", "caregiver"] },
+    meta: { permission: "aide_notes.write" },
   },
   {
     path: "/aide-notes/:id/print",
     name: "aide-note-print",
     component: AideNotePrintView,
     props: true,
+    meta: { permission: "reports.read" },
   },
   {
     path: "/nurse-notes",
     name: "nurse-notes",
     component: NurseNoteListView,
+    meta: { permission: "nurse_notes.read" },
   },
   {
     path: "/nurse-notes/new",
     name: "nurse-note-create",
     component: NurseNoteFormView,
     props: { mode: "create" },
-    meta: { roles: ["admin", "manager", "nurse"] },
+    meta: { permission: "nurse_notes.write" },
   },
   {
     path: "/nurse-notes/:id",
     name: "nurse-note-detail",
     component: NurseNoteDetailView,
     props: true,
+    meta: { permission: "nurse_notes.read" },
   },
   {
     path: "/nurse-notes/:id/edit",
     name: "nurse-note-edit",
     component: NurseNoteFormView,
     props: { mode: "edit" },
-    meta: { roles: ["admin", "manager", "nurse"] },
+    meta: { permission: "nurse_notes.write" },
   },
   {
     path: "/nurse-notes/:id/print",
     name: "nurse-note-print",
     component: NurseNotePrintView,
     props: true,
+    meta: { permission: "reports.read" },
   },
   {
     path: "/admin/users",
     name: "admin-users",
     component: AdminUsersView,
-    meta: { roles: ["admin"] },
+    meta: { permission: "user_admin.manage" },
   },
   {
     path: "/settings/branding",
     name: "branding-settings",
     component: BrandingSettingsView,
-    meta: { roles: ["admin", "manager"] },
+    meta: { permission: "branding.write" },
+  },
+  {
+    path: "/access-denied",
+    name: "access-denied",
+    component: AccessDeniedView,
   },
 ];
 
@@ -208,10 +229,15 @@ router.beforeEach(async (to) => {
     await login();
     return false;
   }
-  if (!hasAnyRole(to.meta.roles || [])) {
-    return to.name === "dashboard"
-      ? { name: "patients" }
-      : { name: "dashboard" };
+  if (
+    to.name !== "access-denied"
+    && to.meta.permission
+    && !can(to.meta.permission)
+  ) {
+    return {
+      name: "access-denied",
+      query: { from: to.fullPath },
+    };
   }
   return true;
 });

--- a/frontend/src/views/AccessDeniedView.js
+++ b/frontend/src/views/AccessDeniedView.js
@@ -1,0 +1,47 @@
+import { computed } from "vue";
+
+import { canViewDashboard } from "../permissions.js";
+
+
+export default {
+  setup() {
+    const returnRoute = computed(() =>
+      canViewDashboard() ? { name: "dashboard" } : { name: "patients" },
+    );
+    const returnLabel = computed(() =>
+      canViewDashboard() ? "Return to dashboard" : "Return to patients",
+    );
+
+    return {
+      returnLabel,
+      returnRoute,
+    };
+  },
+  template: `
+    <div class="page-shell">
+      <v-card class="access-denied">
+        <v-card-text class="text-center pa-10">
+          <v-icon
+            icon="mdi-shield-lock-outline"
+            color="warning"
+            size="58"
+            class="mb-5"
+          />
+          <h1 class="text-h5 font-weight-bold mb-3">Access denied</h1>
+          <p class="text-body-1 text-medium-emphasis mb-6">
+            Your current SeniorMate role does not allow access to this page.
+            Contact an administrator if you believe your access should change.
+          </p>
+          <v-btn
+            color="primary"
+            variant="flat"
+            prepend-icon="mdi-arrow-left"
+            :to="returnRoute"
+          >
+            {{ returnLabel }}
+          </v-btn>
+        </v-card-text>
+      </v-card>
+    </div>
+  `,
+};

--- a/frontend/src/views/AideNoteDetailView.js
+++ b/frontend/src/views/AideNoteDetailView.js
@@ -1,6 +1,7 @@
 import { computed, onMounted, ref } from "vue";
 
 import { getAideNote } from "../services/aideNotes.js";
+import { canCreateAideNote, canViewReports } from "../permissions.js";
 import { listPatients } from "../services/patients.js";
 import { listVisits } from "../services/visits.js";
 
@@ -81,6 +82,8 @@ export default {
 
     return {
       aideNote,
+      canCreateAideNote,
+      canViewReports,
       checklistSections,
       error,
       formatChecklist,
@@ -111,10 +114,10 @@ export default {
           </v-col>
           <v-col cols="12" md="4" class="text-md-right">
             <div class="d-flex flex-wrap justify-md-end ga-2">
-              <v-btn variant="outlined" prepend-icon="mdi-printer-outline" :to="\`/aide-notes/\${aideNote.id}/print\`">
+              <v-btn v-if="canViewReports()" variant="outlined" prepend-icon="mdi-printer-outline" :to="\`/aide-notes/\${aideNote.id}/print\`">
                 Print note
               </v-btn>
-              <v-btn color="primary" prepend-icon="mdi-pencil-outline" :to="\`/aide-notes/\${aideNote.id}/edit\`">
+              <v-btn v-if="canCreateAideNote()" color="primary" prepend-icon="mdi-pencil-outline" :to="\`/aide-notes/\${aideNote.id}/edit\`">
                 Edit aide note
               </v-btn>
             </div>

--- a/frontend/src/views/AideNoteListView.js
+++ b/frontend/src/views/AideNoteListView.js
@@ -1,6 +1,7 @@
 import { computed, onMounted, ref } from "vue";
 
 import { deleteAideNote, listAideNotes } from "../services/aideNotes.js";
+import { canCreateAideNote } from "../permissions.js";
 import { listPatients } from "../services/patients.js";
 import { listVisits } from "../services/visits.js";
 
@@ -138,6 +139,7 @@ export default {
       changePage,
       clearFilters,
       confirmDelete,
+      canCreateAideNote,
       deleting,
       error,
       filters,
@@ -216,8 +218,8 @@ export default {
           <template #[\`item.actions\`]="{ item }">
             <div class="table-actions">
               <v-btn icon="mdi-eye-outline" variant="text" :to="\`/aide-notes/\${item.id}\`" aria-label="View aide note" title="View aide note" />
-              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/aide-notes/\${item.id}/edit\`" aria-label="Edit aide note" title="Edit aide note" />
-              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete aide note" title="Delete aide note" @click="askDelete(item)" />
+              <v-btn v-if="canCreateAideNote()" icon="mdi-pencil-outline" variant="text" :to="\`/aide-notes/\${item.id}/edit\`" aria-label="Edit aide note" title="Edit aide note" />
+              <v-btn v-if="canCreateAideNote()" icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete aide note" title="Delete aide note" @click="askDelete(item)" />
             </div>
           </template>
         </v-data-table>

--- a/frontend/src/views/App.js
+++ b/frontend/src/views/App.js
@@ -5,13 +5,43 @@ import {
   defaultLogoUrl,
   useDefaultLogo,
 } from "../branding.js";
+import {
+  can,
+  canManageBranding,
+  canManageUsers,
+} from "../permissions.js";
 
 const navItems = [
-  { title: "Dashboard", icon: "mdi-view-dashboard-outline", to: "/" },
-  { title: "Patients", icon: "mdi-account-heart-outline", to: "/patients" },
-  { title: "Visits", icon: "mdi-calendar-clock-outline", to: "/visits" },
-  { title: "Aide Notes", icon: "mdi-clipboard-check-outline", to: "/aide-notes" },
-  { title: "Nurse Notes", icon: "mdi-clipboard-pulse-outline", to: "/nurse-notes" },
+  {
+    title: "Dashboard",
+    icon: "mdi-view-dashboard-outline",
+    to: "/",
+    permission: "dashboard.read",
+  },
+  {
+    title: "Patients",
+    icon: "mdi-account-heart-outline",
+    to: "/patients",
+    permission: "patients.read",
+  },
+  {
+    title: "Visits",
+    icon: "mdi-calendar-clock-outline",
+    to: "/visits",
+    permission: "visits.read",
+  },
+  {
+    title: "Aide Notes",
+    icon: "mdi-clipboard-check-outline",
+    to: "/aide-notes",
+    permission: "aide_notes.read",
+  },
+  {
+    title: "Nurse Notes",
+    icon: "mdi-clipboard-pulse-outline",
+    to: "/nurse-notes",
+    permission: "nurse_notes.read",
+  },
 ];
 
 export default {
@@ -30,14 +60,11 @@ export default {
           .toUpperCase() || "SM"
       );
     });
-    const canManageBranding = computed(
-      () =>
-        !authState.enabled ||
-        authState.roles.some((role) => ["admin", "manager"].includes(role)),
+    const visibleNavItems = computed(() =>
+      navItems.filter((item) => can(item.permission)),
     );
-    const canManageUsers = computed(
-      () => !authState.enabled || authState.roles.includes("admin"),
-    );
+    const showBrandingSettings = computed(() => canManageBranding());
+    const showUserManagement = computed(() => canManageUsers());
     const sidebarTextColor = computed(() => {
       const hex = brandingState.sidebar_color.replace("#", "");
       const [red, green, blue] = [0, 2, 4].map((index) =>
@@ -51,17 +78,17 @@ export default {
     return {
       authState,
       brandingState,
-      canManageBranding,
-      canManageUsers,
       defaultLogoUrl,
       displayRole,
       drawer,
       login,
       logout,
-      navItems,
+      showBrandingSettings,
+      showUserManagement,
       sidebarTextColor,
       useDefaultLogo,
       userInitials,
+      visibleNavItems,
     };
   },
   template: `
@@ -94,7 +121,7 @@ export default {
         <v-list density="comfortable" nav class="px-3 pt-4">
           <v-list-subheader>Workspace</v-list-subheader>
           <v-list-item
-            v-for="item in navItems"
+            v-for="item in visibleNavItems"
             :key="item.to"
             :prepend-icon="item.icon"
             :title="item.title"
@@ -106,14 +133,14 @@ export default {
         </v-list>
 
         <v-list
-          v-if="canManageUsers || canManageBranding"
+          v-if="showUserManagement || showBrandingSettings"
           density="comfortable"
           nav
           class="px-3"
         >
           <v-list-subheader>Settings</v-list-subheader>
           <v-list-item
-            v-if="canManageUsers"
+            v-if="showUserManagement"
             prepend-icon="mdi-account-cog-outline"
             title="Users"
             to="/admin/users"
@@ -121,7 +148,7 @@ export default {
             rounded="lg"
           />
           <v-list-item
-            v-if="canManageBranding"
+            v-if="showBrandingSettings"
             prepend-icon="mdi-palette-outline"
             title="Branding"
             to="/settings/branding"

--- a/frontend/src/views/AssessmentDetailView.js
+++ b/frontend/src/views/AssessmentDetailView.js
@@ -1,6 +1,7 @@
 import { computed, onMounted, ref } from "vue";
 
 import { getAssessment } from "../services/assessments.js";
+import { canManageAssessments, canViewReports } from "../permissions.js";
 import { getPatient } from "../services/patients.js";
 import { getVisit } from "../services/visits.js";
 
@@ -77,6 +78,8 @@ export default {
 
     return {
       assessment,
+      canManageAssessments,
+      canViewReports,
       error,
       findingRows,
       loading,
@@ -107,6 +110,7 @@ export default {
         >
           <template #actions>
             <v-btn
+              v-if="canViewReports()"
               variant="outlined"
               prepend-icon="mdi-printer-outline"
               :to="\`/assessments/\${assessment.id}/print\`"
@@ -114,6 +118,7 @@ export default {
               Print assessment
             </v-btn>
             <v-btn
+              v-if="canManageAssessments()"
               color="primary"
               prepend-icon="mdi-pencil-outline"
               :to="\`/assessments/\${assessment.id}/edit\`"

--- a/frontend/src/views/NurseNoteDetailView.js
+++ b/frontend/src/views/NurseNoteDetailView.js
@@ -1,6 +1,7 @@
 import { computed, onMounted, ref } from "vue";
 
 import { getNurseNote } from "../services/nurseNotes.js";
+import { canCreateNurseNote, canViewReports } from "../permissions.js";
 import { listPatients } from "../services/patients.js";
 import { listVisits } from "../services/visits.js";
 
@@ -108,6 +109,8 @@ export default {
 
     return {
       clinicalSections,
+      canCreateNurseNote,
+      canViewReports,
       error,
       formatValue,
       loading,
@@ -140,10 +143,10 @@ export default {
           </v-col>
           <v-col cols="12" md="4" class="text-md-right">
             <div class="d-flex flex-wrap justify-md-end ga-2">
-              <v-btn variant="outlined" prepend-icon="mdi-printer-outline" :to="\`/nurse-notes/\${nurseNote.id}/print\`">
+              <v-btn v-if="canViewReports()" variant="outlined" prepend-icon="mdi-printer-outline" :to="\`/nurse-notes/\${nurseNote.id}/print\`">
                 Print note
               </v-btn>
-              <v-btn color="primary" prepend-icon="mdi-pencil-outline" :to="\`/nurse-notes/\${nurseNote.id}/edit\`">
+              <v-btn v-if="canCreateNurseNote()" color="primary" prepend-icon="mdi-pencil-outline" :to="\`/nurse-notes/\${nurseNote.id}/edit\`">
                 Edit nurse note
               </v-btn>
             </div>

--- a/frontend/src/views/NurseNoteListView.js
+++ b/frontend/src/views/NurseNoteListView.js
@@ -1,6 +1,7 @@
 import { computed, onMounted, ref } from "vue";
 
 import { deleteNurseNote, listNurseNotes } from "../services/nurseNotes.js";
+import { canCreateNurseNote } from "../permissions.js";
 import { listPatients } from "../services/patients.js";
 import { listVisits } from "../services/visits.js";
 
@@ -136,6 +137,7 @@ export default {
       changePage,
       clearFilters,
       confirmDelete,
+      canCreateNurseNote,
       deleting,
       error,
       filters,
@@ -214,8 +216,8 @@ export default {
           <template #[\`item.actions\`]="{ item }">
             <div class="table-actions">
               <v-btn icon="mdi-eye-outline" variant="text" :to="\`/nurse-notes/\${item.id}\`" aria-label="View nurse note" title="View nurse note" />
-              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/nurse-notes/\${item.id}/edit\`" aria-label="Edit nurse note" title="Edit nurse note" />
-              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete nurse note" title="Delete nurse note" @click="askDelete(item)" />
+              <v-btn v-if="canCreateNurseNote()" icon="mdi-pencil-outline" variant="text" :to="\`/nurse-notes/\${item.id}/edit\`" aria-label="Edit nurse note" title="Edit nurse note" />
+              <v-btn v-if="canCreateNurseNote()" icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete nurse note" title="Delete nurse note" @click="askDelete(item)" />
             </div>
           </template>
         </v-data-table>

--- a/frontend/src/views/PatientDetailView.js
+++ b/frontend/src/views/PatientDetailView.js
@@ -3,6 +3,13 @@ import { computed, onMounted, ref } from "vue";
 import MedicalRecordsSection from "../components/MedicalRecordsSection.js";
 import PatientAvatar from "../components/PatientAvatar.js";
 import PatientAssessmentsSection from "../components/PatientAssessmentsSection.js";
+import {
+  canEditPatient,
+  canManagePatientPhotos,
+  canManageVisits,
+  canVerifyPatientPhoto,
+  canViewReports,
+} from "../permissions.js";
 import { getPatientAideNotes } from "../services/aideNotes.js";
 import { getPatientNurseNotes } from "../services/nurseNotes.js";
 import {
@@ -181,6 +188,11 @@ export default {
       askDelete,
       confirmDelete,
       confirmPhotoDelete,
+      canEditPatient,
+      canManagePatientPhotos,
+      canManageVisits,
+      canVerifyPatientPhoto,
+      canViewReports,
       deleting,
       deletingPhoto,
       fullName,
@@ -242,20 +254,20 @@ export default {
             </v-chip>
           </template>
           <template #actions>
-              <v-btn color="primary" prepend-icon="mdi-calendar-plus-outline" :to="\`/visits/new?patient_id=\${patient.id}\`">
+              <v-btn v-if="canManageVisits()" color="primary" prepend-icon="mdi-calendar-plus-outline" :to="\`/visits/new?patient_id=\${patient.id}\`">
                 New visit
               </v-btn>
-              <v-btn color="primary" variant="tonal" prepend-icon="mdi-pencil-outline" :to="\`/patients/\${patient.id}/edit\`">
+              <v-btn v-if="canEditPatient()" color="primary" variant="tonal" prepend-icon="mdi-pencil-outline" :to="\`/patients/\${patient.id}/edit\`">
                 Edit patient
               </v-btn>
-              <v-btn variant="outlined" prepend-icon="mdi-printer-outline" :to="\`/patients/\${patient.id}/print\`">
+              <v-btn v-if="canViewReports()" variant="outlined" prepend-icon="mdi-printer-outline" :to="\`/patients/\${patient.id}/print\`">
                 Print summary
               </v-btn>
-              <v-btn variant="outlined" prepend-icon="mdi-camera-outline" @click="openPhotoDialog">
+              <v-btn v-if="canManagePatientPhotos()" variant="outlined" prepend-icon="mdi-camera-outline" @click="openPhotoDialog">
                 {{ patient.has_photo ? 'Replace photo' : 'Upload photo' }}
               </v-btn>
               <v-btn
-                v-if="patient.has_photo"
+                v-if="patient.has_photo && canVerifyPatientPhoto()"
                 variant="outlined"
                 :prepend-icon="patient.photo_verified ? 'mdi-shield-off-outline' : 'mdi-check-decagram-outline'"
                 :loading="updatingVerification"
@@ -264,7 +276,7 @@ export default {
                 {{ patient.photo_verified ? 'Mark unverified' : 'Mark verified' }}
               </v-btn>
               <v-btn
-                v-if="patient.has_photo"
+                v-if="patient.has_photo && canManagePatientPhotos()"
                 color="error"
                 variant="text"
                 prepend-icon="mdi-delete-outline"
@@ -321,7 +333,7 @@ export default {
               icon="mdi-calendar-clock-outline"
               class="data-card"
             >
-              <div class="d-flex justify-end mb-4">
+              <div v-if="canManageVisits()" class="d-flex justify-end mb-4">
                 <v-btn color="primary" prepend-icon="mdi-plus" :to="\`/visits/new?patient_id=\${patient.id}\`">
                   New visit
                 </v-btn>
@@ -332,8 +344,8 @@ export default {
                     icon="mdi-calendar-plus-outline"
                     title="No visits yet"
                     description="Create the first visit for this patient."
-                    action-label="Create visit"
-                    :action-to="\`/visits/new?patient_id=\${patient.id}\`"
+                    :action-label="canManageVisits() ? 'Create visit' : ''"
+                    :action-to="canManageVisits() ? \`/visits/new?patient_id=\${patient.id}\` : ''"
                   />
                 </template>
                 <template #[\`item.status\`]="{ item }">
@@ -342,8 +354,8 @@ export default {
                 <template #[\`item.actions\`]="{ item }">
                   <div class="table-actions">
                     <v-btn icon="mdi-eye-outline" variant="text" :to="\`/visits/\${item.id}\`" aria-label="View visit" title="View visit" />
-                    <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/visits/\${item.id}/edit\`" aria-label="Edit visit" title="Edit visit" />
-                    <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete visit" title="Delete visit" @click="askDelete(item)" />
+                    <v-btn v-if="canManageVisits()" icon="mdi-pencil-outline" variant="text" :to="\`/visits/\${item.id}/edit\`" aria-label="Edit visit" title="Edit visit" />
+                    <v-btn v-if="canManageVisits()" icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete visit" title="Delete visit" @click="askDelete(item)" />
                   </div>
                 </template>
               </v-data-table>
@@ -405,7 +417,7 @@ export default {
         </v-window>
       </template>
 
-      <v-dialog v-model="photoDialog" max-width="560">
+      <v-dialog v-if="canManagePatientPhotos()" v-model="photoDialog" max-width="560">
         <v-card>
           <v-card-title class="d-flex align-center ga-2">
             <v-icon icon="mdi-camera-outline" color="primary" />
@@ -433,6 +445,7 @@ export default {
       </v-dialog>
 
       <ConfirmDialog
+        v-if="canManagePatientPhotos()"
         v-model="confirmPhotoDelete"
         title="Delete patient photo"
         message="Delete this patient profile photo? The private stored image will also be removed."
@@ -441,6 +454,7 @@ export default {
       />
 
       <ConfirmDialog
+        v-if="canManageVisits()"
         v-model="confirmDelete"
         title="Delete visit"
         :message="\`Delete \${selectedVisit?.visit_type || 'this visit'} from \${selectedVisit?.visit_date || 'the patient record'}?\`"

--- a/frontend/src/views/PatientListView.js
+++ b/frontend/src/views/PatientListView.js
@@ -1,6 +1,11 @@
 import { computed, onMounted, ref } from "vue";
 
 import PatientAvatar from "../components/PatientAvatar.js";
+import {
+  canCreatePatient,
+  canDeletePatient,
+  canEditPatient,
+} from "../permissions.js";
 import { deletePatient, listPatients } from "../services/patients.js";
 
 export default {
@@ -109,6 +114,9 @@ export default {
       changePage,
       clearFilters,
       confirmDelete,
+      canCreatePatient,
+      canDeletePatient,
+      canEditPatient,
       deleting,
       error,
       filters,
@@ -131,7 +139,7 @@ export default {
         icon="mdi-account-heart-outline"
       >
         <template #actions>
-          <v-btn color="primary" prepend-icon="mdi-plus" to="/patients/new">
+          <v-btn v-if="canCreatePatient()" color="primary" prepend-icon="mdi-plus" to="/patients/new">
             New patient
           </v-btn>
         </template>
@@ -197,8 +205,8 @@ export default {
               icon="mdi-account-plus-outline"
               title="No patients yet"
               description="Create the first patient profile to begin tracking care."
-              action-label="Create patient"
-              action-to="/patients/new"
+              :action-label="canCreatePatient() ? 'Create patient' : ''"
+              :action-to="canCreatePatient() ? '/patients/new' : ''"
             />
           </template>
 
@@ -216,8 +224,8 @@ export default {
           <template #[\`item.actions\`]="{ item }">
             <div class="table-actions">
               <v-btn icon="mdi-eye-outline" variant="text" :to="\`/patients/\${item.id}\`" aria-label="View patient" title="View patient" />
-              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/patients/\${item.id}/edit\`" aria-label="Edit patient" title="Edit patient" />
-              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete patient" title="Delete patient" @click="askDelete(item)" />
+              <v-btn v-if="canEditPatient()" icon="mdi-pencil-outline" variant="text" :to="\`/patients/\${item.id}/edit\`" aria-label="Edit patient" title="Edit patient" />
+              <v-btn v-if="canDeletePatient()" icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete patient" title="Delete patient" @click="askDelete(item)" />
             </div>
           </template>
         </v-data-table>

--- a/frontend/src/views/VisitDetailView.js
+++ b/frontend/src/views/VisitDetailView.js
@@ -1,6 +1,13 @@
 import { computed, onMounted, ref } from "vue";
 
 import PatientAvatar from "../components/PatientAvatar.js";
+import {
+  canCreateAideNote,
+  canCreateNurseNote,
+  canManageAssessments,
+  canManageVisits,
+  canViewReports,
+} from "../permissions.js";
 import { getVisitAssessments } from "../services/assessments.js";
 import { getVisitAideNote } from "../services/aideNotes.js";
 import { getVisitNurseNote } from "../services/nurseNotes.js";
@@ -92,6 +99,11 @@ export default {
       aideNote,
       assessments,
       assessmentLabels,
+      canCreateAideNote,
+      canCreateNurseNote,
+      canManageAssessments,
+      canManageVisits,
+      canViewReports,
       error,
       loading,
       nurseNote,
@@ -134,10 +146,10 @@ export default {
             <v-btn variant="outlined" prepend-icon="mdi-account-outline" :to="\`/patients/\${visit.patient_id}\`">
               Patient
             </v-btn>
-            <v-btn variant="outlined" prepend-icon="mdi-printer-outline" :to="\`/visits/\${visit.id}/print\`">
+            <v-btn v-if="canViewReports()" variant="outlined" prepend-icon="mdi-printer-outline" :to="\`/visits/\${visit.id}/print\`">
               Print summary
             </v-btn>
-            <v-btn color="primary" prepend-icon="mdi-pencil-outline" :to="\`/visits/\${visit.id}/edit\`">
+            <v-btn v-if="canManageVisits()" color="primary" prepend-icon="mdi-pencil-outline" :to="\`/visits/\${visit.id}/edit\`">
               Edit visit
             </v-btn>
           </template>
@@ -151,7 +163,7 @@ export default {
         >
           <div class="documentation-actions">
             <v-btn
-              v-if="!aideNote"
+              v-if="!aideNote && canCreateAideNote()"
               class="documentation-action"
               color="primary"
               variant="tonal"
@@ -161,7 +173,7 @@ export default {
               Create aide note
             </v-btn>
             <v-btn
-              v-if="!nurseNote"
+              v-if="!nurseNote && canCreateNurseNote()"
               class="documentation-action"
               color="secondary"
               variant="tonal"
@@ -191,6 +203,7 @@ export default {
               View nurse note
             </v-btn>
             <v-btn
+              v-if="canManageAssessments()"
               class="documentation-action"
               color="secondary"
               variant="tonal"
@@ -200,7 +213,7 @@ export default {
               New assessment
             </v-btn>
             <v-btn
-              v-if="aideNote"
+              v-if="aideNote && canCreateAideNote()"
               class="documentation-action"
               variant="outlined"
               prepend-icon="mdi-pencil-outline"
@@ -209,7 +222,7 @@ export default {
               Edit aide note
             </v-btn>
             <v-btn
-              v-if="nurseNote"
+              v-if="nurseNote && canCreateNurseNote()"
               class="documentation-action"
               variant="outlined"
               prepend-icon="mdi-pencil-outline"
@@ -260,6 +273,7 @@ export default {
             message="Create an assessment with this patient and visit already selected."
           >
             <v-btn
+              v-if="canManageAssessments()"
               color="primary"
               :to="\`/assessments/new?visit_id=\${visit.id}\`"
             >

--- a/frontend/src/views/VisitListView.js
+++ b/frontend/src/views/VisitListView.js
@@ -2,6 +2,7 @@ import { computed, onMounted, ref } from "vue";
 
 import { listPatients } from "../services/patients.js";
 import { deleteVisit, listVisits } from "../services/visits.js";
+import { canManageVisits } from "../permissions.js";
 
 export default {
   setup() {
@@ -132,6 +133,7 @@ export default {
       changePage,
       clearFilters,
       confirmDelete,
+      canManageVisits,
       deleting,
       error,
       filters,
@@ -153,7 +155,7 @@ export default {
         icon="mdi-calendar-clock-outline"
       >
         <template #actions>
-          <v-btn color="primary" prepend-icon="mdi-plus" to="/visits/new">
+          <v-btn v-if="canManageVisits()" color="primary" prepend-icon="mdi-plus" to="/visits/new">
             New visit
           </v-btn>
         </template>
@@ -216,8 +218,8 @@ export default {
               icon="mdi-calendar-plus-outline"
               title="No visits yet"
               description="Schedule the first patient visit to begin tracking care activity."
-              action-label="Create visit"
-              action-to="/visits/new"
+              :action-label="canManageVisits() ? 'Create visit' : ''"
+              :action-to="canManageVisits() ? '/visits/new' : ''"
             />
           </template>
 
@@ -232,8 +234,8 @@ export default {
           <template #[\`item.actions\`]="{ item }">
             <div class="table-actions">
               <v-btn icon="mdi-eye-outline" variant="text" :to="\`/visits/\${item.id}\`" aria-label="View visit" title="View visit" />
-              <v-btn icon="mdi-pencil-outline" variant="text" :to="\`/visits/\${item.id}/edit\`" aria-label="Edit visit" title="Edit visit" />
-              <v-btn icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete visit" title="Delete visit" @click="askDelete(item)" />
+              <v-btn v-if="canManageVisits()" icon="mdi-pencil-outline" variant="text" :to="\`/visits/\${item.id}/edit\`" aria-label="Edit visit" title="Edit visit" />
+              <v-btn v-if="canManageVisits()" icon="mdi-delete-outline" variant="text" color="error" aria-label="Delete visit" title="Delete visit" @click="askDelete(item)" />
             </div>
           </template>
         </v-data-table>

--- a/frontend/tests/permissions.test.js
+++ b/frontend/tests/permissions.test.js
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  permissionsForRoles,
+  rolesCan,
+} from "../src/permission-policy.js";
+
+
+test("admin wildcard grants every permission", () => {
+  assert.equal(rolesCan(["admin"], "future.permission"), true);
+  assert.equal(rolesCan(["admin"], "user_admin.manage"), true);
+});
+
+test("viewer remains read only with report access", () => {
+  assert.equal(rolesCan(["viewer"], "patients.read"), true);
+  assert.equal(rolesCan(["viewer"], "patients.write"), false);
+  assert.equal(rolesCan(["viewer"], "visits.write"), false);
+  assert.equal(rolesCan(["viewer"], "reports.read"), true);
+});
+
+test("clinical write permissions match the backend map", () => {
+  assert.equal(rolesCan(["caregiver"], "aide_notes.write"), true);
+  assert.equal(rolesCan(["caregiver"], "nurse_notes.write"), false);
+  assert.equal(rolesCan(["nurse"], "nurse_notes.write"), true);
+  assert.equal(rolesCan(["nurse"], "medical_records.write"), true);
+  assert.equal(rolesCan(["nurse"], "patient_photos.verify"), false);
+});
+
+test("settings permissions distinguish managers from admins", () => {
+  assert.equal(rolesCan(["manager"], "branding.write"), true);
+  assert.equal(rolesCan(["manager"], "user_admin.manage"), false);
+  assert.equal(rolesCan(["admin"], "user_admin.manage"), true);
+});
+
+test("multiple roles combine their permissions", () => {
+  const permissions = permissionsForRoles(["viewer", "caregiver"]);
+  assert.equal(permissions.has("dashboard.read"), true);
+  assert.equal(permissions.has("aide_notes.write"), true);
+});


### PR DESCRIPTION
# Summary

- Add a centralized frontend role-to-permission policy aligned with backend authorization.
- Filter navigation and patient, visit, note, assessment, medical-record, photo, report, branding, and user-management actions by permission.
- Protect restricted routes with permission metadata and a dedicated Access Denied page.
- Add permission tests and document role behavior, including auth-disabled local development.

## Related Issue / Task

- Feature: `25-rbac-ui-hardening`

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `cd frontend && npm run test:permissions`
- `cd frontend && npm run build`
- `git diff --check`
- Browser verification of auth-disabled admin navigation/actions and the Access Denied route on `http://localhost:5174`

## Screenshots

- N/A. Permission-driven visibility and the Access Denied route were validated in the local browser.

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.