### PR TITLE
docs: add SeniorMate developer learning path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Added a VitePress public website for SeniorMate v1.0.0 with product, screenshot, architecture, documentation, roadmap, and contact pages plus an automated GitHub Pages deployment workflow.
+- Added a developer learning path covering the SeniorMate backend, frontend, data model, request flows, platform engineering, troubleshooting, code-reading order, and practical maintenance exercises.
 
 ## [1.0.0] - 2026-06-12
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ Each report supports relevant filters and CSV export. See
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution process.
 
+## Developer Learning Path
+
+Maintainers and developers learning the codebase can start with the
+[SeniorMate Developer Learning Guide](docs/learning/seniormate-developer-guide.md).
+It connects the Flask backend, Vue frontend, PostgreSQL data model, Keycloak,
+MinIO, Docker Compose, testing, CI/CD, troubleshooting, request diagrams, and
+practical code exercises.
+
 ## Architecture
 
 ```mermaid

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,18 @@ best matches what you need to do.
 - [Deployment Guide](technical/deployment-guide.md)
 - [Demo Environment](technical/demo-environment.md)
 
+## Developer Learning Path
+
+- [SeniorMate Developer Guide](learning/seniormate-developer-guide.md)
+- [Flask Backend Guide](learning/flask-backend-guide.md)
+- [Vue Frontend Guide](learning/vue-frontend-guide.md)
+- [Platform Engineering Guide](learning/platform-engineering-guide.md)
+- [Data Model Walkthrough](learning/data-model-walkthrough.md)
+- [Request Flow Diagrams](learning/request-flows.md)
+- [Troubleshooting Guide](learning/troubleshooting.md)
+- [Code Reading Roadmap](learning/code-reading-roadmap.md)
+- [Practical Learning Exercises](learning/exercises.md)
+
 ## Architecture
 
 - [Architecture Overview](architecture/overview.md)

--- a/docs/learning/code-reading-roadmap.md
+++ b/docs/learning/code-reading-roadmap.md
@@ -1,0 +1,175 @@
+# Code Reading Roadmap
+
+Read SeniorMate in this order to build a mental model from platform boundaries
+inward. Do not try to read every file linearly.
+
+## 1. Docker Compose
+
+Read:
+
+- `docker-compose.yml`
+- `.env.example`
+
+Questions:
+
+- Which services exist?
+- Which addresses are for the host versus containers?
+- Which data is persistent?
+- Which services must start before the backend?
+
+Outcome: you can draw the local runtime without reading application code.
+
+## 2. Backend Factory and Configuration
+
+Read:
+
+- `backend/run.py`
+- `backend/app/__init__.py`
+- `backend/app/config.py`
+- `backend/app/extensions.py`
+
+Questions:
+
+- How is the Flask app created?
+- Where are integrations registered?
+- Which endpoints are public?
+- How does test configuration replace production configuration?
+
+## 3. Backend Models
+
+Read in this order:
+
+1. `patient.py`
+2. `visit.py`
+3. `aide_note.py`
+4. `nurse_note.py`
+5. `patient_assessment.py`
+6. `medical_record.py`
+7. `organization_settings.py`
+
+Keep the [Data Model Walkthrough](data-model-walkthrough.md) open. Trace foreign
+keys, relationship cascades, JSON fields, and `to_dict()` methods.
+
+## 4. Backend Routes
+
+Begin with `routes/patients.py` because it shows CRUD, filtering, validation,
+photo storage, and consistent responses.
+
+Then read:
+
+- `visits.py`
+- `aide_notes.py`
+- `nurse_notes.py`
+- `assessments.py`
+- `medical_records.py`
+- `dashboard.py`
+- `reports.py`
+- `branding.py`
+- `admin_users.py`
+
+For each route, answer:
+
+1. What permission is required?
+2. How is input validated?
+3. Which records are queried?
+4. Where is the transaction committed?
+5. What does success/error JSON look like?
+
+## 5. Backend Services and Cross-Cutting Helpers
+
+Read:
+
+- `auth.py`
+- `storage.py`
+- `keycloak_admin.py`
+- `routes/query_utils.py`
+- `swagger.py`
+
+Notice which concerns are shared and which remain route-local.
+
+## 6. Frontend Router
+
+Read `frontend/src/router.js`.
+
+Build a list of:
+
+- Route name and path.
+- View component.
+- Required permission.
+- Create/edit/detail/print relationships.
+
+## 7. Frontend Bootstrap and Layout
+
+Read:
+
+- `main.js`
+- `views/App.js`
+- `branding.js`
+- `styles/main.css`
+
+Trace startup ordering, Vuetify defaults, navigation filtering, and the
+branding fallback.
+
+## 8. Frontend Services
+
+Read:
+
+- `services/http.js`
+- `services/query.js`
+- `services/patients.js`
+- One JSON-heavy service.
+- `services/medicalRecords.js` for multipart/blob handling.
+
+Understand how tokens, JSON, FormData, errors, and downloads differ.
+
+## 9. Frontend Pages
+
+Follow one complete workflow:
+
+1. `PatientListView.js`
+2. `PatientFormView.js`
+3. `PatientDetailView.js`
+4. `MedicalRecordsSection.js`
+
+Then compare the same patterns in Visits and Notes.
+
+## 10. Authentication and RBAC
+
+Read side by side:
+
+- `backend/app/auth.py`
+- `frontend/src/auth.js`
+- `frontend/src/permission-policy.js`
+- `frontend/src/permissions.js`
+- `frontend/tests/permissions.test.js`
+
+Look for duplicated policy and the tests that prevent drift.
+
+## 11. Tests
+
+Start at `backend/tests/conftest.py`, then read:
+
+- `test_patients.py`
+- `test_auth.py`
+- `test_medical_records.py`
+- The test matching your intended change.
+
+Ask how external systems are replaced and where database state is reset.
+
+## 12. CI and Delivery
+
+Read:
+
+- `.github/workflows/backend-ci.yml`
+- `.github/workflows/frontend-ci.yml`
+- `.github/workflows/docker-build.yml`
+- `.github/workflows/github-pages.yml`
+- Backend and frontend Dockerfiles
+
+Match each CI command to something you can run locally.
+
+## Reading Exercise
+
+Choose one browser action, such as uploading a patient photo. Write down every
+file touched from click to database/object storage, then verify your path
+against [Request Flows](request-flows.md).

--- a/docs/learning/data-model-walkthrough.md
+++ b/docs/learning/data-model-walkthrough.md
@@ -1,0 +1,226 @@
+# Data Model Walkthrough
+
+SeniorMate's relational model centers on a patient and the care activity around
+that patient. Identity and file bytes remain in dedicated external systems.
+
+## Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    PATIENT ||--o{ VISIT : has
+    PATIENT ||--o{ AIDE_NOTE : has
+    PATIENT ||--o{ NURSE_NOTE : has
+    PATIENT ||--o{ ASSESSMENT : has
+    PATIENT ||--o{ MEDICAL_RECORD : has
+    VISIT ||--o| AIDE_NOTE : documents
+    VISIT ||--o| NURSE_NOTE : documents
+    VISIT o|--o{ ASSESSMENT : contextualizes
+
+    PATIENT {
+        int id PK
+        string first_name
+        string last_name
+        string status
+        string photo_object_key UK
+        boolean photo_verified
+        boolean is_demo_data
+    }
+    VISIT {
+        int id PK
+        int patient_id FK
+        date visit_date
+        string visit_type
+        string staff_role
+        string status
+        boolean is_demo_data
+    }
+    AIDE_NOTE {
+        int id PK
+        int patient_id FK
+        int visit_id FK,UK
+        json personal_care
+        json nutrition
+        string aide_name
+        boolean is_demo_data
+    }
+    NURSE_NOTE {
+        int id PK
+        int patient_id FK
+        int visit_id FK,UK
+        string diagnosis
+        json vital_signs
+        text narrative
+        boolean is_demo_data
+    }
+    ASSESSMENT {
+        int id PK
+        int patient_id FK
+        int visit_id FK
+        string assessment_type
+        date assessment_date
+        json findings
+        string status
+        boolean is_demo_data
+    }
+    MEDICAL_RECORD {
+        int id PK
+        int patient_id FK
+        string title
+        string file_name
+        string storage_object_key UK
+        datetime uploaded_at
+        boolean is_demo_data
+    }
+```
+
+The repository also has a fuller [existing ERD](../diagrams/erd.md).
+
+## Patient
+
+`Patient` is the central domain entity.
+
+It stores:
+
+- Identity and demographics.
+- Contact and emergency contact details.
+- Diagnosis summary and active/inactive status.
+- Patient photo metadata.
+- Demo-data marker.
+- Created and updated timestamps.
+
+Relationships cascade to visits, notes, assessments, and medical records. A
+patient delete is therefore a high-impact operation.
+
+Photo bytes are not stored in the row. `photo_object_key` points to private
+MinIO storage.
+
+## Visit
+
+A Visit belongs to exactly one Patient.
+
+It records:
+
+- Date and visit type.
+- Staff name and aide/nurse role.
+- Time in and out.
+- Notes and scheduled/completed/cancelled status.
+
+A visit may have:
+
+- Zero or one AideNote.
+- Zero or one NurseNote.
+- Many Assessments.
+
+Deleting a visit cascades its Aide/Nurse Note. Assessment foreign keys use
+`SET NULL`, preserving assessments without visit context.
+
+## AideNote
+
+An AideNote belongs to one Patient and one Visit. `visit_id` is unique, so a
+visit cannot have duplicate aide notes.
+
+Checklist sections are JSON:
+
+- Personal care
+- Nutrition
+- Mental status
+- Elimination
+- Activity
+- Assistive devices
+- Housekeeping
+
+JSON provides flexibility while the clinical form evolves, but it reduces
+database-level validation and reporting convenience. Changes to the JSON shape
+must remain backward compatible or include a migration strategy.
+
+## NurseNote
+
+A NurseNote has the same one-per-visit rule and contains larger clinical JSON
+sections such as vital signs, pain, respiratory, cardiac, skin, and functional
+status.
+
+Long narrative fields remain text columns. This hybrid approach keeps common
+free text simple while allowing structured sections to evolve.
+
+## PatientAssessment
+
+An assessment always belongs to a Patient and may belong to a Visit.
+
+Supported types are constrained:
+
+- `fall_risk`
+- `nutrition`
+- `mobility`
+- `cognitive`
+- `general`
+
+Status is `draft` or `completed`. Findings are JSON; summary and
+recommendations are text.
+
+## MedicalRecord
+
+MedicalRecord stores metadata:
+
+- Patient link.
+- Title, description, and type.
+- Original filename, MIME type, and size.
+- MinIO bucket and object key.
+- Uploader and timestamps.
+
+It does not store file bytes. Upload and delete workflows must keep PostgreSQL
+metadata and MinIO object lifecycle aligned.
+
+## OrganizationSettings
+
+OrganizationSettings is currently a singleton row, not a multi-tenant
+relationship.
+
+It stores:
+
+- Organization and app display names.
+- Custom logo metadata/object key.
+- Theme colors.
+- Login banner and footer text.
+
+The public branding endpoint resolves safe defaults when no row or custom
+value exists.
+
+## Users and Roles
+
+There is no SeniorMate `User` table.
+
+Keycloak stores:
+
+- User identity.
+- Passwords and sessions.
+- Enabled and verified state.
+- Realm roles.
+
+JWT claims connect a logged-in identity to SeniorMate permissions at request
+time. The current roles are admin, manager, nurse, caregiver, and viewer.
+
+This means clinical records currently reference staff names as strings rather
+than Keycloak user IDs. A future audit model may store immutable identity
+subject IDs alongside display names.
+
+## Demo Data Marker
+
+Major domain records include `is_demo_data`, defaulting to false. Seed and
+clear commands use this marker so demo cleanup does not delete normal records.
+
+## Migration History
+
+Migration files document model evolution:
+
+1. Patients
+2. Visits
+3. Aide Notes
+4. Nurse Notes
+5. Medical Records
+6. Patient photo fields
+7. Assessments
+8. Organization settings
+9. Demo-data markers
+
+Reading migrations in order is often the clearest way to understand why the
+current schema looks the way it does.

