### PR TITLE
feat: add guarded demo seed data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ APP_ENV=development
 APP_DEBUG=true
 APP_SECRET_KEY=change-me-local-only
 CORS_ORIGINS=http://localhost:5173
+DEMO_DATA_ENABLED=false
 
 BACKEND_HOST=127.0.0.1
 BACKEND_PORT=5001

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added guarded, repeatable demo seed and clear commands with explicit demo markers, fictional patients and care activity, generated private medical-record PDFs, safety tests, and setup documentation.
 - Added centralized frontend role permissions, permission-aware navigation and actions, restricted-route handling, an Access Denied page, permission tests, and a user-facing roles guide.
 - Added admin-only Keycloak user management with a dedicated Admin API client, user and role endpoints, temporary password resets, Swagger documentation, mocked backend tests, and an Admin → Users interface.
 - Added organization branding settings with a singleton database model, private MinIO logo storage, safe public branding delivery, admin/manager APIs, Swagger documentation, dynamic frontend theming, and a Settings → Branding page with live preview and default fallback.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ For a temporary unauthenticated development session, set both
 `AUTH_ENABLED=false` and `VITE_AUTH_ENABLED=false`. Automated backend tests
 continue to disable authentication explicitly.
 
+Optional fictional demo records can be created through guarded Flask CLI
+commands. Demo seeding is disabled by default and never runs at startup. See
+[docs/setup/demo-data.md](docs/setup/demo-data.md) for enablement, seed, reset,
+and safety instructions.
+
 Administrators and managers can customize the app and organization names,
 logo, theme colors, banner text, and footer text from `Settings → Branding`.
 Custom logos remain private in MinIO and are delivered through the backend.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -4,6 +4,7 @@ from flasgger import Swagger, swag_from
 from sqlalchemy import text
 
 from app.config import Config
+from app.demo_data import register_demo_commands
 from app.auth import protect_api_request
 from app.extensions import db, migrate
 from app.models import AideNote as AideNote
@@ -43,6 +44,7 @@ def create_app(config_object=Config):
     app.register_blueprint(nurse_notes_bp)
     app.register_blueprint(patients_bp)
     app.register_blueprint(visits_bp)
+    register_demo_commands(app)
 
     @app.get("/api/health")
     @swag_from(health_spec)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -2,6 +2,7 @@ import os
 
 
 class Config:
+    APP_ENV = os.getenv("APP_ENV", "development")
     SECRET_KEY = os.getenv("APP_SECRET_KEY", "change-me-local-only")
     DEBUG = os.getenv("APP_DEBUG", "false").lower() == "true"
     SQLALCHEMY_DATABASE_URI = os.getenv(
@@ -9,6 +10,7 @@ class Config:
         "postgresql+psycopg://seniormate:change-me-local-only@localhost:5432/seniormate",
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+    DEMO_DATA_ENABLED = os.getenv("DEMO_DATA_ENABLED", "false").lower() == "true"
     AUTH_ENABLED = os.getenv("AUTH_ENABLED", "true").lower() == "true"
     KEYCLOAK_ISSUER = os.getenv(
         "KEYCLOAK_ISSUER",

--- a/backend/app/demo_data.py
+++ b/backend/app/demo_data.py
@@ -1,0 +1,459 @@
+from datetime import UTC, date, datetime, time, timedelta
+from io import BytesIO
+
+import click
+from flask import current_app
+
+from app.extensions import db
+from app.models import (
+    AideNote,
+    MedicalRecord,
+    NurseNote,
+    Patient,
+    PatientAssessment,
+    Visit,
+)
+from app.storage import get_medical_record_storage
+
+
+DEMO_PATIENTS = (
+    ("Maya", "Henderson", "1942-03-14", "female", "Hypertension and osteoarthritis"),
+    ("Arthur", "Bennett", "1938-11-02", "male", "Type 2 diabetes and reduced mobility"),
+    ("Elena", "Morales", "1946-07-21", "female", "Chronic obstructive pulmonary disease"),
+    ("Samuel", "Brooks", "1940-01-09", "male", "Congestive heart failure"),
+    ("Nora", "Patel", "1951-05-18", "female", "Early cognitive impairment"),
+    ("George", "Kim", "1936-09-27", "male", "Post-stroke weakness"),
+    ("Lillian", "Foster", "1944-12-06", "female", "Osteoporosis and fall risk"),
+    ("Henry", "Wallace", "1948-04-30", "male", "Parkinsonian symptoms"),
+    ("Rosa", "Martinez", "1939-08-12", "female", "Diabetes and peripheral neuropathy"),
+    ("Edward", "Clarke", "1943-02-25", "male", "Coronary artery disease"),
+    ("Grace", "Nguyen", "1950-10-16", "female", "Chronic kidney disease"),
+    ("Walter", "Reed", "1937-06-03", "male", "Arthritis and chronic pain"),
+    ("Irene", "Sullivan", "1945-01-29", "female", "Macular degeneration"),
+    ("Frank", "Douglas", "1941-07-08", "male", "Hypertension and balance concerns"),
+    ("Teresa", "Ramirez", "1949-03-19", "female", "Recovery after hip replacement"),
+    ("Leonard", "Price", "1935-12-11", "male", "Mild dementia"),
+    ("June", "Carter", "1947-05-05", "female", "Asthma and limited endurance"),
+    ("Raymond", "Owens", "1942-09-23", "male", "Diabetes and wound monitoring"),
+    ("Dolores", "Evans", "1938-04-17", "female", "Heart failure and edema"),
+    ("Albert", "Turner", "1946-11-28", "male", "Post-operative rehabilitation"),
+    ("Beatrice", "Coleman", "1940-06-15", "female", "Nutrition and weight monitoring"),
+    ("Victor", "Hayes", "1952-02-04", "male", "Multiple sclerosis"),
+    ("Marian", "Perry", "1943-08-31", "female", "Anxiety and medication support"),
+    ("Louis", "Ward", "1939-10-20", "male", "Respiratory monitoring"),
+)
+
+AIDE_NAMES = ("Avery Johnson", "Jordan Lee", "Morgan Davis", "Casey Brown")
+NURSE_NAMES = ("Taylor Morgan, RN", "Riley Chen, RN", "Jamie Patel, LPN")
+VISIT_TYPES = (
+    "Personal care",
+    "Skilled nursing",
+    "Medication review",
+    "Wellness check",
+    "Mobility support",
+)
+ASSESSMENT_TYPES = ("fall_risk", "nutrition", "mobility", "cognitive", "general")
+
+
+def _demo_enabled():
+    return current_app.config.get("DEMO_DATA_ENABLED", False)
+
+
+def _require_demo_enabled():
+    if current_app.config.get("APP_ENV") == "production":
+        raise click.ClickException(
+            "Demo data commands are unavailable when APP_ENV=production."
+        )
+    if not _demo_enabled():
+        raise click.ClickException(
+            "Demo data is disabled. Set DEMO_DATA_ENABLED=true explicitly "
+            "before running this command."
+        )
+
+
+def _pdf_bytes(patient_name):
+    message = f"SeniorMate fictional demo care summary for {patient_name}."
+    content = f"BT /F1 12 Tf 72 720 Td ({message}) Tj ET".encode("ascii")
+    objects = (
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        (
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            b"/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+        ),
+        b"<< /Length "
+        + str(len(content)).encode("ascii")
+        + b" >>\nstream\n"
+        + content
+        + b"\nendstream",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    )
+    pdf = bytearray(b"%PDF-1.4\n")
+    offsets = [0]
+    for object_number, body in enumerate(objects, start=1):
+        offsets.append(len(pdf))
+        pdf.extend(f"{object_number} 0 obj\n".encode("ascii"))
+        pdf.extend(body)
+        pdf.extend(b"\nendobj\n")
+    xref_offset = len(pdf)
+    pdf.extend(f"xref\n0 {len(objects) + 1}\n".encode("ascii"))
+    pdf.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        pdf.extend(f"{offset:010d} 00000 n \n".encode("ascii"))
+    pdf.extend(
+        (
+            f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+            f"startxref\n{xref_offset}\n%%EOF\n"
+        ).encode("ascii")
+    )
+    return bytes(pdf)
+
+
+def _non_demo_dependencies_exist(patient_ids, visit_ids):
+    checks = (
+        Visit.query.filter(
+            Visit.patient_id.in_(patient_ids),
+            Visit.is_demo_data.is_(False),
+        ),
+        AideNote.query.filter(
+            AideNote.patient_id.in_(patient_ids),
+            AideNote.is_demo_data.is_(False),
+        ),
+        NurseNote.query.filter(
+            NurseNote.patient_id.in_(patient_ids),
+            NurseNote.is_demo_data.is_(False),
+        ),
+        PatientAssessment.query.filter(
+            PatientAssessment.patient_id.in_(patient_ids),
+            PatientAssessment.is_demo_data.is_(False),
+        ),
+        MedicalRecord.query.filter(
+            MedicalRecord.patient_id.in_(patient_ids),
+            MedicalRecord.is_demo_data.is_(False),
+        ),
+    )
+    if visit_ids:
+        checks += (
+            AideNote.query.filter(
+                AideNote.visit_id.in_(visit_ids),
+                AideNote.is_demo_data.is_(False),
+            ),
+            NurseNote.query.filter(
+                NurseNote.visit_id.in_(visit_ids),
+                NurseNote.is_demo_data.is_(False),
+            ),
+            PatientAssessment.query.filter(
+                PatientAssessment.visit_id.in_(visit_ids),
+                PatientAssessment.is_demo_data.is_(False),
+            ),
+        )
+    return any(query.first() is not None for query in checks)
+
+
+def clear_demo_records():
+    demo_patients = Patient.query.filter_by(is_demo_data=True).all()
+    patient_ids = [patient.id for patient in demo_patients]
+    visit_ids = [
+        visit_id
+        for (visit_id,) in db.session.query(Visit.id)
+        .filter(Visit.is_demo_data.is_(True))
+        .all()
+    ]
+
+    if patient_ids and _non_demo_dependencies_exist(patient_ids, visit_ids):
+        raise click.ClickException(
+            "Demo patients or visits have non-demo dependent records. "
+            "Clear or reclassify those records before deleting demo data."
+        )
+
+    records = MedicalRecord.query.filter_by(is_demo_data=True).all()
+    storage = get_medical_record_storage()
+    for record in records:
+        storage.delete(record.storage_object_key)
+
+    counts = {
+        "medical_records": len(records),
+        "assessments": PatientAssessment.query.filter_by(is_demo_data=True).count(),
+        "aide_notes": AideNote.query.filter_by(is_demo_data=True).count(),
+        "nurse_notes": NurseNote.query.filter_by(is_demo_data=True).count(),
+        "visits": Visit.query.filter_by(is_demo_data=True).count(),
+        "patients": len(demo_patients),
+    }
+
+    MedicalRecord.query.filter_by(is_demo_data=True).delete(
+        synchronize_session=False
+    )
+    PatientAssessment.query.filter_by(is_demo_data=True).delete(
+        synchronize_session=False
+    )
+    AideNote.query.filter_by(is_demo_data=True).delete(synchronize_session=False)
+    NurseNote.query.filter_by(is_demo_data=True).delete(synchronize_session=False)
+    Visit.query.filter_by(is_demo_data=True).delete(synchronize_session=False)
+    Patient.query.filter_by(is_demo_data=True).delete(synchronize_session=False)
+    db.session.commit()
+    return counts
+
+
+def seed_demo_records(today=None):
+    clear_demo_records()
+    current_date = today or date.today()
+    storage = get_medical_record_storage()
+    uploaded_keys = []
+    counts = {
+        "patients": 0,
+        "visits": 0,
+        "aide_notes": 0,
+        "nurse_notes": 0,
+        "assessments": 0,
+        "medical_records": 0,
+    }
+
+    try:
+        for index, patient_data in enumerate(DEMO_PATIENTS, start=1):
+            first_name, last_name, birth_date, gender, diagnosis = patient_data
+            patient = Patient(
+                first_name=first_name,
+                last_name=last_name,
+                date_of_birth=date.fromisoformat(birth_date),
+                gender=gender,
+                phone=f"202-555-{1000 + index:04d}",
+                email=f"{first_name.lower()}.{last_name.lower()}@example.test",
+                address=f"{100 + index} Demo Lane, Sample City, ST 200{index:02d}",
+                emergency_contact_name=f"{first_name} Family Contact",
+                emergency_contact_phone=f"202-555-{2000 + index:04d}",
+                diagnosis_summary=diagnosis,
+                status="inactive" if index % 7 == 0 else "active",
+                is_demo_data=True,
+            )
+            db.session.add(patient)
+            db.session.flush()
+            counts["patients"] += 1
+
+            patient_visits = []
+            for visit_number in range(4):
+                sequence = (index - 1) * 4 + visit_number
+                days_ago = (sequence * 7) % 91
+                visit_day = current_date - timedelta(days=days_ago)
+                staff_role = "aide" if visit_number % 2 == 0 else "nurse"
+                staff_name = (
+                    AIDE_NAMES[sequence % len(AIDE_NAMES)]
+                    if staff_role == "aide"
+                    else NURSE_NAMES[sequence % len(NURSE_NAMES)]
+                )
+                start_hour = 8 + sequence % 7
+                status = (
+                    "cancelled"
+                    if sequence % 13 == 0
+                    else "scheduled"
+                    if sequence % 11 == 0
+                    else "completed"
+                )
+                visit = Visit(
+                    patient_id=patient.id,
+                    visit_date=visit_day,
+                    visit_type=VISIT_TYPES[sequence % len(VISIT_TYPES)],
+                    staff_name=staff_name,
+                    staff_role=staff_role,
+                    time_in=time(start_hour, 0),
+                    time_out=time(start_hour + 1, 15),
+                    notes=(
+                        "Fictional demo visit completed with routine safety "
+                        "checks and care-plan review."
+                    ),
+                    status=status,
+                    is_demo_data=True,
+                )
+                db.session.add(visit)
+                db.session.flush()
+                patient_visits.append(visit)
+                counts["visits"] += 1
+
+                note_timestamp = datetime.combine(
+                    visit_day,
+                    time(start_hour + 1, 30),
+                    tzinfo=UTC,
+                )
+                if status == "completed" and staff_role == "aide":
+                    db.session.add(
+                        AideNote(
+                            patient_id=patient.id,
+                            visit_id=visit.id,
+                            personal_care={
+                                "bathing": True,
+                                "grooming": True,
+                                "dressing": sequence % 3 != 0,
+                            },
+                            nutrition={
+                                "meal_prepared": True,
+                                "meal_percentage": 75 + (sequence % 3) * 10,
+                                "fluids_encouraged": True,
+                            },
+                            mental_status={"alert": True, "confused": False},
+                            elimination={"toileting_assistance": sequence % 2 == 0},
+                            activity={"ambulation": True, "range_of_motion": True},
+                            assistive_devices={
+                                "walker": index % 3 == 0,
+                                "cane": index % 3 == 1,
+                            },
+                            housekeeping={"laundry": True, "light_cleaning": True},
+                            additional_notes=(
+                                "Patient tolerated care well and remained "
+                                "comfortable throughout the fictional demo visit."
+                            ),
+                            aide_name=staff_name,
+                            signature_data="Demo signature on file",
+                            signature_date=visit_day,
+                            time_in=visit.time_in,
+                            time_out=visit.time_out,
+                            created_at=note_timestamp,
+                            updated_at=note_timestamp,
+                            is_demo_data=True,
+                        )
+                    )
+                    counts["aide_notes"] += 1
+                elif status == "completed" and staff_role == "nurse":
+                    systolic = 116 + sequence % 18
+                    db.session.add(
+                        NurseNote(
+                            patient_id=patient.id,
+                            visit_id=visit.id,
+                            diagnosis=diagnosis,
+                            living_arrangements={"setting": "home", "support": True},
+                            visit_type={"skilled_nursing": True},
+                            vital_signs={
+                                "blood_pressure": f"{systolic}/{70 + sequence % 10}",
+                                "pulse": 68 + sequence % 12,
+                                "temperature_f": 97.8 + (sequence % 4) * 0.2,
+                                "oxygen_saturation": 95 + sequence % 4,
+                            },
+                            diet={"ordered": "heart healthy", "tolerance": "good"},
+                            pain_assessment={
+                                "score": sequence % 4,
+                                "location": "generalized" if sequence % 4 else "none",
+                            },
+                            respiratory={"effort": "unlabored", "lungs": "clear"},
+                            cardiac={"rhythm": "regular", "edema": index % 6 == 0},
+                            skin_integrity={"intact": index % 5 != 0},
+                            wound_evaluation={
+                                "present": index % 5 == 0,
+                                "status": "stable" if index % 5 == 0 else "none",
+                            },
+                            skilled_nursing=(
+                                "Medication reconciliation, vital-sign review, "
+                                "and fictional care-plan education completed."
+                            ),
+                            response_to_intervention=(
+                                "Patient demonstrated stable response."
+                            ),
+                            patient_caregiver_understanding={"teach_back": True},
+                            narrative=(
+                                "Demo clinical narrative: no acute distress; "
+                                "continue current plan and routine monitoring."
+                            ),
+                            signature_data="Demo clinician signature on file",
+                            signature_date=visit_day,
+                            created_at=note_timestamp,
+                            updated_at=note_timestamp,
+                            is_demo_data=True,
+                        )
+                    )
+                    counts["nurse_notes"] += 1
+
+            for assessment_number in range(2):
+                assessment_type = ASSESSMENT_TYPES[
+                    (index + assessment_number) % len(ASSESSMENT_TYPES)
+                ]
+                assessment_day = current_date - timedelta(
+                    days=(index * 3 + assessment_number * 11) % 60
+                )
+                db.session.add(
+                    PatientAssessment(
+                        patient_id=patient.id,
+                        visit_id=patient_visits[assessment_number].id
+                        if assessment_number == 0
+                        else None,
+                        assessment_type=assessment_type,
+                        assessment_date=assessment_day,
+                        performed_by=NURSE_NAMES[index % len(NURSE_NAMES)],
+                        summary=f"Fictional {assessment_type.replace('_', ' ')} review.",
+                        findings={
+                            "risk_level": ("moderate" if index % 3 else "high"),
+                            "score": 4 + (index + assessment_number) % 7,
+                            "demo": True,
+                        },
+                        recommendations=(
+                            "Continue care plan, reinforce safety education, "
+                            "and reassess at the next scheduled visit."
+                        ),
+                        status="completed" if assessment_number == 0 else "draft",
+                        is_demo_data=True,
+                    )
+                )
+                counts["assessments"] += 1
+
+            patient_name = f"{first_name} {last_name}"
+            pdf = _pdf_bytes(patient_name)
+            object_key = f"demo/patients/{patient.id}/care-summary.pdf"
+            storage.upload(
+                object_key,
+                BytesIO(pdf),
+                len(pdf),
+                "application/pdf",
+            )
+            uploaded_keys.append(object_key)
+            uploaded_at = datetime.combine(
+                current_date - timedelta(days=index % 30),
+                time(10, 0),
+                tzinfo=UTC,
+            )
+            db.session.add(
+                MedicalRecord(
+                    patient_id=patient.id,
+                    title="Demo care plan summary",
+                    description=(
+                        "Generated fictional document for SeniorMate demos only."
+                    ),
+                    record_type="care_plan",
+                    file_name="demo-care-summary.pdf",
+                    file_mime_type="application/pdf",
+                    file_size=len(pdf),
+                    storage_bucket=storage.bucket,
+                    storage_object_key=object_key,
+                    uploaded_by="Demo Data Seeder",
+                    uploaded_at=uploaded_at,
+                    is_demo_data=True,
+                )
+            )
+            counts["medical_records"] += 1
+
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        for object_key in uploaded_keys:
+            storage.delete(object_key)
+        raise
+
+    return counts
+
+
+def _format_counts(prefix, counts):
+    summary = ", ".join(
+        f"{value} {name.replace('_', ' ')}" for name, value in counts.items()
+    )
+    return f"{prefix}: {summary}."
+
+
+def register_demo_commands(app):
+    @app.cli.command("seed-demo")
+    def seed_demo_command():
+        """Replace existing demo records with a fresh deterministic dataset."""
+        _require_demo_enabled()
+        counts = seed_demo_records()
+        click.echo(_format_counts("Demo data seeded", counts))
+
+    @app.cli.command("clear-demo")
+    def clear_demo_command():
+        """Delete only records explicitly marked as demo data."""
+        _require_demo_enabled()
+        counts = clear_demo_records()
+        click.echo(_format_counts("Demo data cleared", counts))

--- a/backend/app/models/aide_note.py
+++ b/backend/app/models/aide_note.py
@@ -33,6 +33,12 @@ class AideNote(db.Model):
     signature_date = db.Column(db.Date, nullable=True)
     time_in = db.Column(db.Time, nullable=True)
     time_out = db.Column(db.Time, nullable=True)
+    is_demo_data = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False,
+        index=True,
+    )
     created_at = db.Column(
         db.DateTime(timezone=True),
         nullable=False,
@@ -72,6 +78,7 @@ class AideNote(db.Model):
             "time_out": self.time_out.isoformat(timespec="minutes")
             if self.time_out
             else None,
+            "is_demo_data": self.is_demo_data,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }

--- a/backend/app/models/medical_record.py
+++ b/backend/app/models/medical_record.py
@@ -27,6 +27,12 @@ class MedicalRecord(db.Model):
         nullable=False,
         default=lambda: datetime.now(UTC),
     )
+    is_demo_data = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False,
+        index=True,
+    )
     created_at = db.Column(
         db.DateTime(timezone=True),
         nullable=False,
@@ -57,6 +63,7 @@ class MedicalRecord(db.Model):
             "uploaded_at": self.uploaded_at.isoformat()
             if self.uploaded_at
             else None,
+            "is_demo_data": self.is_demo_data,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }

