### PR TITLE
fix: enable Keycloak authentication by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ BACKEND_PORT=5001
 FRONTEND_HOST=127.0.0.1
 FRONTEND_PORT=5173
 VITE_API_BASE_URL=http://localhost:5001/api
-VITE_AUTH_ENABLED=false
+VITE_AUTH_ENABLED=true
 VITE_KEYCLOAK_URL=http://localhost:8080
 VITE_KEYCLOAK_REALM=seniormate
 VITE_KEYCLOAK_CLIENT_ID=seniormate-frontend
@@ -23,7 +23,7 @@ POSTGRES_USER=seniormate
 POSTGRES_PASSWORD=change-me-local-only
 POSTGRES_PORT=5432
 
-AUTH_ENABLED=false
+AUTH_ENABLED=true
 KEYCLOAK_ISSUER=http://localhost:8080/realms/seniormate
 KEYCLOAK_JWKS_URL=http://keycloak:8080/realms/seniormate/protocol/openid-connect/certs
 KEYCLOAK_AUDIENCE=seniormate-api

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Enabled authentication and the Keycloak service by default in the standard local Docker Compose stack.
 - Fixed Aide Notes and Nurse Notes list routes failing to render and leaving subsequent navigation blank.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,12 +110,11 @@ Docker Compose is the recommended way to run the local SeniorMate stack. It star
    - MinIO console: `http://localhost:9001`
    - PostgreSQL: `localhost:5432`
 
-Authentication is disabled by default for quick local development and automated
-tests. To exercise the full Keycloak login and role-based authorization flow,
-set `AUTH_ENABLED=true` and `VITE_AUTH_ENABLED=true` in `.env`, then start:
+Authentication and Keycloak are enabled by default. Start the complete local
+stack, including the imported development realm, with:
 
 ```bash
-docker compose --profile auth up --build
+docker compose up --build
 ```
 
 Keycloak runs at `http://localhost:8080`. SeniorMate uses Authorization Code
@@ -123,6 +122,10 @@ with PKCE in the frontend and validates signed access tokens, issuer, audience,
 and expiry in the backend. See
 [docs/setup/keycloak-local-setup.md](docs/setup/keycloak-local-setup.md) for
 the imported realm, local demo users, roles, and Swagger testing workflow.