--- a/docs/learning/exercises.md
+++ b/docs/learning/exercises.md
@@ -1,0 +1,226 @@
+# SeniorMate Learning Exercises
+
+Use a separate feature branch for each exercise. Update tests, documentation,
+and `CHANGELOG.md` when the exercise changes repository behavior.
+
+## Add a New Patient Field
+
+**Goal:** Add a preferred language field end to end.
+
+**Files to inspect**
+
+- `backend/app/models/patient.py`
+- `backend/app/routes/patients.py`
+- `backend/app/swagger.py`
+- `backend/migrations/versions/`
+- `frontend/src/views/PatientFormView.js`
+- `frontend/src/views/PatientDetailView.js`
+- `backend/tests/test_patients.py`
+
+**Suggested steps**
+
+1. Add a nullable model column.
+2. Generate and inspect a migration.
+3. Add the field to allowed payload fields and serialization.
+4. Update OpenAPI.
+5. Add create/update tests.
+6. Add the form and detail display.
+
+**Expected result:** The field survives create, edit, reload, and API
+serialization.
+
+## Add a New Visit Status
+
+**Goal:** Add `missed` as a visit status.
+
+**Files to inspect**
+
+- `backend/app/models/visit.py`
+- Visits route validation
+- Visits Swagger schemas
+- Visit forms, status chips, dashboard/reports
+- Visit tests and migration history
+
+**Suggested steps**
+
+1. Update the database check constraint through a migration.
+2. Update backend validation and OpenAPI enum.
+3. Add the option to frontend forms/filters.
+4. Decide how reports count missed visits.
+5. Add focused tests.
+
+**Expected result:** Missed visits can be saved, filtered, displayed, and
+reported consistently.
+
+## Add a Dashboard Card
+
+**Goal:** Display cancelled visits this month.
+
+**Files to inspect**
+
+- `backend/app/routes/dashboard.py`
+- Dashboard Swagger schema
+- `backend/tests/test_dashboard.py`
+- `frontend/src/services/dashboard.js`
+- `frontend/src/views/DashboardView.js`
+
+**Suggested steps**
+
+1. Add the aggregate to the dashboard endpoint.
+2. Update Swagger and backend tests.
+3. Add the metric card with an appropriate icon and empty value.
+4. Build and inspect responsive layout.
+
+**Expected result:** The card reflects seeded/current-month data.
+
+## Add a Report Filter
+
+**Goal:** Filter medical-record summary by `record_type`.
+
+**Files to inspect**
+
+- `backend/app/routes/reports.py`
+- Report Swagger specifications
+- `frontend/src/services/reports.js`
+- `frontend/src/views/ReportDetailView.js`
+- `backend/tests/test_reports.py`
+
+**Suggested steps**
+
+1. Parse the new query parameter.
+2. Apply it only to the relevant report query.
+3. Document the filter.
+4. Add frontend filter metadata/control.
+5. Test JSON and CSV paths.
+
+**Expected result:** Table, summary, chart groups, and CSV all represent the
+same filtered dataset.
+
+## Add a Role Permission
+
+**Goal:** Allow managers, but not nurses, to verify patient photos.
+
+**Files to inspect**
+
+- `backend/app/auth.py`
+- `frontend/src/permission-policy.js`
+- `frontend/src/permissions.js`
+- Auth and permission tests
+
+**Suggested steps**
+
+1. Confirm the desired policy already/does not already exist.
+2. Update backend and frontend maps together.
+3. Add positive and negative tests.
+4. Login with each role and inspect action visibility/API behavior.
+
+**Expected result:** UI visibility and backend enforcement agree.
+
+## Add a New API Endpoint
+
+**Goal:** Add `GET /api/patients/<id>/summary`.
+
+**Files to inspect**
+
+- Patient route and model
+- Related visit/note/assessment models
+- `backend/app/auth.py`
+- `backend/app/swagger.py`
+- API tests
+
+**Suggested steps**
+
+1. Define the response and permission.
+2. Query only the data needed.
+3. Add a route and Swagger spec.
+4. Test found/not-found and authorization behavior.
+5. Avoid duplicating an existing printable-report payload without reason.
+
+**Expected result:** Swagger and tests describe a stable summary response.
+
+## Add a Frontend Form Field
+
+**Goal:** Add helper text and validation for patient email.
+
+**Files to inspect**
+
+- `PatientFormView.js`
+- `services/patients.js`
+- Patient backend validation
+
+**Suggested steps**
+
+1. Add local email validation without replacing backend validation.
+2. Display a field error near the input.
+3. Confirm API errors still map into `errors`.
+4. Check create and edit modes.
+
+**Expected result:** Invalid input is clear and valid data saves normally.
+
+## Add a Backend Test
+
+**Goal:** Test that deleting a patient removes related visits.
+
+**Files to inspect**
+
+- `backend/tests/conftest.py`
+- `test_patients.py`
+- `test_visits.py`
+- Patient/Visit relationships
+
+**Suggested steps**
+
+1. Create a patient and visit through the API.
+2. Delete the patient.
+3. Verify the visit no longer exists.
+4. Keep the test independent of execution order.
+
+**Expected result:** The test proves cascade behavior at the application
+boundary.
+
+## Debug a Failed Migration
+
+**Goal:** Practice diagnosing a migration revision mismatch.
+
+**Files to inspect**
+
+- `backend/migrations/versions/`
+- `backend/migrations/env.py`
+- Current model definitions
+
+**Suggested steps**
+
+1. Use a disposable local database.
+2. Run `flask db current`, `heads`, and `history`.
+3. Identify the expected parent revision.
+4. Inspect upgrade/downgrade functions.
+5. Restore a clean database and replay upgrades.
+
+**Expected result:** You can explain the mismatch before applying a fix. Do
+not practice destructive migration operations on real data.
+
+## Trace an API Request to the Database
+
+**Goal:** Trace patient creation from browser click to SQLAlchemy commit.
+
+**Files to inspect**
+
+- `PatientFormView.js`
+- `services/patients.js`
+- `services/http.js`
+- `backend/app/auth.py`
+- `routes/patients.py`
+- `models/patient.py`
+- `test_patients.py`
+
+**Suggested steps**
+
+1. Add temporary browser/backend breakpoints or safe debug logging locally.
+2. Submit a patient.
+3. Record payload changes at every boundary.
+4. Identify where authorization, validation, serialization, and persistence
+   occur.
+5. Remove temporary logging.
+
+**Expected result:** You can draw the complete request path and identify the
+best layer for a future rule.

