### PR TITLE
feat: add reporting and analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added permission-protected reporting APIs and frontend views for patient census, visit activity, staff activity, assessments, and medical records with practical filters, charts, tables, and CSV export.
 - Added guarded, repeatable demo seed and clear commands with explicit demo markers, fictional patients and care activity, generated private medical-record PDFs, safety tests, and setup documentation.
 - Added centralized frontend role permissions, permission-aware navigation and actions, restricted-route handling, an Access Denied page, permission tests, and a user-facing roles guide.
 - Added admin-only Keycloak user management with a dedicated Admin API client, user and role endpoints, temporary password resets, Swagger documentation, mocked backend tests, and an Admin → Users interface.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ Printable patient summaries include recent visits, assessments, and medical
 record metadata. Uploaded medical record files are referenced by name and are
 not embedded in reports.
 
+Operational analytics are available from the Reports section with patient
+census, visit activity, staff activity, assessment, and medical-record views.
+Each report supports relevant filters and CSV export. See
+[docs/user-guide/reports.md](docs/user-guide/reports.md).
+
 ## Development Workflow
 
 - Start new work from an up-to-date `main` branch.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -22,6 +22,7 @@ from app.routes.branding import branding_bp
 from app.routes.medical_records import medical_records_bp
 from app.routes.nurse_notes import nurse_notes_bp
 from app.routes.patients import patients_bp
+from app.routes.reports import reports_bp
 from app.routes.visits import visits_bp
 from app.swagger import health_spec, swagger_config, swagger_template
 
@@ -43,6 +44,7 @@ def create_app(config_object=Config):
     app.register_blueprint(medical_records_bp)
     app.register_blueprint(nurse_notes_bp)
     app.register_blueprint(patients_bp)
+    app.register_blueprint(reports_bp)
     app.register_blueprint(visits_bp)
     register_demo_commands(app)
 

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -164,6 +164,8 @@ def _resource_for_path(path):
         return "branding"
     if path.startswith("/api/dashboard"):
         return "dashboard"
+    if path.startswith("/api/reports"):
+        return "reports"
     if "/medical-records" in path:
         return "medical_records"
     if "/aide-notes" in path or "/aide-note" in path:

--- a/backend/app/routes/reports.py
+++ b/backend/app/routes/reports.py
@@ -1,0 +1,494 @@
+import csv
+from collections import Counter, defaultdict
+from datetime import UTC, datetime, time
+from io import StringIO
+
+from flasgger import swag_from
+from flask import Blueprint, Response, jsonify, request
+
+from app.models import (
+    MedicalRecord,
+    Patient,
+    PatientAssessment,
+    Visit,
+)
+from app.swagger import (
+    assessment_summary_report_spec,
+    medical_records_summary_report_spec,
+    patient_census_report_spec,
+    staff_activity_report_spec,
+    visit_activity_report_spec,
+)
+
+
+reports_bp = Blueprint("reports", __name__, url_prefix="/api/reports")
+
+
+def _parse_date(name):
+    value = request.args.get(name)
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError:
+        raise ValueError(f"{name} must use YYYY-MM-DD format.") from None
+
+
+def _parse_patient_id():
+    value = request.args.get("patient_id")
+    if not value:
+        return None
+    try:
+        patient_id = int(value)
+    except ValueError:
+        raise ValueError("patient_id must be a positive integer.") from None
+    if patient_id < 1:
+        raise ValueError("patient_id must be a positive integer.")
+    return patient_id
+
+
+def _filters():
+    start_date = _parse_date("start_date")
+    end_date = _parse_date("end_date")
+    if start_date and end_date and start_date > end_date:
+        raise ValueError("start_date must be on or before end_date.")
+    return {
+        "start_date": start_date,
+        "end_date": end_date,
+        "patient_id": _parse_patient_id(),
+        "staff_role": request.args.get("staff_role"),
+        "staff_name": request.args.get("staff_name"),
+        "visit_type": request.args.get("visit_type"),
+        "status": request.args.get("status"),
+    }
+
+
+def _group_counts(values, empty_label="Not specified"):
+    counts = Counter(value or empty_label for value in values)
+    return [
+        {"label": label, "count": count}
+        for label, count in sorted(
+            counts.items(),
+            key=lambda item: (-item[1], item[0]),
+        )
+    ]
+
+
+def _date_groups(values):
+    return [
+        {"label": label, "count": count}
+        for label, count in sorted(Counter(values).items())
+    ]
+
+
+def _date_boundary(value, boundary):
+    return datetime.combine(value, boundary, tzinfo=UTC)
+
+
+def _patient_name(patient):
+    return f"{patient.first_name} {patient.last_name}"
+
+
+def _success(data, message):
+    return jsonify({"data": data, "message": message})
+
+
+def _csv_response(name, headers, rows):
+    output = StringIO()
+    writer = csv.DictWriter(output, fieldnames=headers, extrasaction="ignore")
+    writer.writeheader()
+    writer.writerows(rows)
+    return Response(
+        output.getvalue(),
+        mimetype="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{name}.csv"'},
+    )
+
+
+def _respond(name, data, headers):
+    if request.args.get("format", "json").lower() == "csv":
+        return _csv_response(name, headers, data["rows"])
+    return _success(data, f"{name.replace('-', ' ').title()} retrieved successfully")
+
+
+def _apply_visit_filters(query, filters):
+    if filters["start_date"]:
+        query = query.filter(Visit.visit_date >= filters["start_date"])
+    if filters["end_date"]:
+        query = query.filter(Visit.visit_date <= filters["end_date"])
+    if filters["patient_id"]:
+        query = query.filter(Visit.patient_id == filters["patient_id"])
+    if filters["staff_role"]:
+        query = query.filter(Visit.staff_role == filters["staff_role"])
+    if filters["staff_name"]:
+        query = query.filter(Visit.staff_name.ilike(f"%{filters['staff_name']}%"))
+    if filters["visit_type"]:
+        query = query.filter(Visit.visit_type == filters["visit_type"])
+    if filters["status"]:
+        query = query.filter(Visit.status == filters["status"])
+    return query
+
+
+def _report_errors(view):
+    def wrapped(*args, **kwargs):
+        try:
+            return view(*args, **kwargs)
+        except ValueError as exc:
+            return jsonify({"message": str(exc)}), 400
+
+    wrapped.__name__ = view.__name__
+    return wrapped
+
+
+@reports_bp.get("/patient-census")
+@swag_from(patient_census_report_spec)
+@_report_errors
+def patient_census_report():
+    filters = _filters()
+    query = Patient.query
+    if filters["patient_id"]:
+        query = query.filter(Patient.id == filters["patient_id"])
+    if filters["status"]:
+        query = query.filter(Patient.status == filters["status"])
+    if filters["start_date"]:
+        query = query.filter(
+            Patient.created_at >= _date_boundary(filters["start_date"], time.min)
+        )
+    if filters["end_date"]:
+        query = query.filter(
+            Patient.created_at <= _date_boundary(filters["end_date"], time.max)
+        )
+    patients = query.order_by(Patient.created_at.desc(), Patient.id.desc()).all()
+    rows = [
+        {
+            "patient_id": patient.id,
+            "patient_name": _patient_name(patient),
+            "status": patient.status,
+            "gender": patient.gender or "",
+            "date_of_birth": patient.date_of_birth.isoformat()
+            if patient.date_of_birth
+            else "",
+            "diagnosis": patient.diagnosis_summary or "",
+            "created_at": patient.created_at.date().isoformat(),
+        }
+        for patient in patients
+    ]
+    data = {
+        "summary": {
+            "total_patients": len(patients),
+            "active_patients": sum(p.status == "active" for p in patients),
+            "inactive_patients": sum(p.status == "inactive" for p in patients),
+        },
+        "groups": {
+            "patients_by_gender": _group_counts(p.gender for p in patients),
+            "patients_by_diagnosis": _group_counts(
+                p.diagnosis_summary for p in patients
+            ),
+        },
+        "recent": rows[:10],
+        "rows": rows,
+    }
+    return _respond(
+        "patient-census",
+        data,
+        [
+            "patient_id",
+            "patient_name",
+            "status",
+            "gender",
+            "date_of_birth",
+            "diagnosis",
+            "created_at",
+        ],
+    )
+
+
+@reports_bp.get("/visit-activity")
+@swag_from(visit_activity_report_spec)
+@_report_errors
+def visit_activity_report():
+    filters = _filters()
+    visits = (
+        _apply_visit_filters(Visit.query, filters)
+        .order_by(Visit.visit_date.desc(), Visit.id.desc())
+        .all()
+    )
+    rows = [
+        {
+            "visit_id": visit.id,
+            "patient_name": _patient_name(visit.patient),
+            "visit_date": visit.visit_date.isoformat(),
+            "visit_type": visit.visit_type,
+            "staff_name": visit.staff_name or "",
+            "staff_role": visit.staff_role or "",
+            "status": visit.status,
+        }
+        for visit in visits
+    ]
+    data = {
+        "summary": {
+            "total_visits": len(visits),
+            "completed_visits": sum(v.status == "completed" for v in visits),
+            "scheduled_visits": sum(v.status == "scheduled" for v in visits),
+            "cancelled_visits": sum(v.status == "cancelled" for v in visits),
+        },
+        "groups": {
+            "visits_by_type": _group_counts(v.visit_type for v in visits),
+            "visits_by_status": _group_counts(v.status for v in visits),
+            "visits_by_staff_role": _group_counts(v.staff_role for v in visits),
+            "visits_over_time": _date_groups(
+                v.visit_date.isoformat() for v in visits
+            ),
+        },
+        "recent": rows[:10],
+        "rows": rows,
+    }
+    return _respond(
+        "visit-activity",
+        data,
+        [
+            "visit_id",
+            "patient_name",
+            "visit_date",
+            "visit_type",
+            "staff_name",
+            "staff_role",
+            "status",
+        ],
+    )
+
+
+@reports_bp.get("/staff-activity")
+@swag_from(staff_activity_report_spec)
+@_report_errors
+def staff_activity_report():
+    filters = _filters()
+    visits = _apply_visit_filters(Visit.query, filters).all()
+    staff = defaultdict(
+        lambda: {
+            "staff_name": "",
+            "staff_role": "",
+            "total_visits": 0,
+            "aide_notes_completed": 0,
+            "nurse_notes_completed": 0,
+            "assessments_completed": 0,
+        }
+    )
+    visit_ids = {visit.id for visit in visits}
+    for visit in visits:
+        key = (visit.staff_name or "Unassigned", visit.staff_role or "unspecified")
+        staff[key]["staff_name"], staff[key]["staff_role"] = key
+        staff[key]["total_visits"] += 1
+        if visit.aide_note:
+            staff[key]["aide_notes_completed"] += 1
+        if visit.nurse_note:
+            staff[key]["nurse_notes_completed"] += 1
+
+    assessment_query = PatientAssessment.query.filter(
+        PatientAssessment.status == "completed"
+    )
+    if filters["start_date"]:
+        assessment_query = assessment_query.filter(
+            PatientAssessment.assessment_date >= filters["start_date"]
+        )
+    if filters["end_date"]:
+        assessment_query = assessment_query.filter(
+            PatientAssessment.assessment_date <= filters["end_date"]
+        )
+    if filters["patient_id"]:
+        assessment_query = assessment_query.filter(
+            PatientAssessment.patient_id == filters["patient_id"]
+        )
+    if filters["staff_name"]:
+        assessment_query = assessment_query.filter(
+            PatientAssessment.performed_by.ilike(
+                f"%{filters['staff_name']}%"
+            )
+        )
+    if filters["staff_role"] and filters["staff_role"] != "nurse":
+        assessment_query = assessment_query.filter(False)
+    for assessment in assessment_query.all():
+        if assessment.visit_id and assessment.visit_id not in visit_ids:
+            continue
+        name = assessment.performed_by or "Unassigned"
+        matching_keys = [key for key in staff if key[0] == name]
+        key = matching_keys[0] if matching_keys else (name, "nurse")
+        staff[key]["staff_name"], staff[key]["staff_role"] = key
+        staff[key]["assessments_completed"] += 1
+
+    rows = sorted(
+        staff.values(),
+        key=lambda row: (-row["total_visits"], row["staff_name"]),
+    )
+    data = {
+        "summary": {
+            "total_staff": len(rows),
+            "total_visits": sum(row["total_visits"] for row in rows),
+            "total_notes": sum(
+                row["aide_notes_completed"] + row["nurse_notes_completed"]
+                for row in rows
+            ),
+            "total_assessments": sum(
+                row["assessments_completed"] for row in rows
+            ),
+        },
+        "groups": {
+            "activity_by_role": _group_counts(
+                row["staff_role"]
+                for row in rows
+                for _ in range(row["total_visits"])
+            ),
+        },
+        "recent": rows[:10],
+        "rows": rows,
+    }
+    return _respond(
+        "staff-activity",
+        data,
+        [
+            "staff_name",
+            "staff_role",
+            "total_visits",
+            "aide_notes_completed",
+            "nurse_notes_completed",
+            "assessments_completed",
+        ],
+    )
+
+
+@reports_bp.get("/assessment-summary")
+@swag_from(assessment_summary_report_spec)
+@_report_errors
+def assessment_summary_report():
+    filters = _filters()
+    query = PatientAssessment.query
+    if filters["start_date"]:
+        query = query.filter(
+            PatientAssessment.assessment_date >= filters["start_date"]
+        )
+    if filters["end_date"]:
+        query = query.filter(
+            PatientAssessment.assessment_date <= filters["end_date"]
+        )
+    if filters["patient_id"]:
+        query = query.filter(
+            PatientAssessment.patient_id == filters["patient_id"]
+        )
+    if filters["status"]:
+        query = query.filter(PatientAssessment.status == filters["status"])
+    assessments = query.order_by(
+        PatientAssessment.assessment_date.desc(),
+        PatientAssessment.id.desc(),
+    ).all()
+    rows = [
+        {
+            "assessment_id": assessment.id,
+            "patient_name": _patient_name(assessment.patient),
+            "assessment_date": assessment.assessment_date.isoformat(),
+            "assessment_type": assessment.assessment_type,
+            "status": assessment.status,
+            "performed_by": assessment.performed_by or "",
+            "linked_visit": "Yes" if assessment.visit_id else "No",
+        }
+        for assessment in assessments
+    ]
+    data = {
+        "summary": {
+            "total_assessments": len(assessments),
+            "completed_assessments": sum(
+                a.status == "completed" for a in assessments
+            ),
+            "draft_assessments": sum(a.status == "draft" for a in assessments),
+            "linked_to_visits": sum(bool(a.visit_id) for a in assessments),
+        },
+        "groups": {
+            "assessments_by_type": _group_counts(
+                a.assessment_type for a in assessments
+            ),
+            "assessments_by_status": _group_counts(a.status for a in assessments),
+        },
+        "recent": rows[:10],
+        "rows": rows,
+    }
+    return _respond(
+        "assessment-summary",
+        data,
+        [
+            "assessment_id",
+            "patient_name",
+            "assessment_date",
+            "assessment_type",
+            "status",
+            "performed_by",
+            "linked_visit",
+        ],
+    )
+
+
+@reports_bp.get("/medical-records-summary")
+@swag_from(medical_records_summary_report_spec)
+@_report_errors
+def medical_records_summary_report():
+    filters = _filters()
+    query = MedicalRecord.query
+    if filters["start_date"]:
+        query = query.filter(
+            MedicalRecord.uploaded_at
+            >= _date_boundary(filters["start_date"], time.min)
+        )
+    if filters["end_date"]:
+        query = query.filter(
+            MedicalRecord.uploaded_at
+            <= _date_boundary(filters["end_date"], time.max)
+        )
+    if filters["patient_id"]:
+        query = query.filter(MedicalRecord.patient_id == filters["patient_id"])
+    if filters["visit_type"]:
+        query = query.filter(MedicalRecord.record_type == filters["visit_type"])
+    records = query.order_by(
+        MedicalRecord.uploaded_at.desc(),
+        MedicalRecord.id.desc(),
+    ).all()
+    rows = [
+        {
+            "record_id": record.id,
+            "patient_name": _patient_name(record.patient),
+            "title": record.title,
+            "record_type": record.record_type or "",
+            "file_name": record.file_name,
+            "uploaded_by": record.uploaded_by or "",
+            "uploaded_at": record.uploaded_at.date().isoformat(),
+        }
+        for record in records
+    ]
+    data = {
+        "summary": {
+            "total_records": len(records),
+            "patients_with_records": len({record.patient_id for record in records}),
+            "record_types": len(
+                {record.record_type for record in records if record.record_type}
+            ),
+            "recent_uploads": len(rows[:10]),
+        },
+        "groups": {
+            "records_by_type": _group_counts(r.record_type for r in records),
+            "records_over_time": _date_groups(
+                r.uploaded_at.date().isoformat() for r in records
+            ),
+        },
+        "recent": rows[:10],
+        "rows": rows,
+    }
+    return _respond(
+        "medical-records-summary",
+        data,
+        [
+            "record_id",
+            "patient_name",
+            "title",
+            "record_type",
+            "file_name",
+            "uploaded_by",
+            "uploaded_at",
+        ],
+    )