+
+For a temporary unauthenticated development session, set both
+`AUTH_ENABLED=false` and `VITE_AUTH_ENABLED=false`. Automated backend tests
+continue to disable authentication explicitly.
 
 Administrators and managers can customize the app and organization names,
 logo, theme colors, banner text, and footer text from `Settings → Branding`.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,7 +9,7 @@ class Config:
         "postgresql+psycopg://seniormate:change-me-local-only@localhost:5432/seniormate",
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    AUTH_ENABLED = os.getenv("AUTH_ENABLED", "false").lower() == "true"
+    AUTH_ENABLED = os.getenv("AUTH_ENABLED", "true").lower() == "true"
     KEYCLOAK_ISSUER = os.getenv(
         "KEYCLOAK_ISSUER",
         "http://localhost:8080/realms/seniormate",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       MEDICAL_RECORD_MAX_FILE_SIZE: ${MEDICAL_RECORD_MAX_FILE_SIZE:-10485760}
       PATIENT_PHOTO_MAX_FILE_SIZE: ${PATIENT_PHOTO_MAX_FILE_SIZE:-5242880}
       BRANDING_LOGO_MAX_FILE_SIZE: ${BRANDING_LOGO_MAX_FILE_SIZE:-2097152}
-      AUTH_ENABLED: ${AUTH_ENABLED:-false}
+      AUTH_ENABLED: ${AUTH_ENABLED:-true}
       KEYCLOAK_ISSUER: ${KEYCLOAK_ISSUER:-http://localhost:8080/realms/seniormate}
       KEYCLOAK_JWKS_URL: ${KEYCLOAK_JWKS_URL:-http://keycloak:8080/realms/seniormate/protocol/openid-connect/certs}
       KEYCLOAK_AUDIENCE: ${KEYCLOAK_AUDIENCE:-seniormate-api}
@@ -69,6 +69,8 @@ services:
         condition: service_healthy
       minio:
         condition: service_started
+      keycloak:
+        condition: service_started
 
   frontend:
     build:
@@ -78,7 +80,7 @@ services:
     command: sh -c "npm install && npm run dev"
     environment:
       VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:5001/api}
-      VITE_AUTH_ENABLED: ${VITE_AUTH_ENABLED:-false}
+      VITE_AUTH_ENABLED: ${VITE_AUTH_ENABLED:-true}
       VITE_KEYCLOAK_URL: ${VITE_KEYCLOAK_URL:-http://localhost:8080}
       VITE_KEYCLOAK_REALM: ${VITE_KEYCLOAK_REALM:-seniormate}
       VITE_KEYCLOAK_CLIENT_ID: ${VITE_KEYCLOAK_CLIENT_ID:-seniormate-frontend}
@@ -94,8 +96,7 @@ services:
   keycloak:
     image: quay.io/keycloak/keycloak:26.2
     container_name: seniormate-keycloak
-    profiles:
-      - auth
+    restart: unless-stopped
     command: start-dev --import-realm
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-admin}

--- a/docs/architecture/auth-design.md
+++ b/docs/architecture/auth-design.md
@@ -153,10 +153,11 @@ The frontend authentication layer:
   Denied page.
 - Treats backend `401` and `403` responses as authoritative.
 
-`AUTH_ENABLED=false` and `VITE_AUTH_ENABLED=false` provide an explicit local
+Authentication is enabled by default in the application and local Compose
+stack. `AUTH_ENABLED=false` and `VITE_AUTH_ENABLED=false` provide an explicit
 development and test bypass. The frontend assumes the `admin` role in this
-mode so existing local workflows remain available. Both flags should be
-enabled together when testing real authentication.
+mode so existing local workflows remain available. Both flags must use the
+same value.
 
 Hidden actions and route guards are usability controls only. They reduce
 predictable `403` responses but must never replace backend permission checks.

--- a/docs/setup/keycloak-local-setup.md
+++ b/docs/setup/keycloak-local-setup.md
@@ -1,22 +1,22 @@
 # Local Keycloak Setup
 
 SeniorMate includes a development-only Keycloak realm import for testing login,
-logout, token refresh, and role-based permissions. Authentication remains
-disabled unless both the backend and frontend feature flags are enabled.
+logout, token refresh, and role-based permissions. Authentication is enabled
+by default in the local Compose stack.
 
 ## Start the Authenticated Stack
 
-Create `.env` from the example and set:
+Create `.env` from the example. The default values already enable:
 
 ```bash
 AUTH_ENABLED=true
 VITE_AUTH_ENABLED=true
 ```
 
-Start the Compose profile:
+Start the standard Compose stack:
 
 ```bash
-docker compose --profile auth up --build
+docker compose up --build
 ```
 
 Open:
@@ -79,7 +79,8 @@ Delete or replace these users in any non-local environment.
 - Frontend route guards improve navigation UX; backend permission checks remain
   authoritative.
 - With `AUTH_ENABLED=false`, the backend uses a local development identity and
-  existing tests do not contact Keycloak.
+  existing tests do not contact Keycloak. Set `VITE_AUTH_ENABLED=false` at the
+  same time to bypass frontend login.
 - Admin users can manage realm users at `http://localhost:5173/admin/users`.
   Other SeniorMate roles cannot access the navigation item or backend routes.
 
@@ -100,9 +101,9 @@ Keycloak imports the realm when its data volume is empty. To recreate the local
 realm from the checked-in import:
 
 ```bash
-docker compose --profile auth down
+docker compose down
 docker volume rm seniormate_keycloak_data
-docker compose --profile auth up --build
+docker compose up --build
 ```
 
 Removing the Keycloak volume deletes local users and realm changes.

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -142,19 +142,18 @@ Docker Compose uses named volumes for persistent local data:
 
 ## Keycloak
 
-Authentication is disabled by default so local development and tests do not
-depend on a live identity provider. To run the authenticated stack, set these
-values in `.env`:
+Authentication and Keycloak are enabled in the standard local stack. The safe
+placeholder values in `.env.example` are sufficient for local development:
 
 ```bash
 AUTH_ENABLED=true
 VITE_AUTH_ENABLED=true
 ```
 
-Then start all services with:
+Start all services with:
 
 ```bash
-docker compose --profile auth up --build
+docker compose up --build
 ```
 
 - Keycloak: `http://localhost:8080`
@@ -167,6 +166,9 @@ The imported realm and development accounts are described in
 [keycloak-local-setup.md](keycloak-local-setup.md). The credentials in that
 document are local placeholders and must never be reused outside development.
 
+To bypass login temporarily, set both auth flags to `false`. Keep the frontend
+and backend values aligned.
+
 ## Troubleshooting
 
 - If ports are already in use, adjust `BACKEND_PORT`, `FRONTEND_PORT`, `POSTGRES_PORT`, `MINIO_API_PORT`, or `MINIO_CONSOLE_PORT` in `.env`.
@@ -175,8 +177,8 @@ document are local placeholders and must never be reused outside development.
   persistent `frontend_node_modules` volume stays current after package changes.
   If dependencies still behave oddly, recreate the frontend container with
   `docker compose up -d --force-recreate frontend`.
-- If login cannot reach Keycloak, confirm the stack was started with
-  `--profile auth` and that both auth feature flags have the same value.
+- If login cannot reach Keycloak, confirm the `keycloak` container is running
+  and that both auth feature flags have the same value.
 - If an authenticated API request returns `401`, confirm the token issuer is
   `http://localhost:8080/realms/seniormate` and includes the
   `seniormate-api` audience.

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -2,7 +2,7 @@ export const apiBaseUrl =
   import.meta.env.VITE_API_BASE_URL || "http://localhost:5001/api";
 
 export const authConfig = {
-  enabled: import.meta.env.VITE_AUTH_ENABLED === "true",
+  enabled: import.meta.env.VITE_AUTH_ENABLED !== "false",
   url: import.meta.env.VITE_KEYCLOAK_URL || "http://localhost:8080",
   realm: import.meta.env.VITE_KEYCLOAK_REALM || "seniormate",
   clientId:


### PR DESCRIPTION
# Summary

- Start Keycloak as part of the standard `docker compose up` stack instead of requiring an `auth` profile.
- Default backend and frontend authentication flags to enabled across Compose, Flask, Vite, and `.env.example`.
- Preserve the explicit local/test bypass when both auth flags are set to `false`.
- Update authentication and local setup documentation to describe the default authenticated workflow.

## Related Issue / Task

- Follow-up to Feature 25 RBAC UI hardening

## Type of Change

- [ ] Feature
- [x] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `docker-compose config`
- `docker-compose up -d keycloak`
- Keycloak OIDC discovery endpoint returned HTTP 200
- `cd backend && .venv/bin/ruff check .`
- `cd backend && .venv/bin/pytest` (121 passed)
- `cd frontend && npm run test:permissions` (5 passed)
- `cd frontend && npm run build`
- `git diff --check`

## Screenshots

N/A. This change affects service startup and authentication defaults.

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.