--- a/docs/learning/flask-backend-guide.md
+++ b/docs/learning/flask-backend-guide.md
@@ -1,0 +1,257 @@
+# Flask Backend Guide
+
+This guide explains the SeniorMate backend as it exists in v1.0.0.
+
+## Application Factory
+
+[`backend/app/__init__.py`](../../backend/app/__init__.py) exposes
+`create_app(config_object=Config)`. The factory pattern lets production code
+use `Config` while tests supply `TestConfig`.
+
+The factory initializes:
+
+- Flask and environment configuration.
+- CORS.
+- Flasgger.
+- SQLAlchemy and Flask-Migrate.
+- Global API protection.
+- Domain blueprints.
+- Flask CLI demo commands.
+- Public health and root routes.
+
+[`backend/run.py`](../../backend/run.py) creates the application object used by
+`flask run`, the development container, and direct Python execution.
+
+## Configuration and Extensions
+
+`app/config.py` reads environment variables once when the class is imported.
+Important settings include:
+
+- `SQLALCHEMY_DATABASE_URI`
+- `AUTH_ENABLED`
+- Keycloak issuer, JWKS, audience, and Admin API values
+- MinIO endpoint, credentials, bucket, and secure mode
+- File-size limits
+- CORS origins
+
+`app/extensions.py` creates unbound `db` and `migrate` objects. The factory
+binds them to the current app. This avoids circular imports and makes test apps
+possible.
+
+## Blueprints and Routes
+
+Each module under `app/routes/` owns an API area. Blueprints either use a
+resource prefix such as `/api/patients` or the shared `/api` prefix.
+
+A typical route module contains:
+
+1. Allowed fields and domain constants.
+2. Parsing and validation helpers.
+3. Success/error response helpers.
+4. CRUD handlers.
+5. Related-resource handlers.
+6. `@swag_from(...)` references.
+
+Example patient creation:
+
+```text
+POST /api/patients
+  -> parse_patient_payload()
+  -> Patient(**data)
+  -> db.session.add()
+  -> db.session.commit()
+  -> patient.to_dict()
+```
+
+## Models and SQLAlchemy
+
+Models live under `app/models/`. They define:
+
+- Table and column mappings.
+- Foreign keys and database constraints.
+- ORM relationships.
+- Timestamp defaults.
+- `to_dict()` response serialization.
+
+Important patterns:
+
+- `ondelete="CASCADE"` removes child records with a deleted patient/visit.
+- ORM `cascade="all, delete-orphan"` aligns Python-side lifecycle behavior.
+- Visit note relationships use `uselist=False` plus a unique `visit_id`.
+- Assessment visit deletion uses `SET NULL`, preserving the assessment.
+- JSON columns hold flexible checklist and clinical sections.
+- check constraints protect statuses, roles, and assessment types.
+
+Models currently serialize themselves. There is no separate serializer layer.
+
+## Runtime Schema and Validation Approach
+
+SeniorMate does **not** currently use Marshmallow or Pydantic.
+
+Runtime validation is implemented with explicit functions such as:
+
+- `parse_patient_payload`
+- `parse_aide_note_payload`
+- `parse_nurse_note_payload`
+- `parse_assessment_payload`
+- `validate_upload`
+
+These functions whitelist fields, normalize strings, parse dates/times,
+verify relationships, and build field-specific errors.
+
+OpenAPI schemas in `app/swagger.py` document requests and responses, but
+Flasgger does not enforce them as the runtime validation layer.
+
+When adding a field, update all relevant layers:
+
+1. Model and migration.
+2. Parser/validator.
+3. `to_dict()`.
+4. Swagger schema.
+5. Tests.
+6. Frontend form/service if user-facing.
+
+## Migrations
+
+Flask-Migrate integrates Alembic with the app factory. Migration files are
+ordered under `backend/migrations/versions/`.
+
+Common commands from `backend/`:
+
+```bash
+flask --app run:app db current
+flask --app run:app db history
+flask --app run:app db migrate -m "Add patient field"
+flask --app run:app db upgrade
+flask --app run:app db downgrade
+```
+
+Always inspect generated migrations. Confirm:
+
+- Correct types and nullability.
+- Safe defaults for existing rows.
+- Expected constraints and indexes.
+- Upgrade and downgrade symmetry.
+
+The container mounts `./backend:/app`, so migration files created inside the
+backend container appear in the repository.
+
+## Service Layer
+
+SeniorMate has a selective service layer rather than a universal one.
+
+Extracted adapters:
+
+- `app/storage.py`: private MinIO bucket and object operations.
+- `app/keycloak_admin.py`: token caching and Keycloak Admin API operations.
+
+Domain CRUD is mostly performed directly inside route functions. This is
+reasonable at the current scale, but a future service layer would be helpful
+when:
+
+- The same transaction is reused by multiple interfaces.
+- A workflow spans several aggregates.
+- Domain rules become difficult to test through routes.
+- Retry or audit behavior must be centralized.
+
+Do not create a service class merely to move a few SQLAlchemy calls. Extract
+when it creates a clearer boundary.
+
+## Error Handling
+
+Domain routes return consistent JSON errors:
+
+```json
+{
+  "message": "Invalid aide note data",
+  "errors": {
+    "visit_id": "Visit does not belong to the selected patient."
+  }
+}
+```
+
+External adapters translate low-level failures:
+
+- MinIO errors become `PrivateObjectStorageError`.
+- Keycloak errors become `KeycloakAdminError` with an HTTP-oriented status.
+- JWT failures become a generic `401` without exposing token internals.
+
+There is not yet a global Flask exception handler. Unexpected exceptions are
+handled by Flask, while expected validation and integration failures are
+translated near the route.
+
+## Authentication and Authorization
+
+`app.before_request(protect_api_request)` makes authorization a cross-cutting
+API concern.
+
+Public paths include health, Swagger, OpenAPI, and public branding. For other
+API requests:
+
+1. `authenticate_request()` reads the bearer token.
+2. `decode_access_token()` fetches a signing key through `PyJWKClient`.
+3. PyJWT validates signature, issuer, audience, and expiry.
+4. Realm and API-client roles are filtered to supported SeniorMate roles.
+5. `_required_permission()` maps path and method to a permission.
+6. `user_has_permission()` evaluates the role permission union.
+
+`login_required` and `roles_required` decorators are available for special
+cases, but most current routes rely on the global hook.
+
+The path-based permission mapper is simple and centralized. When adding a new
+route family, update `_resource_for_path()` or the route may be denied because
+no permission is resolved.
+
+## Swagger/OpenAPI
+
+Flasgger is initialized in the factory. Specifications are Python dictionaries
+in `app/swagger.py` and attached with `@swag_from`.
+
+Development URLs:
+
+- Swagger UI: `http://localhost:5001/api/docs`
+- OpenAPI JSON: `http://localhost:5001/api/openapi.json`
+
+When API behavior changes, confirm both the runtime parser and Swagger
+description remain aligned.
+
+## Request-to-Response Walkthrough
+
+For `POST /api/patients`:
+
+1. Flask matches the patient blueprint route.
+2. `protect_api_request` authenticates and requires `patients.write`.
+3. The route reads JSON with `request.get_json(silent=True)`.
+4. `parse_patient_payload` validates and normalizes data.
+5. A `Patient` object is added to the SQLAlchemy session.
+6. `db.session.commit()` persists the transaction.
+7. `Patient.to_dict()` converts Python/date fields to JSON-safe values.
+8. Flask returns `201` with data and a success message.
+
+For a medical-record upload, the route additionally validates file signatures,
+uploads to MinIO, stores metadata, and compensates by deleting the object if
+the database commit fails.
+
+## Testing the Backend
+
+`tests/conftest.py` creates:
+
+- A testing Flask app.
+- In-memory SQLite tables.
+- Authentication-disabled development behavior.
+- Fake object storage.
+- A fake Keycloak Admin client.
+
+This keeps tests deterministic and fast. Use dependency injection through
+`app.extensions` when adding another external adapter.
+
+Run:
+
+```bash
+cd backend
+.venv/bin/ruff check app tests
+.venv/bin/pytest -q
+```
+
+Start with the test that matches the route module you changed, then run the
+full suite.