--- a/backend/app/models/nurse_note.py
+++ b/backend/app/models/nurse_note.py
@@ -48,6 +48,12 @@ class NurseNote(db.Model):
     narrative = db.Column(db.Text, nullable=True)
     signature_data = db.Column(db.Text, nullable=True)
     signature_date = db.Column(db.Date, nullable=True)
+    is_demo_data = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False,
+        index=True,
+    )
     created_at = db.Column(
         db.DateTime(timezone=True),
         nullable=False,
@@ -98,6 +104,7 @@ class NurseNote(db.Model):
             "signature_date": self.signature_date.isoformat()
             if self.signature_date
             else None,
+            "is_demo_data": self.is_demo_data,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }

--- a/backend/app/models/patient.py
+++ b/backend/app/models/patient.py
@@ -23,6 +23,12 @@ class Patient(db.Model):
     emergency_contact_phone = db.Column(db.String(50), nullable=True)
     diagnosis_summary = db.Column(db.Text, nullable=True)
     status = db.Column(db.String(20), nullable=False, default="active")
+    is_demo_data = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False,
+        index=True,
+    )
     photo_object_key = db.Column(db.String(1024), nullable=True, unique=True)
     photo_file_name = db.Column(db.String(255), nullable=True)
     photo_mime_type = db.Column(db.String(100), nullable=True)
