### PR TITLE
fix: use Docker MinIO endpoint for demo seeding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,7 @@ KEYCLOAK_ADMIN_PASSWORD=change-me-local-only
 KEYCLOAK_PORT=8080
 
 MINIO_ENDPOINT=http://localhost:9000
+MINIO_DOCKER_ENDPOINT=http://minio:9000
 MINIO_ACCESS_KEY=local-access-key
 MINIO_SECRET_KEY=change-me-local-only
 MINIO_BUCKET=seniormate-medical-records

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Fixed demo seeding from Docker by separating the backend container's MinIO service endpoint from the host-side endpoint.
 - Enabled authentication and the Keycloak service by default in the standard local Docker Compose stack.
 - Fixed Aide Notes and Nurse Notes list routes failing to render and leaving subsequent navigation blank.
 

--- a/backend/app/demo_data.py
+++ b/backend/app/demo_data.py
@@ -13,7 +13,7 @@ from app.models import (
     PatientAssessment,
     Visit,
 )
-from app.storage import get_medical_record_storage
+from app.storage import PrivateObjectStorageError, get_medical_record_storage
 
 
 DEMO_PATIENTS = (
@@ -448,12 +448,18 @@ def register_demo_commands(app):
     def seed_demo_command():
         """Replace existing demo records with a fresh deterministic dataset."""
         _require_demo_enabled()
-        counts = seed_demo_records()
+        try:
+            counts = seed_demo_records()
+        except PrivateObjectStorageError as exc:
+            raise click.ClickException(str(exc)) from exc
         click.echo(_format_counts("Demo data seeded", counts))
 
     @app.cli.command("clear-demo")
     def clear_demo_command():
         """Delete only records explicitly marked as demo data."""
         _require_demo_enabled()
-        counts = clear_demo_records()
+        try:
+            counts = clear_demo_records()
+        except PrivateObjectStorageError as exc:
+            raise click.ClickException(str(exc)) from exc
         click.echo(_format_counts("Demo data cleared", counts))

--- a/backend/tests/test_demo_data.py
+++ b/backend/tests/test_demo_data.py
@@ -7,6 +7,7 @@ from app.models import (
     PatientAssessment,
     Visit,
 )
+from app.storage import PrivateObjectStorageError
 
 
 def demo_counts():
@@ -70,6 +71,24 @@ def test_seed_demo_is_repeatable(app, medical_record_storage):
     assert demo_counts()["visits"] == 96
     assert demo_counts()["medical_records"] == 24
     assert len(medical_record_storage.objects) == 24
+
+
+def test_seed_demo_reports_storage_failure_without_traceback(
+    app,
+    medical_record_storage,
+):
+    app.config["DEMO_DATA_ENABLED"] = True
+
+    def unavailable_storage(*args, **kwargs):
+        raise PrivateObjectStorageError("Private file storage is unavailable.")
+
+    medical_record_storage.upload = unavailable_storage
+    result = app.test_cli_runner().invoke(args=["seed-demo"])
+
+    assert result.exit_code == 1
+    assert "Private file storage is unavailable." in result.output
+    assert "Traceback" not in result.output
+    assert Patient.query.count() == 0
 
 
 def test_clear_demo_deletes_only_marked_records(app, medical_record_storage):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       BACKEND_HOST: 0.0.0.0
       BACKEND_PORT: 5000
       DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://seniormate:change-me-local-only@postgres:5432/seniormate}
-      MINIO_ENDPOINT: ${MINIO_ENDPOINT:-http://minio:9000}
+      MINIO_ENDPOINT: ${MINIO_DOCKER_ENDPOINT:-http://minio:9000}
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-local-access-key}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-change-me-local-only}
       MINIO_BUCKET: ${MINIO_BUCKET:-seniormate-medical-records}

--- a/docs/setup/demo-data.md
+++ b/docs/setup/demo-data.md
@@ -27,6 +27,12 @@ The checked-in default remains `false`.
 The commands also refuse to run when `APP_ENV=production`, even if the demo
 flag is mistakenly enabled.
 
+The backend container connects to MinIO through
+`MINIO_DOCKER_ENDPOINT=http://minio:9000`. `MINIO_ENDPOINT=http://localhost:9000`
+is reserved for running the Flask backend directly on the host. If the seeder
+reports that private storage is unavailable, recreate the backend container
+and confirm the `minio` service is running.
+
 ## Prepare the Database
 
 Apply the latest migration before seeding:

--- a/docs/setup/local-development.md
+++ b/docs/setup/local-development.md
@@ -73,7 +73,8 @@ if it does not exist. The bucket is not configured for public access.
 
 Medical Record storage settings:
 
-- `MINIO_ENDPOINT`: backend connection URL for MinIO
+- `MINIO_ENDPOINT`: host-side backend connection URL for MinIO
+- `MINIO_DOCKER_ENDPOINT`: backend container connection URL for MinIO
 - `MINIO_ACCESS_KEY`: application access key
 - `MINIO_SECRET_KEY`: application secret key
 - `MINIO_BUCKET`: private bucket used for patient documents


### PR DESCRIPTION
# Summary

- Separate the host-side MinIO endpoint from the backend container endpoint.
- Configure Docker Compose to use `MINIO_DOCKER_ENDPOINT=http://minio:9000` by default, preventing `localhost:9000` from resolving inside the backend container.
- Convert demo seed/clear storage failures into concise Flask CLI errors instead of Python tracebacks.
- Document the host and Docker MinIO endpoint behavior and troubleshooting steps.

## Related Issue / Task

- Follow-up fix for Feature 26 demo seed data

## Type of Change

- [ ] Feature
- [x] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `cd backend && .venv/bin/pytest` (127 passed)
- `cd backend && .venv/bin/ruff check .`
- `docker-compose config` confirmed backend `MINIO_ENDPOINT=http://minio:9000`
- Recreated the backend container
- Verified the backend container environment reports `MINIO_ENDPOINT=http://minio:9000`
- Ran `docker-compose exec -T backend flask seed-demo` successfully

## Screenshots

N/A. This fixes backend container networking and CLI error handling.

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.