--- a/docs/learning/platform-engineering-guide.md
+++ b/docs/learning/platform-engineering-guide.md
@@ -1,0 +1,232 @@
+# Platform Engineering Guide
+
+SeniorMate is an application repository, but its local platform is a compact
+example of platform engineering concerns: service orchestration,
+configuration, identity, persistence, delivery automation, and operational
+boundaries.
+
+## Docker Compose as the Local Platform
+
+`docker-compose.yml` declares the local service graph:
+
+- PostgreSQL
+- MinIO
+- Keycloak
+- Flask backend
+- Vue/Vite frontend
+
+Compose gives developers one repeatable command:
+
+```bash
+docker compose up --build
+```
+
+It also describes health dependencies, ports, persistent volumes, source-code
+mounts, and environment injection. This is a developer platform contract.
+
+## Environment Variables
+
+`.env.example` is the configuration catalog and safe starting point. Values
+flow into Compose, then into application containers.
+
+Principles:
+
+- Commit placeholders, never real secrets.
+- Keep frontend variables prefixed with `VITE_`; they are compiled into the
+  browser bundle and must not contain secrets.
+- Treat backend secrets as runtime values.
+- Document units for numeric values such as byte limits.
+- Keep host and container endpoints distinct.
+
+Use `docker compose config` to see the fully resolved Compose configuration.
+
+## Service Discovery
+
+Compose creates a private network and DNS names matching service names.
+
+Inside the backend container:
+
+- PostgreSQL is `postgres:5432`.
+- MinIO is `minio:9000`.
+- Keycloak is `keycloak:8080`.
+
+From the host browser:
+
+- Flask is `localhost:5001`.
+- MinIO API is `localhost:9000`.
+- Keycloak is `localhost:8080`.
+
+The backend uses a browser-visible Keycloak issuer but a container-visible
+JWKS/Admin endpoint. This split is intentional: token `iss` must match what
+Keycloak publishes, while server-to-server calls use Compose DNS.
+
+## PostgreSQL Persistence
+
+The `postgres_data` named volume preserves database files across container
+recreation.
+
+Operational lessons:
+
+- `docker compose down` preserves named volumes.
+- `docker compose down -v` deletes local persisted data.
+- Schema state is managed with Alembic migrations, not container startup SQL.
+- Back up PostgreSQL separately from MinIO.
+
+Useful checks:
+
+```bash
+docker compose exec postgres pg_isready -U seniormate -d seniormate
+docker compose exec postgres psql -U seniormate -d seniormate
+docker compose exec backend flask --app run:app db current
+```
+
+## MinIO Object Storage
+
+MinIO provides an S3-compatible private bucket. PostgreSQL stores metadata and
+object keys; MinIO stores bytes.
+
+This separation teaches:
+
+- Object lifecycle management.
+- Metadata versus blob storage.
+- Private download mediation.
+- Compensating cleanup when one half of a cross-system operation fails.
+
+The current adapter automatically creates the bucket on first upload. A
+production platform should provision buckets and policies explicitly.
+
+## Keycloak Identity Provider
+
+Keycloak owns:
+
+- Users and credentials.
+- Login and sessions.
+- Realm/client roles.
+- Signed tokens and JWKS.
+
+SeniorMate owns:
+
+- Permission mapping.
+- API enforcement.
+- UI visibility.
+- Domain records and business operations.
+
+The local realm import makes development repeatable. A production platform
+would manage realm configuration as versioned infrastructure, protect admin
+client secrets, use TLS, and define backup/restore procedures.
+
+## GitHub Actions CI/CD
+
+Current workflows validate:
+
+- Backend dependencies, Ruff, and Pytest.
+- Frontend dependency installation and build.
+- Docker Compose configuration and application images.
+- VitePress website build and GitHub Pages deployment.
+
+The application delivery process stops at validation. Images are not pushed
+to a registry and the runtime application is not deployed automatically.
+
+This is a useful maturity boundary:
+
+```text
+Current: source -> test -> build
+Future:  source -> test -> scan -> package -> attest -> deploy -> verify
+```
+
+## GitHub Pages
+
+The public site lives in `docs-site/`. Its VitePress base is `/SeniorMate/`
+because it is a project page, not a user root page.
+
+The workflow:
+
+1. Checks out `main`.
+2. Configures Node and Pages.
+3. Runs `npm ci`.
+4. Builds VitePress.
+5. Uploads `.vitepress/dist`.
+6. Deploys to the `github-pages` environment.
+
+Repository Pages settings must use GitHub Actions as the source.
+
+## Release and Versioning
+
+SeniorMate uses Semantic Versioning. Version `1.0.0` appears in:
+
+- Frontend package metadata.
+- Backend version metadata.
+- Health/OpenAPI responses.
+- Application footer.
+- Changelog and release notes.
+
+A release process should keep code version, documentation, tag, and GitHub
+Release aligned.
+
+## Observability Gaps
+
+The current platform has application/container logs and health checks, but no
+full observability stack.
+
+Future improvements:
+
+- Structured JSON logging with request and correlation IDs.
+- Metrics for request latency, error rates, database pool, uploads, and auth.
+- Distributed tracing across frontend/API/external services where practical.
+- PostgreSQL, MinIO, and Keycloak health dashboards.
+- Alerting and service-level objectives.
+- Audit logging for clinical and administrative actions.
+- Central log retention and redaction rules.
+
+## Production-Readiness Checklist
+
+### Configuration and secrets
+
+- Replace every development placeholder.
+- Store secrets in a managed secret system.
+- Validate required configuration at startup.
+- Separate development, staging, and production configuration.
+
+### Networking and TLS
+
+- Use HTTPS for frontend, API, Keycloak, and MinIO.
+- Restrict PostgreSQL and MinIO from public access.
+- Configure trusted proxies and hostnames.
+- Set strict CORS origins.
+
+### Data
+
+- Automate PostgreSQL and MinIO backups.
+- Test restore procedures.
+- Run migrations as a controlled deployment step.
+- Define retention and deletion policies.
+
+### Identity and security
+
+- Harden Keycloak and rotate admin-client credentials.
+- Review role mappings and token lifetimes.
+- Add security headers and dependency/container scanning.
+- Add audit logging.
+- Perform threat modeling for clinical data.
+
+### Runtime
+
+- Use a production WSGI server and immutable images.
+- Add liveness/readiness probes.
+- Set resource requests and limits.
+- Use restart and rollout policies.
+- Remove development source mounts and debug mode.
+
+### Delivery
+
+- Publish versioned images.
+- Generate SBOMs and provenance.
+- Add staging deployment and smoke tests.
+- Require approvals for production.
+- Define rollback procedures.
+
+### Observability
+
+- Centralize logs.
+- Add metrics, dashboards, alerts, and SLOs.
+- Protect sensitive data in telemetry.