@@ -82,6 +88,7 @@ class Patient(db.Model):
             "emergency_contact_phone": self.emergency_contact_phone,
             "diagnosis_summary": self.diagnosis_summary,
             "status": self.status,
+            "is_demo_data": self.is_demo_data,
             "has_photo": bool(self.photo_object_key),
             "photo_verified": self.photo_verified,
             "photo_file_name": self.photo_file_name,

--- a/backend/app/models/patient_assessment.py
+++ b/backend/app/models/patient_assessment.py
@@ -39,6 +39,12 @@ class PatientAssessment(db.Model):
     findings = db.Column(db.JSON, nullable=True)
     recommendations = db.Column(db.Text, nullable=True)
     status = db.Column(db.String(20), nullable=False, default="draft")
+    is_demo_data = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False,
+        index=True,
+    )
     created_at = db.Column(
         db.DateTime(timezone=True),
         nullable=False,
@@ -68,6 +74,7 @@ class PatientAssessment(db.Model):
             "findings": self.findings,
             "recommendations": self.recommendations,
             "status": self.status,
+            "is_demo_data": self.is_demo_data,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }

--- a/backend/app/models/visit.py
+++ b/backend/app/models/visit.py
@@ -30,6 +30,12 @@ class Visit(db.Model):
     time_out = db.Column(db.Time, nullable=True)
     notes = db.Column(db.Text, nullable=True)
     status = db.Column(db.String(20), nullable=False, default="scheduled")