--- a/backend/app/swagger.py
+++ b/backend/app/swagger.py
@@ -487,6 +487,111 @@ admin_user_update_properties = {
     key: value for key, value in admin_user_properties.items() if key != "id"
 }
 
+report_filter_parameters = [
+    {
+        "name": "start_date",
+        "in": "query",
+        "type": "string",
+        "format": "date",
+        "required": False,
+    },
+    {
+        "name": "end_date",
+        "in": "query",
+        "type": "string",
+        "format": "date",
+        "required": False,
+    },
+    {
+        "name": "patient_id",
+        "in": "query",
+        "type": "integer",
+        "required": False,
+    },
+    {
+        "name": "status",
+        "in": "query",
+        "type": "string",
+        "required": False,
+    },
+    {
+        "name": "staff_role",
+        "in": "query",
+        "type": "string",
+        "required": False,
+    },
+    {
+        "name": "staff_name",
+        "in": "query",
+        "type": "string",
+        "required": False,
+    },
+    {
+        "name": "visit_type",
+        "in": "query",
+        "type": "string",
+        "required": False,
+        "description": (
+            "Visit type for visit/staff reports; record type for the "
+            "medical-records summary."
+        ),
+    },
+    {
+        "name": "format",
+        "in": "query",
+        "type": "string",
+        "enum": ["json", "csv"],
+        "required": False,
+        "description": "JSON is returned by default. Use csv to download rows.",
+    },
+]
+
+
+def report_spec(summary):
+    return {
+        "tags": ["Reports"],
+        "summary": summary,
+        "parameters": report_filter_parameters,
+        "responses": {
+            200: {
+                "description": "Report data or CSV export.",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "properties": {
+                                "summary": {"type": "object"},
+                                "groups": {"type": "object"},
+                                "recent": {
+                                    "type": "array",
+                                    "items": {"type": "object"},
+                                },
+                                "rows": {
+                                    "type": "array",
+                                    "items": {"type": "object"},
+                                },
+                            },
+                        },
+                        "message": {"type": "string"},
+                    },
+                },
+            },
+            400: {"description": "Invalid report filter."},
+            401: {"description": "Authentication required."},
+            403: {"description": "Reports permission required."},
+        },
+    }
+
+
+patient_census_report_spec = report_spec("Patient census report")
+visit_activity_report_spec = report_spec("Visit activity report")
+staff_activity_report_spec = report_spec("Staff activity report")
+assessment_summary_report_spec = report_spec("Assessment summary report")
+medical_records_summary_report_spec = report_spec(
+    "Medical records summary report"
+)
+
 swagger_config = {
     "headers": [],
     "specs": [

--- a/backend/tests/test_openapi.py
+++ b/backend/tests/test_openapi.py
@@ -47,6 +47,11 @@ def test_openapi_json_includes_health_and_patient_endpoints(client):
     assert "/api/settings/branding/logo" in paths
     assert "/api/public/branding" in paths
     assert "/api/public/branding/logo" in paths
+    assert "/api/reports/patient-census" in paths
+    assert "/api/reports/visit-activity" in paths
+    assert "/api/reports/staff-activity" in paths
+    assert "/api/reports/assessment-summary" in paths
+    assert "/api/reports/medical-records-summary" in paths
     assert "get" in paths["/api/health"]
     assert "get" in paths["/api/dashboard/stats"]
     assert {"get", "post"} <= set(paths["/api/patients"].keys())
@@ -88,6 +93,11 @@ def test_openapi_json_includes_health_and_patient_endpoints(client):
     assert {"post", "delete"} <= set(paths["/api/settings/branding/logo"].keys())
     assert "get" in paths["/api/public/branding"]
     assert "get" in paths["/api/public/branding/logo"]
+    assert "get" in paths["/api/reports/patient-census"]
+    assert "get" in paths["/api/reports/visit-activity"]
+    assert "get" in paths["/api/reports/staff-activity"]
+    assert "get" in paths["/api/reports/assessment-summary"]
+    assert "get" in paths["/api/reports/medical-records-summary"]
 
 
 def test_openapi_json_includes_patient_schemas(client):

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -1,0 +1,163 @@
+from datetime import date
+
+import pytest
+
+from app.demo_data import seed_demo_records
+from app.models import Patient
+from tests.test_auth import enable_auth, token_claims
+
+
+REPORT_PATHS = (
+    "/api/reports/patient-census",
+    "/api/reports/visit-activity",
+    "/api/reports/staff-activity",
+    "/api/reports/assessment-summary",
+    "/api/reports/medical-records-summary",
+)
+
+
+@pytest.fixture()
+def seeded_reports(app):
+    app.config["DEMO_DATA_ENABLED"] = True
+    with app.app_context():
+        counts = seed_demo_records(today=date(2026, 6, 11))
+    return counts
+
+
+@pytest.mark.parametrize("path", REPORT_PATHS)
+def test_reports_return_safe_empty_structure(client, path):
+    response = client.get(path)
+    data = response.get_json()["data"]
+
+    assert response.status_code == 200
+    assert set(data) == {"summary", "groups", "recent", "rows"}
+    assert data["rows"] == []
+    assert data["recent"] == []
+
+
+def test_patient_census_report_structure(client, seeded_reports):
+    response = client.get("/api/reports/patient-census")
+    data = response.get_json()["data"]
+
+    assert response.status_code == 200
+    assert data["summary"] == {
+        "total_patients": 24,
+        "active_patients": 21,
+        "inactive_patients": 3,
+    }
+    assert len(data["rows"]) == 24
+    assert data["groups"]["patients_by_gender"]
+    assert data["groups"]["patients_by_diagnosis"]
+
+
+def test_visit_activity_report_filters_dates_and_status(client, seeded_reports):
+    response = client.get(
+        "/api/reports/visit-activity",
+        query_string={
+            "start_date": "2026-06-01",
+            "end_date": "2026-06-11",
+            "status": "completed",
+        },
+    )
+    data = response.get_json()["data"]
+
+    assert response.status_code == 200
+    assert data["summary"]["total_visits"] > 0
+    assert all(row["status"] == "completed" for row in data["rows"])
+    assert all(
+        date.fromisoformat(row["visit_date"])
+        >= date(2026, 6, 1)
+        for row in data["rows"]
+    )
+
+
+def test_staff_activity_report_counts_linked_work(client, seeded_reports):
+    response = client.get(
+        "/api/reports/staff-activity",
+        query_string={"staff_role": "aide"},
+    )
+    data = response.get_json()["data"]
+
+    assert response.status_code == 200
+    assert data["summary"]["total_staff"] == 2
+    assert data["summary"]["total_visits"] == 48
+    assert data["summary"]["total_notes"] == 40
+    assert all(row["staff_role"] == "aide" for row in data["rows"])
+
+
+def test_assessment_summary_report_filters_patient(client, seeded_reports):
+    patient = Patient.query.filter_by(is_demo_data=True).first()
+    response = client.get(
+        "/api/reports/assessment-summary",
+        query_string={"patient_id": patient.id, "status": "completed"},
+    )
+    data = response.get_json()["data"]
+
+    assert response.status_code == 200
+    assert data["summary"]["total_assessments"] == 1
+    assert data["summary"]["linked_to_visits"] == 1
+    assert all(row["status"] == "completed" for row in data["rows"])
+
+
+def test_medical_records_summary_report_structure(client, seeded_reports):
+    response = client.get("/api/reports/medical-records-summary")
+    data = response.get_json()["data"]
+
+    assert response.status_code == 200
+    assert data["summary"]["total_records"] == 24
+    assert data["summary"]["patients_with_records"] == 24
+    assert data["groups"]["records_by_type"] == [
+        {"label": "care_plan", "count": 24}
+    ]
+
+
+@pytest.mark.parametrize("path", REPORT_PATHS)
+def test_report_csv_export(client, seeded_reports, path):
+    response = client.get(path, query_string={"format": "csv"})
+
+    assert response.status_code == 200
+    assert response.mimetype == "text/csv"
+    assert "attachment;" in response.headers["Content-Disposition"]
+    assert len(response.get_data(as_text=True).splitlines()) > 1
+
+
+def test_invalid_report_date_returns_clear_error(client):
+    response = client.get(
+        "/api/reports/visit-activity",
+        query_string={"start_date": "not-a-date"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == (
+        "start_date must use YYYY-MM-DD format."
+    )
+
+
+def test_reports_require_authentication_when_enabled(app, client):
+    app.config["AUTH_ENABLED"] = True
+
+    response = client.get("/api/reports/patient-census")
+
+    assert response.status_code == 401
+
+
+def test_viewer_can_access_reports(app, client, monkeypatch):
+    enable_auth(app, monkeypatch, token_claims("viewer"))
+
+    response = client.get(
+        "/api/reports/patient-census",
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+    assert response.status_code == 200
+
+
+def test_unknown_role_cannot_access_reports(app, client, monkeypatch):
+    enable_auth(app, monkeypatch, token_claims("unrecognized"))
+
+    response = client.get(
+        "/api/reports/patient-census",
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+    assert response.status_code == 403

--- a/docs/architecture/api-design.md
+++ b/docs/architecture/api-design.md
@@ -1459,3 +1459,64 @@ Assessments are returned newest assessment date first.
 
 This endpoint returns all assessments linked to the visit. A visit can have
 multiple assessment types.
+
+## Reporting and Analytics
+
+All report endpoints require `reports.read` and return JSON by default:
+
+- `GET /api/reports/patient-census`
+- `GET /api/reports/visit-activity`
+- `GET /api/reports/staff-activity`
+- `GET /api/reports/assessment-summary`
+- `GET /api/reports/medical-records-summary`
+
+JSON report responses use a consistent structure:
+
+```json
+{
+  "data": {
+    "summary": {},
+    "groups": {},
+    "recent": [],
+    "rows": []
+  },
+  "message": "Visit Activity retrieved successfully"
+}
+```
+
+`summary` powers metric cards, `groups` contains chart-ready label/count
+arrays, `recent` contains up to ten current records, and `rows` contains the
+complete filtered table.
+
+### Report Filters
+
+Supported parameters are applied where relevant:
+
+- `start_date` and `end_date` in `YYYY-MM-DD` format.
+- `patient_id`.
+- `staff_role`.
+- `staff_name` using partial case-insensitive matching.
+- `visit_type`.
+- `status`.
+
+For the Medical Records Summary, `visit_type` represents the record type to
+keep the shared report query contract small. Invalid dates and reversed date
+ranges return `400` with a clear message.
+
+Example:
+
+```text
+GET /api/reports/visit-activity?start_date=2026-06-01&status=completed
+```
+
+### CSV Export
+
+Add `format=csv` to any report endpoint:
+
+```text
+GET /api/reports/staff-activity?staff_role=nurse&format=csv
+```
+
+The response uses `text/csv` and an attachment filename. CSV contains the
+report's detailed rows after applying the same filters. Server-side PDF and
+Excel exports are not implemented.

--- a/docs/user-guide/reports.md
+++ b/docs/user-guide/reports.md
@@ -1,0 +1,60 @@
+# Reports
+
+SeniorMate reports turn patient, visit, staff, assessment, and medical-record
+activity into operational views for administrators, managers, nurses,
+caregivers, and viewers.
+
+Open **Reports** from the main navigation. Every SeniorMate role currently has
+`reports.read`; backend authorization remains authoritative.
+
+## Available Reports
+
+### Patient Census
+
+Shows total, active, and inactive patients, demographics, diagnosis groupings,
+and recently added patients.
+
+### Visit Activity
+
+Shows visit totals, completion and cancellation counts, visit types, staff
+roles, daily activity, and detailed visit rows.
+
+### Staff Activity
+
+Summarizes visits, aide notes, nurse notes, and completed assessments by staff
+member.
+
+### Assessment Summary
+
+Shows assessment type and status distributions, recent assessments, and how
+many assessments are linked to visits.
+
+### Medical Records Summary
+
+Shows document types, upload dates, recent uploads, and how many patients have
+medical records.
+
+## Filters
+
+Reports expose only relevant filters from:
+
+- Start and end date.
+- Patient ID.
+- Staff role and staff name.
+- Visit type.
+- Status.
+- Record type on the Medical Records Summary.
+
+Select **Apply filters** to refresh the report. **Clear filters** returns to the
+complete dataset. Empty results display a normal empty state rather than an
+error.
+
+## CSV Export
+
+Select **Export CSV** to download the detailed rows for the current report and
+active filters. JSON remains the API default. CSV exports contain tabular
+records, while summary cards and grouped chart data remain available in JSON.
+
+CSV files contain fictional data when used with the guarded demo seed from
+[Demo Data](../setup/demo-data.md). Review exports before sharing them outside
+the local environment.

--- a/docs/user-guide/roles-and-permissions.md
+++ b/docs/user-guide/roles-and-permissions.md
@@ -27,6 +27,7 @@ forbidden actions.
 | Assessments | Manage | Manage | Manage | View | View |
 | Medical records | Manage | Manage | Manage | View/download | View/download |
 | Patient photos | Manage/verify | Manage/verify | View | View | View |
+| Analytics reports | View/export | View/export | View/export | View/export | View/export |
 | Printable reports | View/print | View/print | View/print | View/print | View/print |
 | Branding settings | Manage | Manage | Hidden | Hidden | Hidden |
 | Admin users | Manage | Hidden | Hidden | Hidden | Hidden |

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -18,6 +18,8 @@ import PatientDetailView from "./views/PatientDetailView.js";
 import PatientFormView from "./views/PatientFormView.js";
 import PatientListView from "./views/PatientListView.js";
 import PatientPrintView from "./views/PatientPrintView.js";
+import ReportDetailView from "./views/ReportDetailView.js";
+import ReportsHomeView from "./views/ReportsHomeView.js";
 import NurseNoteDetailView from "./views/NurseNoteDetailView.js";
 import NurseNoteFormView from "./views/NurseNoteFormView.js";
 import NurseNoteListView from "./views/NurseNoteListView.js";
@@ -195,6 +197,47 @@ const routes = [
     name: "nurse-note-print",
     component: NurseNotePrintView,
     props: true,
+    meta: { permission: "reports.read" },
+  },
+  {
+    path: "/reports",
+    name: "reports",
+    component: ReportsHomeView,
+    meta: { permission: "reports.read" },
+  },
+  {
+    path: "/reports/patient-census",
+    name: "report-patient-census",
+    component: ReportDetailView,
+    props: { reportKey: "patient-census" },
+    meta: { permission: "reports.read" },
+  },
+  {
+    path: "/reports/visit-activity",
+    name: "report-visit-activity",
+    component: ReportDetailView,
+    props: { reportKey: "visit-activity" },
+    meta: { permission: "reports.read" },
+  },
+  {
+    path: "/reports/staff-activity",
+    name: "report-staff-activity",
+    component: ReportDetailView,
+    props: { reportKey: "staff-activity" },
+    meta: { permission: "reports.read" },
+  },
+  {
+    path: "/reports/assessment-summary",
+    name: "report-assessment-summary",
+    component: ReportDetailView,
+    props: { reportKey: "assessment-summary" },
+    meta: { permission: "reports.read" },
+  },
+  {
+    path: "/reports/medical-records-summary",
+    name: "report-medical-records-summary",
+    component: ReportDetailView,
+    props: { reportKey: "medical-records-summary" },
     meta: { permission: "reports.read" },
   },
   {

--- a/frontend/src/services/reports.js
+++ b/frontend/src/services/reports.js
@@ -1,0 +1,21 @@
+import { apiBlobRequest, apiRequest } from "./http.js";
+import { withQuery } from "./query.js";
+
+
+const reportPaths = {
+  "patient-census": "/reports/patient-census",
+  "visit-activity": "/reports/visit-activity",
+  "staff-activity": "/reports/staff-activity",
+  "assessment-summary": "/reports/assessment-summary",
+  "medical-records-summary": "/reports/medical-records-summary",
+};
+
+export function getReport(reportKey, filters = {}) {
+  return apiRequest(withQuery(reportPaths[reportKey], filters));
+}
+
+export function exportReportCsv(reportKey, filters = {}) {
+  return apiBlobRequest(
+    withQuery(reportPaths[reportKey], { ...filters, format: "csv" }),
+  );
+}

--- a/frontend/src/views/App.js
+++ b/frontend/src/views/App.js
@@ -42,6 +42,12 @@ const navItems = [
     to: "/nurse-notes",
     permission: "nurse_notes.read",
   },
+  {
+    title: "Reports",
+    icon: "mdi-chart-box-outline",
+    to: "/reports",
+    permission: "reports.read",
+  },
 ];
 
 export default {

--- a/frontend/src/views/ReportDetailView.js
+++ b/frontend/src/views/ReportDetailView.js
@@ -1,0 +1,381 @@
+import { computed, onMounted, reactive, ref, watch } from "vue";
+
+import { exportReportCsv, getReport } from "../services/reports.js";
+
+
+const commonDateFilters = ["start_date", "end_date"];
+
+const configurations = {
+  "patient-census": {
+    title: "Patient Census",
+    subtitle: "Patient population, status, demographics, and diagnoses.",
+    icon: "mdi-account-group-outline",
+    filters: [...commonDateFilters, "patient_id", "status"],
+    statuses: ["active", "inactive"],
+    summaryLabels: {
+      total_patients: "Total patients",
+      active_patients: "Active patients",
+      inactive_patients: "Inactive patients",
+    },
+    groupLabels: {
+      patients_by_gender: "Patients by gender",
+      patients_by_diagnosis: "Patients by diagnosis",
+    },
+    headers: [
+      { title: "Patient", key: "patient_name" },
+      { title: "Status", key: "status" },
+      { title: "Gender", key: "gender" },
+      { title: "Date of birth", key: "date_of_birth" },
+      { title: "Diagnosis", key: "diagnosis" },
+      { title: "Added", key: "created_at" },
+    ],
+  },
+  "visit-activity": {
+    title: "Visit Activity",
+    subtitle: "Care delivery volume, completion, cancellations, and trends.",
+    icon: "mdi-calendar-chart-outline",
+    filters: [
+      ...commonDateFilters,
+      "patient_id",
+      "staff_role",
+      "staff_name",
+      "visit_type",
+      "status",
+    ],
+    statuses: ["scheduled", "completed", "cancelled"],
+    summaryLabels: {
+      total_visits: "Total visits",
+      completed_visits: "Completed",
+      scheduled_visits: "Scheduled",
+      cancelled_visits: "Cancelled",
+    },
+    groupLabels: {
+      visits_by_type: "Visits by type",
+      visits_by_status: "Visits by status",
+      visits_by_staff_role: "Visits by staff role",
+      visits_over_time: "Visits over time",
+    },
+    headers: [
+      { title: "Patient", key: "patient_name" },
+      { title: "Date", key: "visit_date" },
+      { title: "Visit type", key: "visit_type" },
+      { title: "Staff", key: "staff_name" },
+      { title: "Role", key: "staff_role" },
+      { title: "Status", key: "status" },
+    ],
+  },
+  "staff-activity": {
+    title: "Staff Activity",
+    subtitle: "Visits, care notes, and assessments completed by staff.",
+    icon: "mdi-account-hard-hat-outline",
+    filters: [
+      ...commonDateFilters,
+      "patient_id",
+      "staff_role",
+      "staff_name",
+      "visit_type",
+      "status",
+    ],
+    statuses: ["scheduled", "completed", "cancelled"],
+    summaryLabels: {
+      total_staff: "Staff represented",
+      total_visits: "Total visits",
+      total_notes: "Care notes",
+      total_assessments: "Assessments",
+    },
+    groupLabels: { activity_by_role: "Visits by staff role" },
+    headers: [
+      { title: "Staff", key: "staff_name" },
+      { title: "Role", key: "staff_role" },
+      { title: "Visits", key: "total_visits" },
+      { title: "Aide notes", key: "aide_notes_completed" },
+      { title: "Nurse notes", key: "nurse_notes_completed" },
+      { title: "Assessments", key: "assessments_completed" },
+    ],
+  },
+  "assessment-summary": {
+    title: "Assessment Summary",
+    subtitle: "Assessment mix, completion, and linkage to care visits.",
+    icon: "mdi-clipboard-text-search-outline",
+    filters: [...commonDateFilters, "patient_id", "status"],
+    statuses: ["draft", "completed"],
+    summaryLabels: {
+      total_assessments: "Total assessments",
+      completed_assessments: "Completed",
+      draft_assessments: "Draft",
+      linked_to_visits: "Linked to visits",
+    },
+    groupLabels: {
+      assessments_by_type: "Assessments by type",
+      assessments_by_status: "Assessments by status",
+    },
+    headers: [
+      { title: "Patient", key: "patient_name" },
+      { title: "Date", key: "assessment_date" },
+      { title: "Type", key: "assessment_type" },
+      { title: "Status", key: "status" },
+      { title: "Performed by", key: "performed_by" },
+      { title: "Linked visit", key: "linked_visit" },
+    ],
+  },
+  "medical-records-summary": {
+    title: "Medical Records Summary",
+    subtitle: "Document coverage, types, and upload activity.",
+    icon: "mdi-file-chart-outline",
+    filters: [...commonDateFilters, "patient_id", "visit_type"],
+    summaryLabels: {
+      total_records: "Total records",
+      patients_with_records: "Patients covered",
+      record_types: "Record types",
+      recent_uploads: "Recent uploads",
+    },
+    groupLabels: {
+      records_by_type: "Records by type",
+      records_over_time: "Uploads over time",
+    },
+    headers: [
+      { title: "Patient", key: "patient_name" },
+      { title: "Title", key: "title" },
+      { title: "Record type", key: "record_type" },
+      { title: "File", key: "file_name" },
+      { title: "Uploaded by", key: "uploaded_by" },
+      { title: "Uploaded", key: "uploaded_at" },
+    ],
+  },
+};
+
+
+export default {
+  props: {
+    reportKey: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    const report = ref(null);
+    const loading = ref(true);
+    const exporting = ref(false);
+    const error = ref("");
+    const filters = reactive({
+      start_date: "",
+      end_date: "",
+      patient_id: "",
+      staff_role: "",
+      staff_name: "",
+      visit_type: "",
+      status: "",
+    });
+    const config = computed(() => configurations[props.reportKey]);
+    const summaryCards = computed(() =>
+      Object.entries(report.value?.summary || {}).map(([key, value]) => ({
+        title: config.value.summaryLabels[key] || key,
+        value,
+      })),
+    );
+    const groups = computed(() =>
+      Object.entries(report.value?.groups || {}).map(([key, items]) => ({
+        title: config.value.groupLabels[key] || key,
+        items,
+      })),
+    );
+    const activeFilters = computed(() =>
+      Object.fromEntries(
+        Object.entries(filters).filter(
+          ([key, value]) =>
+            config.value.filters.includes(key) && value !== "",
+        ),
+      ),
+    );
+
+    function hasFilter(name) {
+      return config.value.filters.includes(name);
+    }
+
+    function percentage(item, items) {
+      const maximum = Math.max(...items.map((entry) => entry.count), 1);
+      return Math.round((item.count / maximum) * 100);
+    }
+
+    async function loadReport() {
+      loading.value = true;
+      error.value = "";
+      try {
+        const response = await getReport(props.reportKey, activeFilters.value);
+        report.value = response.data;
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    function clearFilters() {
+      Object.keys(filters).forEach((key) => {
+        filters[key] = "";
+      });
+      loadReport();
+    }
+
+    async function downloadCsv() {
+      exporting.value = true;
+      error.value = "";
+      try {
+        const blob = await exportReportCsv(
+          props.reportKey,
+          activeFilters.value,
+        );
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement("a");
+        anchor.href = url;
+        anchor.download = `${props.reportKey}.csv`;
+        anchor.click();
+        URL.revokeObjectURL(url);
+      } catch (err) {
+        error.value = err.message;
+      } finally {
+        exporting.value = false;
+      }
+    }
+
+    watch(() => props.reportKey, loadReport);
+    onMounted(loadReport);
+
+    return {
+      clearFilters,
+      config,
+      downloadCsv,
+      error,
+      exporting,
+      filters,
+      groups,
+      hasFilter,
+      loadReport,
+      loading,
+      percentage,
+      report,
+      reportKey: props.reportKey,
+      summaryCards,
+    };
+  },
+  template: `
+    <div class="page-shell">
+      <v-btn variant="text" prepend-icon="mdi-arrow-left" to="/reports" class="mb-4">
+        Reports
+      </v-btn>
+
+      <PageHeader :title="config.title" :subtitle="config.subtitle" :icon="config.icon">
+        <template #actions>
+          <v-btn
+            variant="outlined"
+            prepend-icon="mdi-download-outline"
+            :loading="exporting"
+            @click="downloadCsv"
+          >
+            Export CSV
+          </v-btn>
+        </template>
+      </PageHeader>
+
+      <ErrorAlert :message="error" />
+
+      <SectionCard title="Filters" icon="mdi-filter-outline" class="mb-6">
+        <v-row>
+          <v-col v-if="hasFilter('start_date')" cols="12" sm="6" md="3">
+            <v-text-field v-model="filters.start_date" label="Start date" type="date" />
+          </v-col>
+          <v-col v-if="hasFilter('end_date')" cols="12" sm="6" md="3">
+            <v-text-field v-model="filters.end_date" label="End date" type="date" />
+          </v-col>
+          <v-col v-if="hasFilter('patient_id')" cols="12" sm="6" md="3">
+            <v-text-field v-model="filters.patient_id" label="Patient ID" type="number" min="1" />
+          </v-col>
+          <v-col v-if="hasFilter('staff_role')" cols="12" sm="6" md="3">
+            <v-select v-model="filters.staff_role" label="Staff role" :items="['aide', 'nurse']" clearable />
+          </v-col>
+          <v-col v-if="hasFilter('staff_name')" cols="12" sm="6" md="3">
+            <v-text-field v-model="filters.staff_name" label="Staff name" />
+          </v-col>
+          <v-col v-if="hasFilter('visit_type')" cols="12" sm="6" md="3">
+            <v-text-field
+              v-model="filters.visit_type"
+              :label="reportKey === 'medical-records-summary' ? 'Record type' : 'Visit type'"
+            />
+          </v-col>
+          <v-col v-if="hasFilter('status')" cols="12" sm="6" md="3">
+            <v-select v-model="filters.status" label="Status" :items="config.statuses" clearable />
+          </v-col>
+        </v-row>
+        <div class="d-flex flex-wrap justify-end ga-3">
+          <v-btn variant="text" @click="clearFilters">Clear filters</v-btn>
+          <v-btn color="primary" prepend-icon="mdi-filter-check-outline" :loading="loading" @click="loadReport">
+            Apply filters
+          </v-btn>
+        </div>
+      </SectionCard>
+
+      <LoadingState v-if="loading" type="heading, card, card, table" />
+
+      <template v-else-if="report">
+        <v-row class="mb-6">
+          <v-col v-for="card in summaryCards" :key="card.title" cols="12" sm="6" lg="3">
+            <v-card class="metric-card metric-card--primary">
+              <v-card-text class="pa-5">
+                <div class="metric-card__value">{{ card.value }}</div>
+                <div class="metric-card__title">{{ card.title }}</div>
+              </v-card-text>
+            </v-card>
+          </v-col>
+        </v-row>
+
+        <EmptyState
+          v-if="!report.rows.length"
+          icon="mdi-chart-box-outline"
+          title="No report data"
+          description="No records match the selected filters."
+          class="mb-6"
+        />
+
+        <v-row v-if="report.rows.length" class="mb-6">
+          <v-col v-for="group in groups" :key="group.title" cols="12" md="6">
+            <SectionCard :title="group.title" icon="mdi-chart-bar">
+              <div v-if="!group.items.length" class="text-medium-emphasis">No grouped data available.</div>
+              <div v-for="item in group.items.slice(0, 12)" :key="item.label" class="chart-row">
+                <div class="chart-row__label">
+                  <span>{{ item.label }}</span>
+                  <strong>{{ item.count }}</strong>
+                </div>
+                <v-progress-linear
+                  :model-value="percentage(item, group.items)"
+                  color="primary"
+                  height="8"
+                  rounded
+                />
+              </div>
+            </SectionCard>
+          </v-col>
+        </v-row>
+
+        <SectionCard title="Report details" icon="mdi-table" class="data-card">
+          <v-data-table
+            :headers="config.headers"
+            :items="report.rows"
+            density="comfortable"
+            :items-per-page="15"
+          >
+            <template #no-data>
+              <EmptyState
+                icon="mdi-table-off"
+                title="No rows to display"
+                description="Adjust the filters and try again."
+              />
+            </template>
+            <template #[\`item.status\`]="{ item }">
+              <StatusChip :status="item.status" />
+            </template>
+          </v-data-table>
+        </SectionCard>
+      </template>
+    </div>
+  `,
+};

--- a/frontend/src/views/ReportsHomeView.js
+++ b/frontend/src/views/ReportsHomeView.js
@@ -1,0 +1,76 @@
+const reports = [
+  {
+    title: "Patient Census",
+    description: "Patient status, demographics, diagnoses, and recent additions.",
+    icon: "mdi-account-group-outline",
+    to: "/reports/patient-census",
+  },
+  {
+    title: "Visit Activity",
+    description: "Visit volume, completion, cancellations, types, and trends.",
+    icon: "mdi-calendar-chart-outline",
+    to: "/reports/visit-activity",
+  },
+  {
+    title: "Staff Activity",
+    description: "Visits, care notes, and assessments completed by staff.",
+    icon: "mdi-account-hard-hat-outline",
+    to: "/reports/staff-activity",
+  },
+  {
+    title: "Assessment Summary",
+    description: "Assessment mix, completion status, and visit linkage.",
+    icon: "mdi-clipboard-text-search-outline",
+    to: "/reports/assessment-summary",
+  },
+  {
+    title: "Medical Records Summary",
+    description: "Document types, upload activity, and patient coverage.",
+    icon: "mdi-file-chart-outline",
+    to: "/reports/medical-records-summary",
+  },
+];
+
+
+export default {
+  setup() {
+    return { reports };
+  },
+  template: `
+    <div class="page-shell">
+      <PageHeader
+        title="Reports"
+        subtitle="Operational views for census, care delivery, staff activity, and clinical documentation."
+        icon="mdi-chart-box-outline"
+      />
+
+      <v-row>
+        <v-col
+          v-for="report in reports"
+          :key="report.to"
+          cols="12"
+          md="6"
+          lg="4"
+        >
+          <v-card class="section-card fill-height">
+            <v-card-text class="pa-6">
+              <v-icon :icon="report.icon" color="primary" size="32" class="mb-4" />
+              <h2 class="text-h6 font-weight-bold mb-2">{{ report.title }}</h2>
+              <p class="text-body-2 text-medium-emphasis mb-5">
+                {{ report.description }}
+              </p>
+              <v-btn
+                color="primary"
+                variant="tonal"
+                append-icon="mdi-arrow-right"
+                :to="report.to"
+              >
+                Open report
+              </v-btn>
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+    </div>
+  `,
+};


### PR DESCRIPTION
# Summary

- Added five permission-protected reporting APIs for patient census, visit activity, staff activity, assessment summaries, and medical records summaries.
- Added practical report filters, consistent JSON payloads, and CSV export without introducing server-side PDF or Excel dependencies.
- Added a Reports landing page and reusable report detail view with metric cards, grouped chart summaries, filters, tables, empty/error/loading states, and CSV download.
- Documented the report API, role access, filters, exports, and user workflow.

## Related Issue / Task

- Feature: 27-reporting-analytics

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `cd backend && .venv/bin/pytest -q` (146 passed)
- `cd backend && .venv/bin/ruff check app tests`
- `cd frontend && npm run test:permissions` (5 passed)
- `cd frontend && npm run build`
- `docker-compose config -q`
- Confirmed the local backend, frontend, PostgreSQL, MinIO, and Keycloak services are running.

## Screenshots

Authenticated browser screenshots are pending because the current local browser session is signed out of Keycloak. The UI production build passes and screenshots will be added after local demo-account login is authorized.

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.