--- a/docs/learning/request-flows.md
+++ b/docs/learning/request-flows.md
@@ -1,0 +1,188 @@
+# SeniorMate Request Flows
+
+These sequence diagrams show the major runtime boundaries. The exact UI
+component varies, but the authentication, API, persistence, and storage paths
+remain consistent.
+
+## User Login
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Vue
+    participant Keycloak
+    participant API as Flask API
+
+    User->>Vue: Open protected route
+    Vue->>Keycloak: Authorization Code + PKCE login
+    Keycloak-->>User: Login form
+    User->>Keycloak: Submit credentials
+    Keycloak-->>Vue: Authorization code
+    Vue->>Keycloak: Exchange code + verifier
+    Keycloak-->>Vue: Access token
+    Vue->>API: GET /api/... + Bearer token
+    API->>Keycloak: Fetch/cache JWKS signing key
+    Keycloak-->>API: Public key
+    API-->>Vue: Authorized JSON response
+```
+
+## Loading the Dashboard
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant View as DashboardView
+    participant Service as dashboard service
+    participant API as Flask API
+    participant DB as PostgreSQL
+
+    User->>View: Open dashboard
+    View->>Service: getDashboardStats()
+    Service->>API: GET /api/dashboard/stats
+    API->>API: Authenticate and require dashboard.read
+    API->>DB: Count and group patients, visits, notes
+    DB-->>API: Aggregates and recent visits
+    API-->>Service: data + message
+    Service-->>View: Parsed response
+    View-->>User: Cards, charts, recent visits
+```
+
+## Creating a Patient
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Form as PatientFormView
+    participant Service as patients service
+    participant API as Patient route
+    participant DB as PostgreSQL
+
+    User->>Form: Enter details and save
+    Form->>Form: Validate required names
+    Form->>Service: createPatient(payload)
+    Service->>API: POST /api/patients
+    API->>API: Require patients.write
+    API->>API: Parse and validate payload
+    API->>DB: INSERT patient
+    DB-->>API: Patient ID and timestamps
+    API-->>Service: 201 patient response
+    Service-->>Form: Created patient
+    Form-->>User: Navigate to Patient Detail
+```
+
+## Uploading a Medical Record
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant UI as MedicalRecordsSection
+    participant API as Medical record route
+    participant DB as PostgreSQL
+    participant MinIO
+
+    User->>UI: Select metadata and file
+    UI->>API: POST multipart /api/medical-records
+    API->>API: Validate patient, size, MIME, extension, signature
+    API->>MinIO: Ensure bucket and upload object
+    MinIO-->>API: Upload complete
+    API->>DB: INSERT metadata + object key
+    alt Database commit succeeds
+        DB-->>API: Record persisted
+        API-->>UI: 201 record response
+    else Database commit fails
+        API->>MinIO: Delete uploaded object
+        API-->>UI: Error
+    end
+```
+
+## Uploading a Patient Photo
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Detail as PatientDetailView
+    participant API as Patient photo route
+    participant DB as PostgreSQL
+    participant MinIO
+
+    User->>Detail: Choose JPEG/PNG
+    Detail->>API: POST /api/patients/:id/photo
+    API->>API: Validate file type, signature, and size
+    API->>MinIO: Upload new profile object
+    API->>DB: Save photo metadata, verified=false
+    DB-->>API: Commit
+    opt Previous photo existed
+        API->>MinIO: Delete previous object
+    end
+    API-->>Detail: Updated patient metadata
+    Detail-->>User: Refresh avatar and review status
+```
+
+## Creating an Aide Note
+
+```mermaid
+sequenceDiagram
+    actor Caregiver
+    participant Form as AideNoteFormView
+    participant API as Aide note route
+    participant DB as PostgreSQL
+
+    Caregiver->>Form: Complete checklist and staff details
+    Form->>API: POST /api/aide-notes
+    API->>API: Require aide_notes.write
+    API->>DB: Find patient and visit
+    DB-->>API: Related records
+    API->>API: Confirm visit belongs to patient
+    API->>DB: Check note does not already exist
+    API->>DB: INSERT AideNote JSON + text fields
+    DB-->>API: Created note
+    API-->>Form: 201 response
+    Form-->>Caregiver: Navigate to note detail
+```
+
+## Creating a Nurse Note
+
+```mermaid
+sequenceDiagram
+    actor Nurse
+    participant Form as NurseNoteFormView
+    participant API as Nurse note route
+    participant DB as PostgreSQL
+
+    Nurse->>Form: Complete clinical sections
+    Form->>API: POST /api/nurse-notes
+    API->>API: Require nurse_notes.write
+    API->>DB: Validate patient and visit relationship
+    API->>DB: Check one-note-per-visit constraint
+    API->>API: Validate JSON clinical sections
+    API->>DB: INSERT NurseNote
+    DB-->>API: Created note
+    API-->>Form: 201 response
+    Form-->>Nurse: Navigate to note detail
+```
+
+## Generating a Report
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant View as ReportDetailView
+    participant Service as reports service
+    participant API as Report route
+    participant DB as PostgreSQL
+
+    User->>View: Choose report and filters
+    View->>Service: getReport(key, filters)
+    Service->>API: GET /api/reports/...?...filters
+    API->>API: Require reports.read and validate filters
+    API->>DB: Query and aggregate records
+    DB-->>API: Filtered rows
+    API-->>Service: Summary, groups, recent, rows
+    Service-->>View: Report data
+    View-->>User: Summary cards, chart, table
+    opt Export CSV
+        User->>Service: Request format=csv
+        Service->>API: GET report?format=csv
+        API-->>User: text/csv download
+    end
+```