+    is_demo_data = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False,
+        index=True,
+    )
     created_at = db.Column(
         db.DateTime(timezone=True),
         nullable=False,
@@ -77,6 +83,7 @@ class Visit(db.Model):
             else None,
             "notes": self.notes,
             "status": self.status,
+            "is_demo_data": self.is_demo_data,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }

--- a/backend/app/swagger.py
+++ b/backend/app/swagger.py
@@ -1,3 +1,10 @@
+demo_marker_property = {
+    "type": "boolean",
+    "readOnly": True,
+    "description": "True only for records created by the guarded demo seeder.",
+    "example": False,
+}
+
 patient_properties = {
     "id": {"type": "integer", "example": 1},
     "first_name": {"type": "string", "example": "Maria"},
@@ -37,6 +44,7 @@ patient_properties = {
         "enum": ["active", "inactive"],
         "example": "active",
     },
+    "is_demo_data": demo_marker_property,
     "has_photo": {"type": "boolean", "example": True},
     "photo_verified": {"type": "boolean", "example": False},
     "photo_file_name": {
@@ -72,6 +80,7 @@ patient_request_properties = {
         "photo_verified",
         "photo_file_name",
         "photo_uploaded_at",
+        "is_demo_data",
         "created_at",
         "updated_at",
     }
@@ -113,6 +122,7 @@ visit_properties = {
         "enum": ["scheduled", "completed", "cancelled"],
         "example": "scheduled",
     },
+    "is_demo_data": demo_marker_property,
     "created_at": {
         "type": "string",
         "format": "date-time",
@@ -128,7 +138,7 @@ visit_properties = {
 visit_request_properties = {
     key: value
     for key, value in visit_properties.items()
-    if key not in {"id", "created_at", "updated_at"}
+    if key not in {"id", "is_demo_data", "created_at", "updated_at"}
 }
 
 checklist_schema = {
@@ -168,6 +178,7 @@ aide_note_properties = {
     },
     "time_in": {"type": "string", "nullable": True, "example": "09:00"},
     "time_out": {"type": "string", "nullable": True, "example": "10:30"},
+    "is_demo_data": demo_marker_property,
     "created_at": {
         "type": "string",
         "format": "date-time",
@@ -183,7 +194,7 @@ aide_note_properties = {
 aide_note_request_properties = {
     key: value
     for key, value in aide_note_properties.items()
-    if key not in {"id", "created_at", "updated_at"}
+    if key not in {"id", "is_demo_data", "created_at", "updated_at"}
 }
 
 clinical_section_schema = {
@@ -254,6 +265,7 @@ nurse_note_properties = {
         "nullable": True,
         "example": "2026-06-01",
     },
+    "is_demo_data": demo_marker_property,
     "created_at": {
         "type": "string",
         "format": "date-time",
@@ -269,7 +281,7 @@ nurse_note_properties = {
 nurse_note_request_properties = {
     key: value
     for key, value in nurse_note_properties.items()
-    if key not in {"id", "created_at", "updated_at"}
+    if key not in {"id", "is_demo_data", "created_at", "updated_at"}
 }
 
 assessment_findings_schema = {
@@ -316,6 +328,7 @@ patient_assessment_properties = {
         "enum": ["draft", "completed"],
         "example": "completed",
     },
+    "is_demo_data": demo_marker_property,
     "created_at": {
         "type": "string",
         "format": "date-time",
@@ -331,7 +344,7 @@ patient_assessment_properties = {
 patient_assessment_request_properties = {
     key: value
     for key, value in patient_assessment_properties.items()
-    if key not in {"id", "created_at", "updated_at"}
+    if key not in {"id", "is_demo_data", "created_at", "updated_at"}
 }
 
 dashboard_group_item_properties = {
@@ -429,6 +442,7 @@ medical_record_properties = {
         "format": "date-time",
         "example": "2026-06-09T10:00:00+00:00",
     },
+    "is_demo_data": demo_marker_property,
     "created_at": {
         "type": "string",
         "format": "date-time",

--- a/backend/migrations/versions/20260611_0009_add_demo_data_markers.py
+++ b/backend/migrations/versions/20260611_0009_add_demo_data_markers.py
@@ -1,0 +1,50 @@
+"""add demo data markers
+
+Revision ID: 20260611_0009
+Revises: 20260610_0008
+Create Date: 2026-06-11 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260611_0009"
+down_revision = "20260610_0008"
+branch_labels = None
+depends_on = None
+
+
+TABLES = (
+    "patients",
+    "visits",
+    "aide_notes",
+    "nurse_notes",
+    "patient_assessments",
+    "medical_records",
+)
+
+
+def upgrade():
+    for table in TABLES:
+        op.add_column(
+            table,
+            sa.Column(
+                "is_demo_data",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+        op.create_index(
+            op.f(f"ix_{table}_is_demo_data"),
+            table,
+            ["is_demo_data"],
+            unique=False,
+        )
+
+
+def downgrade():
+    for table in reversed(TABLES):
+        op.drop_index(op.f(f"ix_{table}_is_demo_data"), table_name=table)
+        op.drop_column(table, "is_demo_data")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,7 +10,9 @@ from tests.test_admin_users import FakeKeycloakAdminClient
 
 class TestConfig(Config):
     TESTING = True
+    APP_ENV = "testing"
     AUTH_ENABLED = False
+    DEMO_DATA_ENABLED = False
     SQLALCHEMY_DATABASE_URI = "sqlite+pysqlite:///:memory:"
     CORS_ORIGINS = ["http://localhost:5173"]
     MEDICAL_RECORD_MAX_FILE_SIZE = 1024 * 1024

--- a/backend/tests/test_demo_data.py
+++ b/backend/tests/test_demo_data.py
@@ -1,0 +1,103 @@
+from app.extensions import db
+from app.models import (
+    AideNote,
+    MedicalRecord,
+    NurseNote,
+    Patient,
+    PatientAssessment,
+    Visit,
+)
+
+
+def demo_counts():
+    return {
+        "patients": Patient.query.filter_by(is_demo_data=True).count(),
+        "visits": Visit.query.filter_by(is_demo_data=True).count(),
+        "aide_notes": AideNote.query.filter_by(is_demo_data=True).count(),
+        "nurse_notes": NurseNote.query.filter_by(is_demo_data=True).count(),
+        "assessments": PatientAssessment.query.filter_by(is_demo_data=True).count(),
+        "medical_records": MedicalRecord.query.filter_by(is_demo_data=True).count(),
+    }
+
+
+def test_seed_demo_refuses_when_disabled(app):
+    result = app.test_cli_runner().invoke(args=["seed-demo"])
+
+    assert result.exit_code == 1
+    assert "DEMO_DATA_ENABLED=true" in result.output
+    assert Patient.query.count() == 0
+
+
+def test_seed_demo_refuses_in_production(app):
+    app.config["DEMO_DATA_ENABLED"] = True
+    app.config["APP_ENV"] = "production"
+
+    result = app.test_cli_runner().invoke(args=["seed-demo"])
+
+    assert result.exit_code == 1
+    assert "APP_ENV=production" in result.output
+    assert Patient.query.count() == 0
+
+
+def test_seed_demo_creates_expected_records(app, medical_record_storage):
+    app.config["DEMO_DATA_ENABLED"] = True
+
+    result = app.test_cli_runner().invoke(args=["seed-demo"])
+
+    assert result.exit_code == 0
+    assert demo_counts() == {
+        "patients": 24,
+        "visits": 96,
+        "aide_notes": 40,
+        "nurse_notes": 40,
+        "assessments": 48,
+        "medical_records": 24,
+    }
+    assert len(medical_record_storage.objects) == 24
+    assert "Demo data seeded" in result.output
+
+
+def test_seed_demo_is_repeatable(app, medical_record_storage):
+    app.config["DEMO_DATA_ENABLED"] = True
+    runner = app.test_cli_runner()
+
+    first = runner.invoke(args=["seed-demo"])
+    second = runner.invoke(args=["seed-demo"])
+
+    assert first.exit_code == 0
+    assert second.exit_code == 0
+    assert demo_counts()["patients"] == 24
+    assert demo_counts()["visits"] == 96
+    assert demo_counts()["medical_records"] == 24
+    assert len(medical_record_storage.objects) == 24
+
+
+def test_clear_demo_deletes_only_marked_records(app, medical_record_storage):
+    app.config["DEMO_DATA_ENABLED"] = True
+    runner = app.test_cli_runner()
+    real_patient = Patient(
+        first_name="Real",
+        last_name="Patient",
+        status="active",
+        is_demo_data=False,
+    )
+    db.session.add(real_patient)
+    db.session.commit()
+
+    seeded = runner.invoke(args=["seed-demo"])
+    cleared = runner.invoke(args=["clear-demo"])
+
+    assert seeded.exit_code == 0
+    assert cleared.exit_code == 0
+    assert demo_counts() == {
+        "patients": 0,
+        "visits": 0,
+        "aide_notes": 0,
+        "nurse_notes": 0,
+        "assessments": 0,
+        "medical_records": 0,
+    }
+    assert db.session.get(Patient, real_patient.id) is not None
+    assert Patient.query.filter_by(is_demo_data=False).count() == 1
+    assert medical_record_storage.objects == {}
+    assert "Demo data cleared" in cleared.output

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       APP_DEBUG: ${APP_DEBUG:-true}
       APP_SECRET_KEY: ${APP_SECRET_KEY:-change-me-local-only}
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:5173}
+      DEMO_DATA_ENABLED: ${DEMO_DATA_ENABLED:-false}
       BACKEND_HOST: 0.0.0.0
       BACKEND_PORT: 5000
       DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://seniormate:change-me-local-only@postgres:5432/seniormate}

--- a/docs/setup/demo-data.md
+++ b/docs/setup/demo-data.md
@@ -1,0 +1,111 @@
+# Demo Data
+
+SeniorMate provides CLI-only demo data commands for local presentations and
+product evaluation. Demo data is never created automatically and is blocked
+unless an operator explicitly enables it.
+
+All generated patients, visits, notes, assessments, and medical records are
+fictional. Do not use the demo commands with production data or credentials.
+
+## Enable Demo Commands
+
+Set this local environment value:
+
+```bash
+DEMO_DATA_ENABLED=true
+```
+
+Recreate the backend container after changing `.env` so it receives the new
+value:
+
+```bash
+docker compose up -d --force-recreate backend
+```
+
+The checked-in default remains `false`.
+
+The commands also refuse to run when `APP_ENV=production`, even if the demo
+flag is mistakenly enabled.
+
+## Prepare the Database
+
+Apply the latest migration before seeding:
+
+```bash
+docker compose exec backend flask db upgrade
+```
+
+The migration adds an indexed `is_demo_data` marker with a default of `false`
+to patients, visits, aide notes, nurse notes, assessments, and medical records.
+Normal application records therefore remain non-demo unless explicitly marked.
+The marker is included as a read-only field in API responses and Swagger
+schemas; normal create and update requests cannot set it.
+
+## Seed Demo Data
+
+```bash
+docker compose exec backend flask seed-demo
+```
+
+The command creates:
+
+- 24 fictional patient profiles with active and inactive statuses.
+- 96 visits spread across the previous 90 days.
+- 40 aide notes and 40 nurse notes linked to completed visits.
+- 48 fall-risk, nutrition, mobility, cognitive, and general assessments.
+- 24 generated fictional care-summary PDFs stored privately in MinIO.
+
+Patient screens use SeniorMate's initials avatar fallback. The seed does not
+create synthetic portraits or mark any profile photo as verified.
+
+The data is designed to populate dashboard metrics, charts, recent activity,
+patient details, visit details, note views, medical records, assessments, and
+printable reports.
+
+## Repeat or Reset
+
+`seed-demo` is repeatable. Before generating a fresh deterministic dataset, it
+removes the prior records marked `is_demo_data=true` and their generated MinIO
+objects. It does not duplicate the previous dataset.
+
+To remove demo data without recreating it:
+
+```bash
+docker compose exec backend flask clear-demo
+```
+
+`clear-demo` deletes only explicitly marked demo records. It preserves normal
+records. As an additional guard, it refuses to delete demo patients or visits
+that have non-demo dependent records attached.
+
+Both commands refuse to run when `DEMO_DATA_ENABLED` is not exactly `true` or
+when the application environment is production.
+
+## Demo Users
+
+Clinical demo seeding does not create or modify Keycloak users. The local
+Keycloak realm import already provides the development-only accounts described
+in [Local Keycloak Setup](keycloak-local-setup.md), including:
+
+- `admin.demo`
+- `manager.demo`
+- `nurse.demo`
+- `caregiver.demo`
+- `viewer.demo`
+
+Their placeholder credentials must never be reused outside local development.
+Keeping identity setup separate prevents the clinical seed command from
+changing realm users unexpectedly.
+
+## Local Python Commands
+
+When running the backend outside Docker:
+
+```bash
+cd backend
+export FLASK_APP=run.py
+export DEMO_DATA_ENABLED=true
+flask db upgrade
+flask seed-demo
+flask clear-demo
+```


### PR DESCRIPTION
# Summary

- Add gated `flask seed-demo` and `flask clear-demo` commands registered through the Flask app factory.
- Add indexed `is_demo_data` markers to patients, visits, aide notes, nurse notes, assessments, and medical records.
- Generate a deterministic presentation dataset with 24 fictional patients, 96 visits, 80 care notes, 48 assessments, and 24 private MinIO PDF records.
- Make seeding repeatable by clearing only prior marked demo records before recreation.
- Block demo commands unless `DEMO_DATA_ENABLED=true` and always block them when `APP_ENV=production`.
- Document enablement, reset behavior, existing Keycloak demo users, and safety constraints.

## Related Issue / Task

- Feature: `26-demo-seed-data`

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `cd backend && .venv/bin/pytest` (126 passed)
- `cd backend && .venv/bin/ruff check .`
- `cd frontend && npm run test:permissions`
- `cd frontend && npm run build`
- Migration upgrade, downgrade to `20260610_0008`, and re-upgrade on temporary SQLite database
- `docker-compose config` confirmed `DEMO_DATA_ENABLED=false`
- PostgreSQL migration through `docker-compose exec -T backend flask db upgrade`
- Disabled `flask seed-demo` refusal verified in the backend container
- Gated seed run twice with identical counts and no duplication
- `flask clear-demo` removed the generated records and MinIO files

## Screenshots

N/A. This feature is intentionally CLI-only; seeded records populate the existing UI and reports.

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.