--- a/docs/learning/seniormate-developer-guide.md
+++ b/docs/learning/seniormate-developer-guide.md
@@ -1,0 +1,291 @@
+# SeniorMate Developer Learning Guide
+
+This guide is the starting point for understanding SeniorMate v1.0.0 as a
+developer and maintainer. It explains how the pieces connect, which files are
+important, and how to reason about a change before editing code.
+
+## Project Purpose
+
+SeniorMate is a caregiver and patient management platform. The application
+connects patient demographics, visits, clinical notes, assessments, private
+medical records, photos, reports, authentication, user administration, and
+organization branding.
+
+The codebase is a useful platform engineering learning project because it
+combines:
+
+- A Vue 3 and Vuetify browser application.
+- A Flask JSON API.
+- PostgreSQL for relational domain data.
+- MinIO for private object storage.
+- Keycloak for identity and roles.
+- Docker Compose for local orchestration.
+- GitHub Actions for validation and GitHub Pages deployment.
+
+## Repository Map
+
+```text
+SeniorMate/
+├── backend/
+│   ├── app/
+│   │   ├── models/          # SQLAlchemy domain entities
+│   │   ├── routes/          # Flask blueprints, validation, and API behavior
+│   │   ├── __init__.py      # Flask application factory
+│   │   ├── auth.py          # JWT authentication and API authorization
+│   │   ├── config.py        # Environment-backed configuration
+│   │   ├── storage.py       # Private MinIO adapter
+│   │   ├── keycloak_admin.py# Keycloak Admin API client
+│   │   └── swagger.py       # Flasgger/OpenAPI specifications
+│   ├── migrations/          # Alembic migrations managed by Flask-Migrate
+│   └── tests/               # Pytest API and service-boundary tests
+├── frontend/
+│   ├── src/
+│   │   ├── components/      # Reusable Vuetify components
+│   │   ├── services/        # HTTP and domain API clients
+│   │   ├── views/           # Routed application screens
+│   │   ├── auth.js          # Keycloak client and reactive auth state
+│   │   ├── router.js        # Routes and permission guard
+│   │   ├── permissions.js   # UI permission helpers
+│   │   └── main.js          # Frontend bootstrap and Vuetify configuration
+│   └── tests/               # Focused frontend permission tests
+├── keycloak/                # Development realm import
+├── docs/                    # Product, operations, and architecture docs
+├── docs-site/               # VitePress public website
+├── .github/workflows/       # CI and GitHub Pages workflows
+├── docker-compose.yml       # Local service graph
+└── .env.example             # Safe environment variable reference
+```
+
+## System at a Glance
+
+```mermaid
+flowchart LR
+    Browser["Vue + Vuetify"] -->|"Bearer token + JSON"| API["Flask API"]
+    Browser -->|"OIDC + PKCE"| Keycloak["Keycloak"]
+    API --> PostgreSQL[("PostgreSQL")]
+    API --> MinIO[("Private MinIO")]
+    API -->|"JWKS / Admin API"| Keycloak
+```
+
+The browser never connects directly to PostgreSQL, MinIO, or the Keycloak
+Admin API. Flask is the application boundary for domain behavior and private
+storage.
+
+## Backend Architecture
+
+Start at [`backend/app/__init__.py`](../../backend/app/__init__.py).
+`create_app()`:
+
+1. Creates the Flask application.
+2. Loads environment-backed configuration.
+3. Enables CORS for `/api/*`.
+4. initializes Flasgger, SQLAlchemy, and Flask-Migrate.
+5. Installs the global authentication/authorization hook.
+6. Registers every domain blueprint.
+7. Registers demo-data CLI commands.
+8. Defines the public health and root endpoints.
+
+Most domain behavior is currently route-centric. A route module generally
+contains:
+
+- Request parsing and validation helpers.
+- SQLAlchemy queries.
+- Transaction commits.
+- Consistent JSON response helpers.
+- Flasgger specification references.
+
+Focused external-service logic is extracted:
+
+- `storage.py` wraps MinIO.
+- `keycloak_admin.py` wraps Keycloak Admin API calls.
+- `auth.py` validates JWTs and maps roles to permissions.
+
+Read [Flask Backend Guide](flask-backend-guide.md) for a complete walkthrough.
+
+## Frontend Architecture
+
+Start at [`frontend/src/main.js`](../../frontend/src/main.js). Bootstrap order
+matters:
+
+1. Public branding is loaded.
+2. Keycloak authentication is initialized.
+3. The router is imported.
+4. Vuetify is created with resolved branding colors.
+5. Reusable components are registered.
+6. The app mounts.
+
+Routes in `router.js` carry permission metadata. The global route guard requires
+authentication and redirects unauthorized navigation to `/access-denied`.
+Views call domain functions under `src/services/`, update Vue refs/reactive
+state, and render Vuetify components.
+
+Read [Vue Frontend Guide](vue-frontend-guide.md) for the detailed flow.
+
+## Database Architecture
+
+PostgreSQL stores domain records and metadata:
+
+- Patient is the central aggregate.
+- Visits belong to patients.
+- Aide Notes and Nurse Notes each belong to one patient and one visit.
+- A visit can have at most one note of each type.
+- Assessments belong to a patient and may reference a visit.
+- Medical Records belong to a patient and store file metadata.
+- OrganizationSettings is a singleton branding record.
+
+File bytes and user identities are deliberately outside PostgreSQL:
+
+- MinIO stores files, patient photos, and branding logos.
+- Keycloak stores users, credentials, sessions, and role assignments.
+
+Read [Data Model Walkthrough](data-model-walkthrough.md).
+
+## Authentication Flow
+
+The frontend uses `keycloak-js` with Authorization Code flow and PKCE. The API
+expects a bearer access token when `AUTH_ENABLED=true`.
+
+The Flask `before_request` hook:
+
+1. Allows public endpoints and CORS preflight requests.
+2. Reads the bearer token.
+3. Fetches the matching signing key from Keycloak JWKS.
+4. Validates RS256 signature, issuer, audience, and expiry.
+5. Extracts approved realm and API client roles.
+6. Maps the request path and HTTP method to a permission.
+7. Returns `401` or `403`, or allows the route to run.
+
+When authentication is explicitly disabled, backend and frontend both use an
+admin-like development identity. This is for local testing, not production.
+
+## File Storage Flow
+
+Medical records, patient photos, and branding logos use the same private
+storage adapter.
+
+1. A multipart request reaches Flask.
+2. The route validates the record owner, filename, MIME type, file signature,
+   and configured size limit.
+3. Flask creates an object key.
+4. `MinioPrivateObjectStorage` ensures the private bucket exists and uploads
+   the stream.
+5. PostgreSQL stores metadata and the object key.
+6. Downloads are streamed through Flask.
+
+If database persistence fails after upload, the route attempts to remove the
+new object. This prevents common orphan-file cases.
+
+## API Design
+
+API routes live below `/api`. Common JSON responses are:
+
+```json
+{
+  "data": {},
+  "message": "Patient created successfully"
+}
+```
+
+Paginated endpoints add:
+
+```json
+{
+  "pagination": {
+    "page": 1,
+    "per_page": 10,
+    "total": 26,
+    "pages": 3
+  }
+}
+```
+
+Validation errors use a message plus field errors:
+
+```json
+{
+  "message": "Invalid patient data",
+  "errors": {
+    "first_name": "This field is required."
+  }
+}
+```
+
+Flasgger builds Swagger UI at `/api/docs` and OpenAPI JSON at
+`/api/openapi.json`. The schemas are Python dictionaries in `app/swagger.py`;
+they are documentation, not the runtime validator.
+
+## Testing Strategy
+
+Backend tests use Pytest, an in-memory SQLite database, Flask's test client,
+and fake MinIO and Keycloak Admin clients. Authentication tests monkeypatch JWT
+decoding, so unit tests do not require a live identity provider.
+
+Frontend automated coverage currently focuses on the pure permission policy.
+The Vite production build catches template, import, and bundling failures.
+Interactive workflows still rely on local browser verification.
+
+Useful commands:
+
+```bash
+cd backend
+.venv/bin/ruff check app tests
+.venv/bin/pytest -q
+
+cd ../frontend
+npm run test:permissions
+npm run build
+```
+
+## CI/CD Flow
+
+Pull requests and pushes to `main` run:
+
+- Backend Ruff and Pytest.
+- Frontend Vite build.
+- Docker Compose validation and backend/frontend image builds.
+
+The GitHub Pages workflow builds `docs-site/` and deploys the artifact after
+changes reach `main`. No workflow currently publishes application containers
+or deploys the application to a production environment.
+
+## Docker Compose Setup
+
+`docker-compose.yml` starts five services:
+
+| Service | Container address | Host address |
+| --- | --- | --- |
+| Frontend | `frontend:5173` | `localhost:5173` |
+| Backend | `backend:5000` | `localhost:5001` |
+| PostgreSQL | `postgres:5432` | `localhost:5432` |
+| MinIO | `minio:9000` | `localhost:9000` |
+| Keycloak | `keycloak:8080` | `localhost:8080` |
+
+Inside a container, `localhost` means that same container. Use Compose service
+names for container-to-container communication. This distinction explains
+many database, MinIO, and Keycloak connection failures.
+
+## First Troubleshooting Loop
+
+When something fails:
+
+1. Identify the boundary: browser, frontend, API, database, storage, or identity.
+2. Inspect service status with `docker compose ps`.
+3. Read the relevant logs with `docker compose logs --tail=200 <service>`.
+4. Confirm effective configuration with `docker compose config`.
+5. Test the backend health endpoint.
+6. Reproduce the failing API call in Swagger or with `curl`.
+7. Run the closest unit test.
+8. Change one layer at a time.
+
+Use the detailed [Troubleshooting Guide](troubleshooting.md) for symptom-based
+diagnosis.
+
+## Recommended Learning Path
+
+1. Follow the [Code Reading Roadmap](code-reading-roadmap.md).
+2. Read the backend and frontend guides side by side.
+3. Trace one workflow in [Request Flows](request-flows.md).
+4. Run the app and compare logs with the sequence diagram.
+5. Complete a small task in [Learning Exercises](exercises.md).
+6. Write down which boundary surprised you. That is usually the best next
+   topic to study.

--- a/docs/learning/troubleshooting.md
+++ b/docs/learning/troubleshooting.md
@@ -1,0 +1,437 @@
+# SeniorMate Troubleshooting Guide
+
+Use this guide to move from a symptom to the failing boundary. Run commands
+from the repository root unless noted otherwise.
+
+## Baseline Checks
+
+```bash
+docker compose ps
+docker compose config
+docker compose logs --tail=100 backend frontend postgres minio keycloak
+curl http://localhost:5001/api/health
+```
+
+Do not paste secrets or access tokens into issues or pull requests.
+
+## Backend Does Not Start
+
+**Symptoms**
+
+- Frontend shows `Failed to fetch`.
+- Backend container restarts.
+- Flask reports an import error.
+
+**Likely causes**
+
+- Missing Python dependency.
+- Invalid environment value.
+- Database unavailable.
+- Import or syntax error.
+
+**Inspect**
+
+- `backend/requirements.txt`
+- `backend/app/__init__.py`
+- `backend/app/config.py`
+- `backend/run.py`
+- `docker-compose.yml`
+
+**Commands**
+
+```bash
+docker compose logs --tail=200 backend
+docker compose build --no-cache backend
+docker compose run --rm backend python -m pip check
+cd backend && .venv/bin/pytest -q
+```
+
+**Suggested fix**
+
+Add the missing dependency to requirements, correct the environment value, or
+fix the import. Rebuild the image after dependency changes.
+
+## Frontend Cannot Reach Backend
+
+**Symptoms**
+
+- Browser displays `Failed to fetch`.
+- Network request targets the wrong port.
+- Backend logs show no request.
+
+**Likely causes**
+
+- Incorrect `VITE_API_BASE_URL`.
+- Backend is stopped.
+- CORS origin mismatch.
+- Browser is using a stale Vite build/configuration.
+
+**Inspect**
+
+- `.env`
+- `frontend/src/config.js`
+- `frontend/src/services/http.js`
+- `backend/app/config.py`
+
+**Commands**
+
+```bash
+docker compose ps backend frontend
+curl http://localhost:5001/api/health
+docker compose logs --tail=100 frontend backend
+```
+
+**Suggested fix**
+
+Use a browser-reachable URL such as `http://localhost:5001/api`, restart the
+frontend after changing Vite variables, and include the frontend origin in
+`CORS_ORIGINS`.
+
+## Database Connection Fails
+
+**Symptoms**
+
+- Health endpoint returns `503` and `database: unavailable`.
+- Psycopg connection errors.
+- Backend cannot resolve or connect to PostgreSQL.
+
+**Likely causes**
+
+- Wrong hostname for the execution context.
+- PostgreSQL is unhealthy.
+- Credentials/database names do not match.
+- Port conflict on the host.
+
+**Inspect**
+
+- `DATABASE_URL`
+- `docker-compose.yml`
+- PostgreSQL service logs
+
+**Commands**
+
+```bash
+docker compose ps postgres
+docker compose logs --tail=200 postgres
+docker compose exec postgres pg_isready -U seniormate -d seniormate
+docker compose exec backend python -c "from app import create_app; print(create_app().config['SQLALCHEMY_DATABASE_URI'])"
+```
+
+**Suggested fix**
+
+Use `postgres:5432` from a container and `localhost:5432` from the host. Align
+database name, username, and password across Compose and the URL.
+
+## Migrations Fail
+
+**Symptoms**
+
+- `flask db upgrade` reports missing revisions or SQL errors.
+- Model and database columns differ.
+- A migration cannot apply to existing rows.
+
+**Likely causes**
+
+- Database is on an unexpected revision.
+- Branches introduced divergent migration heads.
+- Generated migration has an unsafe non-null column.
+- Manual schema edits bypassed Alembic.
+
+**Inspect**
+
+- `backend/migrations/versions/`
+- `backend/migrations/env.py`
+- Changed model
+
+**Commands**
+
+```bash
+docker compose exec backend flask --app run:app db current
+docker compose exec backend flask --app run:app db heads
+docker compose exec backend flask --app run:app db history
+docker compose exec backend flask --app run:app db upgrade
+```
+
+**Suggested fix**
+
+Identify the real current revision before changing anything. Resolve multiple
+heads with a merge migration, and use server defaults or staged nullability
+when existing rows need a new required value. Never stamp a production
+database merely to silence an error.
+
+## MinIO Upload Fails
+
+**Symptoms**
+
+- API returns `Private file storage is unavailable`.
+- Connection refused on `localhost:9000` from the backend container.
+- Upload metadata is not created.
+
+**Likely causes**
+
+- Backend uses the host endpoint instead of Compose DNS.
+- MinIO is stopped.
+- Credentials do not match root credentials.
+- Bucket operation is denied.
+
+**Inspect**
+
+- `MINIO_ENDPOINT` and `MINIO_DOCKER_ENDPOINT`
+- `backend/app/storage.py`
+- `docker-compose.yml`
+
+**Commands**
+
+```bash
+docker compose ps minio
+docker compose logs --tail=200 minio backend
+docker compose exec backend python -c "from app import create_app; print(create_app().config['MINIO_ENDPOINT'])"
+curl http://localhost:9000/minio/health/live
+```
+
+**Suggested fix**
+
+Use `http://minio:9000` inside the backend container. Align access keys,
+restart the services, and verify MinIO health before retrying.
+
+## Keycloak Login Fails
+
+**Symptoms**
+
+- Redirect loop.
+- Keycloak page says client or redirect URI is invalid.
+- Frontend shows authentication unavailable.
+
+**Likely causes**
+
+- Keycloak is not running.
+- Wrong realm/client URL.
+- Redirect URI or web origin missing in realm import.
+- Host/port mismatch.
+
+**Inspect**
+
+- `frontend/src/auth.js`
+- `frontend/src/config.js`
+- `keycloak/seniormate-realm.json`
+- `.env`
+
+**Commands**
+
+```bash
+docker compose ps keycloak
+docker compose logs --tail=200 keycloak frontend
+curl http://localhost:8080/realms/seniormate/.well-known/openid-configuration
+```
+
+**Suggested fix**
+
+Confirm realm `seniormate`, client `seniormate-frontend`, frontend URL, and
+allowed redirect URIs agree. Restart Keycloak after changing the imported
+development realm or update the active realm through its admin console.
+
+## JWT Validation Fails
+
+**Symptoms**
+
+- Login succeeds but API returns `401 Invalid or expired access token`.
+- Backend cannot fetch JWKS.
+- Token audience or issuer errors appear in tests/logs.
+
+**Likely causes**
+
+- `KEYCLOAK_ISSUER` does not exactly match the token `iss`.
+- `KEYCLOAK_AUDIENCE` is absent from the token.
+- Backend JWKS URL uses an unreachable hostname.
+- Token expired or system time is wrong.
+
+**Inspect**
+
+- `backend/app/auth.py`
+- Backend Keycloak environment values
+- Keycloak client/audience configuration
+
+**Commands**
+
+```bash
+docker compose logs --tail=200 backend keycloak
+docker compose exec backend python -c "from app import create_app; a=create_app(); print(a.config['KEYCLOAK_ISSUER'], a.config['KEYCLOAK_JWKS_URL'], a.config['KEYCLOAK_AUDIENCE'])"
+curl http://localhost:8080/realms/seniormate/protocol/openid-connect/certs
+```
+
+**Suggested fix**
+
+Keep the issuer browser-visible if that is what Keycloak signs, use
+`http://keycloak:8080/.../certs` for container-to-container JWKS access, and
+ensure the access token includes `seniormate-api` as audience.
+
+## Role Permissions Do Not Work
+
+**Symptoms**
+
+- Button visibility and API behavior disagree.
+- Admin screen returns `403`.
+- Newly added endpoint is always forbidden.
+
+**Likely causes**
+
+- Frontend and backend permission maps differ.
+- Token role is not an approved SeniorMate role.
+- New route path is missing from backend resource mapping.
+- User needs a fresh token after role changes.
+
+**Inspect**
+
+- `backend/app/auth.py`
+- `frontend/src/permission-policy.js`
+- `frontend/src/permissions.js`
+- `frontend/src/router.js`
+
+**Commands**
+
+```bash
+cd backend && .venv/bin/pytest -q tests/test_auth.py tests/test_admin_users.py
+cd ../frontend && npm run test:permissions
+```
+
+**Suggested fix**
+
+Update both permission maps and tests. Add the route family to
+`_resource_for_path()`. Log out and back in after changing Keycloak roles.
+
+## GitHub Actions Fails
+
+**Symptoms**
+
+- PR check is red.
+- Local tests pass but CI install/build fails.
+- Pages deployment cannot find a Pages site.
+
+**Likely causes**
+
+- Lockfile and package metadata differ.
+- Dependency/tool version differs from local.
+- Workflow path or permissions are wrong.
+- Pages is not configured to use GitHub Actions.
+
+**Inspect**
+
+- `.github/workflows/`
+- Failing job and step logs
+- Relevant lockfiles
+
+**Commands**
+
+```bash
+cd backend && .venv/bin/ruff check . && .venv/bin/pytest
+cd ../frontend && npm ci && npm run build
+cd ../docs-site && npm ci && npm run build
+docker compose config
+```
+
+**Suggested fix**
+
+Reproduce the exact CI command locally. Commit lockfile updates. For Pages,
+select GitHub Actions under repository Settings -> Pages and rerun the
+workflow. Keep workflow permissions limited to what the deployment requires.
+
+## Docker Compose Networking Issues
+
+**Symptoms**
+
+- One container cannot resolve another.
+- `localhost` connection refused inside a container.
+- Host can reach a service but backend cannot.
+
+**Likely causes**
+
+- Hostname belongs to the wrong network context.
+- Service is not on the Compose network.
+- Port mapping is confused with container port.
+
+**Inspect**
+
+- `docker-compose.yml`
+- Effective environment from `docker compose config`
+
+**Commands**
+
+```bash
+docker compose ps
+docker compose exec backend getent hosts postgres minio keycloak
+docker compose exec backend curl -I http://keycloak:8080
+```
+
+**Suggested fix**
+
+Use service names and container ports between containers. Use localhost and
+published ports only from the host.
+
+## CORS Issues
+
+**Symptoms**
+
+- Browser console reports a CORS policy error.
+- Curl succeeds but browser request fails.
+- OPTIONS/preflight fails.
+
+**Likely causes**
+
+- Frontend origin absent from `CORS_ORIGINS`.
+- Scheme, hostname, or port differs.
+- Request is being sent to the wrong backend.
+
+**Inspect**
+
+- `backend/app/__init__.py`
+- `backend/app/config.py`
+- `.env`
+
+**Commands**
+
+```bash
+curl -i -X OPTIONS http://localhost:5001/api/patients \
+  -H "Origin: http://localhost:5173" \
+  -H "Access-Control-Request-Method: GET"
+```
+
+**Suggested fix**
+
+Add the exact browser origin, including scheme and port, to `CORS_ORIGINS`.
+Restart the backend after environment changes.
+
+## Environment Variable Mistakes
+
+**Symptoms**
+
+- A service uses an unexpected default.
+- Boolean flags behave opposite to expectation.
+- Changes appear to have no effect.
+
+**Likely causes**
+
+- Variable is absent or misspelled.
+- `.env` was changed after containers started.
+- Vite variable was not prefixed with `VITE_`.
+- Host and container values were mixed.
+
+**Inspect**
+
+- `.env.example`
+- Local `.env`
+- `docker-compose.yml`
+- `backend/app/config.py`
+- `frontend/src/config.js`
+
+**Commands**
+
+```bash
+docker compose config
+docker compose exec backend env | sort
+docker compose exec frontend env | sort
+```
+
+**Suggested fix**
+
+Compare against `.env.example`, recreate affected containers, and remember that
+frontend environment values are read by Vite and exposed to the browser.

--- a/docs/learning/vue-frontend-guide.md
+++ b/docs/learning/vue-frontend-guide.md
@@ -1,0 +1,233 @@
+# Vue Frontend Guide
+
+This guide explains how the SeniorMate Vue 3 frontend is assembled and how a
+user action becomes an authenticated API request and a UI update.
+
+## Application Bootstrap
+
+[`frontend/src/main.js`](../../frontend/src/main.js) is the entry point.
+
+It:
+
+1. Imports Vuetify, icons, and global CSS.
+2. Loads public branding.
+3. Initializes Keycloak authentication.
+4. Imports the router after auth initialization.
+5. Creates the SeniorMate Vuetify theme.
+6. Registers shared components globally.
+7. Mounts `App`.
+
+Branding loads before rendering so the shell can begin with the configured
+name, logo, and colors instead of visibly changing after mount.
+
+## Vue Style Used in SeniorMate
+
+The project uses Vue's Composition API primitives inside JavaScript component
+objects:
+
+- `ref()` for mutable values.
+- `reactive()` for shared state.
+- `computed()` for derived values.
+- `onMounted()` for initial loading.
+- `useRoute()` and `useRouter()` for navigation.
+
+Components use JavaScript template strings rather than `.vue` single-file
+components. A view exports an object with `setup()` and `template`.
+
+## Router
+
+`src/router.js` defines:
+
+- List, detail, create, edit, and print routes.
+- Report routes.
+- Admin and branding routes.
+- An Access Denied route.
+
+Most routes include `meta.permission`. The global `beforeEach` guard:
+
+1. Allows the authentication error screen to render.
+2. Starts login if the user is unauthenticated.
+3. Checks the required permission.
+4. Redirects unauthorized users to `/access-denied`.
+
+The guard improves user experience. It is not a security boundary; Flask must
+still reject unauthorized API calls.
+
+## Vuetify Layout
+
+`src/views/App.js` defines the application shell:
+
+- Responsive navigation drawer.
+- Permission-filtered navigation.
+- Organization branding.
+- User name and role.
+- Logout action.
+- Version display.
+- Application bar and route content.
+
+Reusable UI components standardize common patterns:
+
+- `PageHeader`
+- `DetailHeader`
+- `SectionCard`
+- `LoadingState`
+- `EmptyState`
+- `ErrorAlert`
+- `ConfirmDialog`
+- `StatusChip`
+- Print components
+
+Views should reuse these before inventing another local pattern.
+
+## Views and Components
+
+Views under `src/views/` correspond to router destinations. They own page-level
+loading, forms, API calls, and navigation.
+
+Components under `src/components/` encapsulate repeated UI or a substantial
+section inside a page. `MedicalRecordsSection`, for example, owns upload,
+metadata edit, download, and delete behavior within Patient Detail.
+
+A useful split is:
+
+- View: route ownership and page composition.
+- Component: reusable presentation or a focused embedded workflow.
+- Service: HTTP request details.
+
+## API Services
+
+`src/services/http.js` is the common HTTP adapter.
+
+`apiRequest()`:
+
+1. Refreshes or retrieves the Keycloak access token.
+2. Creates the API URL from `VITE_API_BASE_URL`.
+3. Adds JSON content type unless the body is `FormData`.
+4. Adds the bearer token.
+5. Calls `fetch`.
+6. Parses JSON and throws an `Error` with the API payload on failure.
+
+`apiBlobRequest()` performs authenticated downloads.
+
+Domain service files such as `patients.js`, `visits.js`, and
+`medicalRecords.js` keep paths and HTTP verbs out of views.
+
+## State Management
+
+SeniorMate does not use Pinia or Vuex.
+
+Shared reactive modules provide the current global state:
+
+- `auth.js`: authentication status, profile, roles, and token availability.
+- `branding.js`: resolved public branding and theme values.
+
+Page state stays local to views and components using refs. This is appropriate
+while most data is route-specific. A central store becomes valuable if the
+same server state needs caching, synchronization, or optimistic updates across
+many unrelated views.
+
+## Authentication State
+
+`auth.js` wraps `keycloak-js`.
+
+Authentication-enabled behavior:
+
+- `login-required` on startup.
+- Authorization Code with PKCE S256.
+- Token refresh before API requests.
+- A 30-second refresh timer.
+- Login retry when a token expires or refresh fails.
+- User profile and roles extracted from token claims.
+
+Authentication-disabled behavior:
+
+- The frontend creates a Development User.
+- The user receives the `admin` role.
+- Existing screens remain usable without Keycloak.
+
+Frontend and backend auth flags must agree during local development.
+
+## Permission Helpers and RBAC UI
+
+`permission-policy.js` is a pure role-to-permission map. It is deliberately
+separate from Vue so Node's built-in test runner can test it.
+
+`permissions.js` connects the pure policy to current `authState.roles` and
+provides helpers such as:
+
+- `can(permission)`
+- `canManagePatients()`
+- `canCreateAideNote()`
+- `canManageMedicalRecords()`
+- `canManageUsers()`
+
+Navigation and action buttons call these helpers. The frontend map should match
+`backend/app/auth.py`. A permission change normally requires updating and
+testing both maps.
+
+## Forms and Validation
+
+Forms use Vuetify fields with local validation before submission. For example,
+PatientForm checks first and last names, normalizes empty strings, then calls
+the patient service.
+
+The backend remains authoritative. On API failure:
+
+- `http.js` throws an error.
+- The view displays `error.message`.
+- Field errors can be read from `error.payload.errors`.
+
+This two-level approach gives immediate feedback while preserving server-side
+integrity.
+
+## User Action-to-UI Walkthrough
+
+Creating a patient:
+
+1. User submits `PatientFormView`.
+2. `validate()` checks required names.
+3. `apiPayload()` normalizes form data.
+4. `createPatient()` calls `apiRequest("/patients", ...)`.
+5. `apiRequest()` refreshes the token and sends the bearer request.
+6. Flask validates and persists the patient.
+7. The service returns the parsed response.
+8. The view routes to `/patients/<id>`.
+9. Patient Detail loads the patient and related records.
+
+Deleting a patient:
+
+1. Patient List hides the action unless the role can write patients.
+2. A confirmation dialog captures intent.
+3. The delete service calls the API.
+4. On success, the view shows feedback and reloads the list.
+
+## Adding a Frontend Field
+
+For a new patient field:
+
+1. Add it to the backend first.
+2. Add it to `emptyForm`.
+3. Render the Vuetify field.
+4. Include any local validation/normalization.
+5. Confirm create and edit preload behavior.
+6. Display it in the appropriate detail/print view.
+7. Run the production build and browser-check narrow layouts.
+
+## Testing and Verification
+
+Run:
+
+```bash
+cd frontend
+npm run test:permissions
+npm run build
+```
+
+The current frontend has limited unit coverage. Also verify:
+
+- Authentication-enabled and disabled startup.
+- Role-specific visibility.
+- Loading, empty, error, and success states.
+- Desktop and narrow browser widths.
+- No raw API stack traces are shown.
+- No broken image or logo states.


### PR DESCRIPTION
# Summary

- Add a codebase-specific developer learning path for SeniorMate v1.0.0.
- Explain the Flask backend, Vue frontend, PostgreSQL model, Keycloak authentication, MinIO storage, Docker Compose platform, tests, CI/CD, and GitHub Pages delivery.
- Add request sequence diagrams, a symptom-driven troubleshooting runbook, a recommended code-reading order, and practical maintenance exercises.
- Link the learning path from the documentation index and README, and record it under Unreleased in the changelog.

The guides describe the implementation that currently exists. In particular, they document that runtime validation is route-local rather than Marshmallow/Pydantic-based, and that the backend has focused MinIO and Keycloak clients rather than a universal service layer.

## Related Issue / Task

- Feature: `31-developer-learning-guide`

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- Validated all relative Markdown links in `docs/learning/`, `docs/index.md`, and `README.md`.
- Confirmed 9 learning documents and 10 Mermaid diagram blocks.
- `cd backend && .venv/bin/ruff check app tests`
- `cd backend && .venv/bin/pytest -q` (147 passed)
- `cd frontend && npm run test:permissions` (5 passed)
- `cd frontend && npm run build`
- `cd docs-site && npm ci && npm run build`
- `docker-compose config -q`
- `git diff --check`

The frontend and VitePress builds retain their existing non-blocking chunk-size warnings.

## Screenshots

N/A. This pull request adds Markdown learning documentation and Mermaid diagrams without changing the application UI.

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.