### PR TITLE
docs: expand developer learning path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Added a VitePress public website for SeniorMate v1.0.0 with product, screenshot, architecture, documentation, roadmap, and contact pages plus an automated GitHub Pages deployment workflow.
-- Added a developer learning path covering the SeniorMate backend, frontend, data model, request flows, platform engineering, troubleshooting, code-reading order, and practical maintenance exercises.
+- Added a developer learning path covering the SeniorMate backend, frontend, data model, request flows, platform engineering, troubleshooting, code-reading order, technology resources and experiments, design tradeoffs, practical maintenance exercises, and an eight-week study plan.
 
 ## [1.0.0] - 2026-06-12
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,10 @@ Maintainers and developers learning the codebase can start with the
 [SeniorMate Developer Learning Guide](docs/learning/seniormate-developer-guide.md).
 It connects the Flask backend, Vue frontend, PostgreSQL data model, Keycloak,
 MinIO, Docker Compose, testing, CI/CD, troubleshooting, request diagrams, and
-practical code exercises.
+practical code exercises. The
+[eight-week study plan](docs/learning/study-plan.md) provides a structured path
+from local containers and Flask basics through authentication, CI/CD, and
+production readiness.
 
 ## Architecture
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,7 @@ best matches what you need to do.
 
 ## Developer Learning Path
 
+- [Eight-Week Study Plan](learning/study-plan.md)
 - [SeniorMate Developer Guide](learning/seniormate-developer-guide.md)
 - [Flask Backend Guide](learning/flask-backend-guide.md)
 - [Vue Frontend Guide](learning/vue-frontend-guide.md)

--- a/docs/learning/data-model-walkthrough.md
+++ b/docs/learning/data-model-walkthrough.md
@@ -3,6 +3,66 @@
 SeniorMate's relational model centers on a patient and the care activity around
 that patient. Identity and file bytes remain in dedicated external systems.
 
+## What Is PostgreSQL?
+
+PostgreSQL is an open-source relational database. It stores structured data in
+tables and supports relationships, transactions, constraints, indexes, JSON,
+and a sophisticated query planner.
+
+SeniorMate uses PostgreSQL because patient and care records have strong
+relationships and integrity rules. A relational database can enforce required
+fields, foreign keys, uniqueness, and status constraints while supporting
+reporting queries across related records.
+
+PostgreSQL is configured in `docker-compose.yml`, connected through
+`DATABASE_URL`, modeled in `backend/app/models/`, and evolved through
+`backend/migrations/`.
+
+## PostgreSQL Concepts in SeniorMate
+
+| Database topic | SeniorMate example |
+| --- | --- |
+| Table | `patients`, `visits`, `medical_records` |
+| Row | One patient or visit instance |
+| Primary key | Integer `id` |
+| Foreign key | `visits.patient_id -> patients.id` |
+| Relationship | Patient has many Visits |
+| Index | Patient/visit foreign keys and demo markers |
+| Unique constraint | One AideNote/NurseNote per visit |
+| Check constraint | Visit status and staff role |
+| Transaction | Upload metadata commit or patient creation |
+| JSON column | Nurse Note clinical sections |
+
+### Tables and Relationships
+
+SQLAlchemy model classes map to PostgreSQL tables. Foreign keys express
+ownership; ORM relationships make related Python objects navigable.
+
+### Indexes
+
+Indexes speed lookups and joins but consume space and make writes slightly more
+expensive. SeniorMate indexes foreign keys and frequently selected demo
+markers. Future filtering should be measured before adding broad indexes.
+
+### Constraints
+
+Constraints protect data even if a future client bypasses current route
+validation. Check, foreign-key, unique, and not-null constraints complement
+application validation.
+
+### Transactions
+
+`db.session.commit()` makes a unit of database work durable. A rollback keeps
+partial changes from persisting. Cross-system MinIO/database operations are
+not one distributed transaction, so routes use compensating deletion.
+
+### Query Planning
+
+PostgreSQL chooses scans, joins, and indexes using table statistics. Use
+`EXPLAIN` or `EXPLAIN ANALYZE` on slow queries, especially reporting and
+multi-filter list endpoints. Never run `EXPLAIN ANALYZE` on a destructive
+statement against real data without understanding its execution.
+
 ## Entity Relationship Diagram
 
 ```mermaid
@@ -224,3 +284,47 @@ Migration files document model evolution:
 
 Reading migrations in order is often the clearest way to understand why the
 current schema looks the way it does.
+
+## Understanding the Design
+
+### Why PostgreSQL instead of MongoDB?
+
+SeniorMate's patient, visit, note, assessment, and record relationships benefit
+from foreign keys, transactions, constraints, and joins. PostgreSQL also
+supports JSON for flexible clinical sections, so the project can combine
+relational integrity with selected document-like fields.
+
+MongoDB could make evolving large JSON documents easier, but relationship
+integrity and cross-record reporting would move more responsibility into
+application code. PostgreSQL's tradeoff is that schema changes require
+migrations and careful relational design.
+
+## Learning Resources
+
+### Beginner
+
+- [PostgreSQL Tutorial](https://www.postgresql.org/docs/current/tutorial.html)
+- [PostgreSQLTutorial.com](https://www.postgresqltutorial.com/)
+
+### Intermediate
+
+- [Indexes](https://www.postgresql.org/docs/current/indexes.html)
+- [Concurrency Control and Transactions](https://www.postgresql.org/docs/current/mvcc.html)
+- [Using EXPLAIN](https://www.postgresql.org/docs/current/using-explain.html)
+- [SQLAlchemy ORM Quick Start](https://docs.sqlalchemy.org/en/20/orm/quickstart.html)
+
+### Official Documentation
+
+- [PostgreSQL Documentation](https://www.postgresql.org/docs/)
+- [PostgreSQL SQL Commands](https://www.postgresql.org/docs/current/sql-commands.html)
+- [SQLAlchemy Documentation](https://docs.sqlalchemy.org/en/20/)
+
+## Suggested Database Experiments
+
+1. Use `psql` to describe the `patients` and `visits` tables.
+2. Insert related test records through the API, then inspect their foreign
+   keys.
+3. Run `EXPLAIN` on the patient search query with and without filters.
+4. Trigger a check-constraint failure in a disposable database.
+5. Open a transaction, update a test row, roll it back, and confirm no change.
+6. Add an index in a throwaway migration and compare the query plan.

--- a/docs/learning/exercises.md
+++ b/docs/learning/exercises.md
@@ -17,6 +17,13 @@ and `CHANGELOG.md` when the exercise changes repository behavior.
 - `frontend/src/views/PatientDetailView.js`
 - `backend/tests/test_patients.py`
 
+**Read first**
+
+- [SQLAlchemy mapped classes](https://docs.sqlalchemy.org/en/20/orm/mapping_styles.html)
+- [Alembic tutorial](https://alembic.sqlalchemy.org/en/latest/tutorial.html)
+- [Vue form bindings](https://vuejs.org/guide/essentials/forms.html)
+- [Vuetify text fields](https://vuetifyjs.com/en/components/text-fields/)
+
 **Suggested steps**
 
 1. Add a nullable model column.
@@ -28,6 +35,14 @@ and `CHANGELOG.md` when the exercise changes repository behavior.
 
 **Expected result:** The field survives create, edit, reload, and API
 serialization.
+
+**Expected skills learned**
+
+- Database model and migration changes
+- Backend serialization and validation
+- OpenAPI schema maintenance
+- Vue and Vuetify form changes
+- End-to-end regression testing
 
 ## Add a New Visit Status
 
@@ -41,6 +56,13 @@ serialization.
 - Visit forms, status chips, dashboard/reports
 - Visit tests and migration history
 
+**Read first**
+
+- [PostgreSQL check constraints](https://www.postgresql.org/docs/current/ddl-constraints.html)
+- [Alembic operations reference](https://alembic.sqlalchemy.org/en/latest/ops.html)
+- [Vue conditional rendering](https://vuejs.org/guide/essentials/conditional.html)
+- [Vuetify chips](https://vuetifyjs.com/en/components/chips/)
+
 **Suggested steps**
 
 1. Update the database check constraint through a migration.
@@ -51,6 +73,13 @@ serialization.
 
 **Expected result:** Missed visits can be saved, filtered, displayed, and
 reported consistently.
+
+**Expected skills learned**
+
+- Constraint evolution through migrations
+- Keeping backend enums and frontend options aligned
+- Updating aggregates and reports safely
+- Testing a value across persistence, API, and UI layers
 
 ## Add a Dashboard Card
 
@@ -64,6 +93,13 @@ reported consistently.
 - `frontend/src/services/dashboard.js`
 - `frontend/src/views/DashboardView.js`
 
+**Read first**
+
+- [SQLAlchemy query guide](https://docs.sqlalchemy.org/en/20/orm/queryguide/index.html)
+- [Vue computed properties](https://vuejs.org/guide/essentials/computed.html)
+- [Vuetify cards](https://vuetifyjs.com/en/components/cards/)
+- [Vuetify grid system](https://vuetifyjs.com/en/components/grids/)
+
 **Suggested steps**
 
 1. Add the aggregate to the dashboard endpoint.
@@ -72,6 +108,13 @@ reported consistently.
 4. Build and inspect responsive layout.
 
 **Expected result:** The card reflects seeded/current-month data.
+
+**Expected skills learned**
+
+- Aggregate database queries
+- API response evolution
+- Reactive dashboard rendering
+- Responsive Vuetify layout
 
 ## Add a Report Filter
 
@@ -85,6 +128,13 @@ reported consistently.
 - `frontend/src/views/ReportDetailView.js`
 - `backend/tests/test_reports.py`
 
+**Read first**
+
+- [Flask request data](https://flask.palletsprojects.com/en/stable/api/#flask.Request)
+- [SQLAlchemy SELECT and WHERE](https://docs.sqlalchemy.org/en/20/tutorial/data_select.html)
+- [OpenAPI parameters](https://swagger.io/docs/specification/v3_0/describing-parameters/)
+- [Vue form bindings](https://vuejs.org/guide/essentials/forms.html)
+
 **Suggested steps**
 
 1. Parse the new query parameter.
@@ -95,6 +145,13 @@ reported consistently.
 
 **Expected result:** Table, summary, chart groups, and CSV all represent the
 same filtered dataset.
+
+**Expected skills learned**
+
+- Query parameter parsing
+- Composable database filters
+- JSON and CSV response consistency
+- Filter state in a frontend view
 
 ## Add a Role Permission
 
@@ -107,6 +164,13 @@ same filtered dataset.
 - `frontend/src/permissions.js`
 - Auth and permission tests
 
+**Read first**
+
+- [Keycloak role mappings](https://www.keycloak.org/docs/latest/server_admin/#role-mappings)
+- [Vue Router route meta fields](https://router.vuejs.org/guide/advanced/meta.html)
+- [JWT introduction](https://jwt.io/introduction)
+- [SeniorMate roles and permissions](../user-guide/roles-and-permissions.md)
+
 **Suggested steps**
 
 1. Confirm the desired policy already/does not already exist.
@@ -115,6 +179,13 @@ same filtered dataset.
 4. Login with each role and inspect action visibility/API behavior.
 
 **Expected result:** UI visibility and backend enforcement agree.
+
+**Expected skills learned**
+
+- Role-based access control design
+- Backend authorization enforcement
+- Frontend permission-driven UX
+- Positive and negative permission testing
 
 ## Add a New API Endpoint
 
@@ -128,6 +199,13 @@ same filtered dataset.
 - `backend/app/swagger.py`
 - API tests
 
+**Read first**
+
+- [Flask routing](https://flask.palletsprojects.com/en/stable/quickstart/#routing)
+- [SQLAlchemy relationship loading](https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html)
+- [OpenAPI paths and operations](https://swagger.io/docs/specification/v3_0/paths-and-operations/)
+- [Flask testing](https://flask.palletsprojects.com/en/stable/testing/)
+
 **Suggested steps**
 
 1. Define the response and permission.
@@ -137,6 +215,13 @@ same filtered dataset.
 5. Avoid duplicating an existing printable-report payload without reason.
 
 **Expected result:** Swagger and tests describe a stable summary response.
+
+**Expected skills learned**
+
+- REST endpoint design
+- Querying related domain data
+- Authorization and error handling
+- OpenAPI documentation and API testing
 
 ## Add a Frontend Form Field
 
@@ -148,6 +233,13 @@ same filtered dataset.
 - `services/patients.js`
 - Patient backend validation
 
+**Read first**
+
+- [Vue form bindings](https://vuejs.org/guide/essentials/forms.html)
+- [Vue event handling](https://vuejs.org/guide/essentials/event-handling.html)
+- [Vuetify forms](https://vuetifyjs.com/en/components/forms/)
+- [Vuetify text fields](https://vuetifyjs.com/en/components/text-fields/)
+
 **Suggested steps**
 
 1. Add local email validation without replacing backend validation.
@@ -156,6 +248,13 @@ same filtered dataset.
 4. Check create and edit modes.
 
 **Expected result:** Invalid input is clear and valid data saves normally.
+
+**Expected skills learned**
+
+- Reactive form state
+- Client-side validation and helper text
+- Mapping backend errors into UI feedback
+- Testing create and edit behavior
 
 ## Add a Backend Test
 
@@ -168,6 +267,12 @@ same filtered dataset.
 - `test_visits.py`
 - Patient/Visit relationships
 
+**Read first**
+
+- [Pytest documentation](https://docs.pytest.org/en/stable/)
+- [Flask testing](https://flask.palletsprojects.com/en/stable/testing/)
+- [SQLAlchemy cascades](https://docs.sqlalchemy.org/en/20/orm/cascades.html)
+
 **Suggested steps**
 
 1. Create a patient and visit through the API.
@@ -177,6 +282,13 @@ same filtered dataset.
 
 **Expected result:** The test proves cascade behavior at the application
 boundary.
+
+**Expected skills learned**
+
+- Test fixture usage
+- Arrange, act, assert structure
+- Relationship cascade behavior
+- Isolated API-level regression testing
 
 ## Debug a Failed Migration
 
@@ -188,6 +300,13 @@ boundary.
 - `backend/migrations/env.py`
 - Current model definitions
 
+**Read first**
+
+- [Flask-Migrate documentation](https://flask-migrate.readthedocs.io/)
+- [Alembic tutorial](https://alembic.sqlalchemy.org/en/latest/tutorial.html)
+- [Alembic branches](https://alembic.sqlalchemy.org/en/latest/branches.html)
+- [PostgreSQL transactions](https://www.postgresql.org/docs/current/tutorial-transactions.html)
+
 **Suggested steps**
 
 1. Use a disposable local database.
@@ -198,6 +317,13 @@ boundary.
 
 **Expected result:** You can explain the mismatch before applying a fix. Do
 not practice destructive migration operations on real data.
+
+**Expected skills learned**
+
+- Reading a migration graph
+- Diagnosing revision and head mismatches
+- Replaying migrations against disposable data
+- Separating diagnosis from destructive repair
 
 ## Trace an API Request to the Database
 
@@ -213,6 +339,13 @@ not practice destructive migration operations on real data.
 - `models/patient.py`
 - `test_patients.py`
 
+**Read first**
+
+- [MDN HTTP overview](https://developer.mozilla.org/en-US/docs/Web/HTTP/Overview)
+- [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch)
+- [Flask request context](https://flask.palletsprojects.com/en/stable/reqcontext/)
+- [SQLAlchemy session basics](https://docs.sqlalchemy.org/en/20/orm/session_basics.html)
+
 **Suggested steps**
 
 1. Add temporary browser/backend breakpoints or safe debug logging locally.
@@ -224,3 +357,10 @@ not practice destructive migration operations on real data.
 
 **Expected result:** You can draw the complete request path and identify the
 best layer for a future rule.
+
+**Expected skills learned**
+
+- Browser-to-database request tracing
+- Identifying authentication and validation boundaries
+- Understanding SQLAlchemy session and commit behavior
+- Choosing the correct layer for a change

--- a/docs/learning/flask-backend-guide.md
+++ b/docs/learning/flask-backend-guide.md
@@ -2,6 +2,42 @@
 
 This guide explains the SeniorMate backend as it exists in v1.0.0.
 
+## What Is Flask?
+
+Flask is a lightweight Python web framework built around Werkzeug. It provides
+routing, request/response handling, application and request contexts,
+configuration, extension hooks, and a development CLI without imposing a
+large application architecture.
+
+SeniorMate uses Flask because its API is modular but still small enough to
+benefit from explicit wiring. The application can select SQLAlchemy,
+Flask-Migrate, Flasgger, PyJWT, and MinIO independently rather than adopting a
+larger all-in-one framework.
+
+Flask appears in:
+
+- `backend/app/__init__.py` for application creation and registration.
+- `backend/app/routes/` for blueprints and request handlers.
+- `backend/app/auth.py` for request hooks, `g`, and JSON auth errors.
+- `backend/run.py` for the development entry point.
+- `backend/tests/` through Flask's test client and application contexts.
+
+## Flask Request Lifecycle
+
+For a protected SeniorMate API request:
+
+1. The WSGI server passes the request to Flask.
+2. Flask creates application and request contexts.
+3. `protect_api_request` runs as a `before_request` callback.
+4. Flask matches the URL to a blueprint view.
+5. The view reads `request`, validates input, and performs domain work.
+6. The view returns data/status that Flask converts into a response.
+7. Flask tears down the request context and SQLAlchemy manages scoped-session
+   cleanup.
+
+Objects such as `request`, `current_app`, and `g` are context-local proxies.
+They look global in code but refer to the active request/application context.
+
 ## Application Factory
 
 [`backend/app/__init__.py`](../../backend/app/__init__.py) exposes
@@ -38,6 +74,16 @@ Important settings include:
 binds them to the current app. This avoids circular imports and makes test apps
 possible.
 
+This delayed initialization is also a dependency injection pattern:
+
+- The factory receives a configuration object.
+- Extensions are created once but bound to each app.
+- Tests replace MinIO and Keycloak clients through `app.extensions`.
+- Auth tests replace token decoding with `monkeypatch`.
+
+SeniorMate does not use a dependency injection container. It uses explicit
+factory parameters, extension registries, and test substitution.
+
 ## Blueprints and Routes
 
 Each module under `app/routes/` owns an API area. Blueprints either use a
@@ -62,6 +108,21 @@ POST /api/patients
   -> db.session.commit()
   -> patient.to_dict()
 ```
+
+## SeniorMate-to-Flask Map
+
+| SeniorMate concept | Flask concept |
+| --- | --- |
+| Patient API | Blueprint and view functions |
+| `/api/patients/<id>` | Variable URL rule |
+| `protect_api_request` | `before_request` middleware-style hook |
+| `login_required` / `roles_required` | View decorators |
+| `Config` / `TestConfig` | Configuration objects |
+| `db` and `migrate` | Delayed extension initialization |
+| Demo seed commands | Flask/Click CLI commands |
+| Swagger setup | Extension-based API documentation |
+| Pytest client | Flask test client |
+| `current_app`, `request`, `g` | Application/request context proxies |
 
 ## Models and SQLAlchemy
 
@@ -204,8 +265,27 @@ no permission is resolved.
 
 ## Swagger/OpenAPI
 
+REST is an architectural style for exposing resources through standard HTTP
+methods and status codes. OpenAPI is a machine-readable description of an HTTP
+API. Swagger is the surrounding tooling commonly used to display and interact
+with an OpenAPI specification.
+
+SeniorMate uses these concepts so frontend developers, testers, and API
+consumers can discover request fields, response shapes, authentication
+requirements, and errors without reading every route.
+
 Flasgger is initialized in the factory. Specifications are Python dictionaries
 in `app/swagger.py` and attached with `@swag_from`.
+
+| SeniorMate concept | API documentation concept |
+| --- | --- |
+| `/api/patients` | REST resource collection |
+| `GET`, `POST`, `PUT`, `DELETE` | HTTP methods |
+| `PatientCreate` | Reusable request schema |
+| `PatientResponse` | Reusable response schema |
+| Bearer security definition | OpenAPI security scheme |
+| `/api/docs` | Swagger UI |
+| `/api/openapi.json` | OpenAPI document |
 
 Development URLs:
 
@@ -214,6 +294,38 @@ Development URLs:
 
 When API behavior changes, confirm both the runtime parser and Swagger
 description remain aligned.
+
+### Why Flasgger instead of generated schemas?
+
+This is a comparison, not a record of a formal historical decision.
+
+Flasgger fits the current Flask routes because it can document existing view
+functions without requiring a route rewrite. Flask-Smorest could connect
+Marshmallow validation and OpenAPI more tightly, while FastAPI could generate
+schemas from type annotations and Pydantic models.
+
+Tradeoff: SeniorMate keeps its explicit route structure, but developers must
+update runtime validation and OpenAPI definitions together.
+
+### API Learning Resources
+
+**Beginner**
+
+- [MDN HTTP Overview](https://developer.mozilla.org/en-US/docs/Web/HTTP/Overview)
+- [Swagger: What Is OpenAPI?](https://swagger.io/docs/specification/v3_0/about/)
+
+**Intermediate**
+
+- [OpenAPI Specification](https://spec.openapis.org/oas/latest.html)
+- [Flasgger Project](https://github.com/flasgger/flasgger)
+
+**Suggested experiments**
+
+1. Open `/api/openapi.json` and locate the patient create operation.
+2. Add an optional query parameter to a learning endpoint and document it.
+3. Compare a validation error from the running API with its documented error
+   schema.
+4. Use Swagger UI to send an authenticated request with a bearer token.
 
 ## Request-to-Response Walkthrough
 
@@ -255,3 +367,62 @@ cd backend
 
 Start with the test that matches the route module you changed, then run the
 full suite.
+
+## Understanding the Design
+
+### Why Flask instead of FastAPI?
+
+This is an architectural comparison, not a record of a formal historical
+decision.
+
+Flask fits SeniorMate because:
+
+- The project already uses explicit route-level validation and Flasgger.
+- The team can see each request step without framework-generated dependency
+  injection or schema behavior.
+- Flask's extension ecosystem matches SQLAlchemy, migrations, CORS, and CLI
+  needs.
+
+FastAPI would offer first-class type-driven validation, dependency injection,
+and generated OpenAPI. That could reduce duplicated runtime/OpenAPI schemas,
+but adopting it would require rewriting routes, authentication hooks, tests,
+and validation around Pydantic/ASGI conventions.
+
+Tradeoff: Flask keeps control and concepts visible, but SeniorMate must
+maintain validation and OpenAPI alignment manually.
+
+## Learning Resources
+
+### Beginner
+
+- [Official Flask Tutorial](https://flask.palletsprojects.com/en/stable/tutorial/)
+- [Flask Quickstart](https://flask.palletsprojects.com/en/stable/quickstart/)
+- [Miguel Grinberg Flask Mega-Tutorial](https://blog.miguelgrinberg.com/post/the-flask-mega-tutorial-part-i-hello-world)
+
+### Intermediate
+
+- [Application Factories](https://flask.palletsprojects.com/en/stable/patterns/appfactories/)
+- [Application Structure and Lifecycle](https://flask.palletsprojects.com/en/stable/lifecycle/)
+- [Blueprints](https://flask.palletsprojects.com/en/stable/blueprints/)
+- [Testing Flask Applications](https://flask.palletsprojects.com/en/stable/testing/)
+- [SQLAlchemy 2.0 Documentation](https://docs.sqlalchemy.org/en/20/)
+- [Alembic Tutorial](https://alembic.sqlalchemy.org/en/latest/tutorial.html)
+
+### Official Documentation
+
+- [Flask Documentation](https://flask.palletsprojects.com/)
+- [Flask API Reference](https://flask.palletsprojects.com/en/stable/api/)
+- [Flask-SQLAlchemy](https://flask-sqlalchemy.palletsprojects.com/)
+- [Flask-Migrate](https://flask-migrate.readthedocs.io/)
+
+## Suggested Flask Experiments
+
+1. Add a public `/api/version` endpoint and test it.
+2. Add a small blueprint with one read-only route, then register it in the
+   factory.
+3. Add an `after_request` callback that sets a safe development-only response
+   header.
+4. Create two test apps with different configuration objects and compare
+   behavior.
+5. Replace fake storage in one test with a deliberately failing adapter and
+   trace the resulting API error.

--- a/docs/learning/platform-engineering-guide.md
+++ b/docs/learning/platform-engineering-guide.md
@@ -5,6 +5,38 @@ example of platform engineering concerns: service orchestration,
 configuration, identity, persistence, delivery automation, and operational
 boundaries.
 
+## What Is Platform Engineering?
+
+Platform engineering creates reusable paths, tools, and infrastructure that
+help developers build and operate software consistently. SeniorMate's current
+platform is small, but its Compose stack, environment contract, identity
+provider, object store, database, and CI workflows form an internal developer
+platform for this application.
+
+The goal is not merely to run containers. It is to make the safe path the
+repeatable path.
+
+## What Is Docker?
+
+Docker packages an application and its runtime dependencies into images and
+runs them as isolated containers. Images are immutable build artifacts;
+containers are running instances.
+
+SeniorMate uses Docker to make Python, Node, PostgreSQL, MinIO, and Keycloak
+versions repeatable across development machines.
+
+Docker concepts in SeniorMate:
+
+| Docker topic | SeniorMate example |
+| --- | --- |
+| Image | `python:3.12-slim`, `node:20-alpine`, PostgreSQL, MinIO, Keycloak |
+| Container | Running `seniormate-backend` or `seniormate-postgres` |
+| Volume | `postgres_data`, `minio_data`, `keycloak_data` |
+| Network | Compose default network and service-name DNS |
+| Port mapping | Host `5001` to backend container `5000` |
+| Bind mount | `./backend:/app` for development source |
+| Compose | `docker-compose.yml` local platform definition |
+
 ## Docker Compose as the Local Platform
 
 `docker-compose.yml` declares the local service graph:
@@ -23,6 +55,14 @@ docker compose up --build
 
 It also describes health dependencies, ports, persistent volumes, source-code
 mounts, and environment injection. This is a developer platform contract.
+
+### Understanding the Docker Design
+
+Compose is appropriate for a single-machine development platform with five
+services and named persistence. Kubernetes would add scheduling, rollout,
+service, secret, and health-management capabilities, but it would add
+substantial local and operational complexity before SeniorMate has a
+production cluster requirement.
 
 ## Environment Variables
 
@@ -82,6 +122,11 @@ docker compose exec backend flask --app run:app db current
 
 ## MinIO Object Storage
 
+### What Is Object Storage?
+
+Object storage keeps binary data as named objects in buckets rather than rows
+or mounted filesystem paths. Each object has a key, bytes, and metadata.
+
 MinIO provides an S3-compatible private bucket. PostgreSQL stores metadata and
 object keys; MinIO stores bytes.
 
@@ -95,7 +140,65 @@ This separation teaches:
 The current adapter automatically creates the bucket on first upload. A
 production platform should provision buckets and policies explicitly.
 
+SeniorMate mapping:
+
+| SeniorMate concept | Object-storage concept |
+| --- | --- |
+| Medical Records | Private objects plus PostgreSQL metadata |
+| Patient Photos | Objects under patient profile keys |
+| Branding Logos | Private branding objects |
+| `MINIO_BUCKET` | Bucket |
+| `storage_object_key` | Object key |
+| Download endpoint | Backend-mediated private object read |
+
+Presigned URLs are time-limited signed links that allow direct object access
+without making a bucket public. SeniorMate currently streams downloads through
+Flask; presigned URLs are a possible future optimization.
+
+### Why MinIO instead of Azure Blob Storage?
+
+MinIO provides S3-compatible object storage that runs locally in Docker
+Compose and avoids requiring a cloud account for development. Azure Blob
+Storage would provide a managed Azure service with platform-native identity,
+durability, and operations, but would make local/offline parity and
+cloud-neutral development more complicated.
+
+Tradeoff: SeniorMate gains portable local storage, while production operators
+must own MinIO provisioning, durability, upgrades, and monitoring unless they
+replace the adapter with a managed S3-compatible service.
+
+### MinIO Learning Resources
+
+**Beginner**
+
+- [MinIO Linux Documentation](https://min.io/docs/minio/linux/index.html)
+- [S3 API Concepts](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
+
+**Intermediate**
+
+- [MinIO Object Management](https://min.io/docs/minio/linux/administration/object-management.html)
+- [MinIO Python SDK](https://min.io/docs/minio/linux/developers/python/minio-py.html)
+
+**Official**
+
+- [MinIO Documentation](https://min.io/docs/)
+
+**Suggested experiments**
+
+1. Upload a medical record and locate its object in the MinIO console.
+2. Compare the PostgreSQL metadata row with the MinIO object key.
+3. Delete an object manually in a disposable environment and observe the
+   download endpoint's missing-object behavior.
+4. Build a short-lived presigned URL in an isolated experiment without
+   replacing the current private download route.
+
 ## Keycloak Identity Provider
+
+### What Is Keycloak?
+
+Keycloak is an open-source identity and access management server. It implements
+standards including OAuth 2.0 and OpenID Connect (OIDC), manages users and
+sessions, issues signed tokens, and provides role/group administration.
 
 Keycloak owns:
 
@@ -115,7 +218,83 @@ The local realm import makes development repeatable. A production platform
 would manage realm configuration as versioned infrastructure, protect admin
 client secrets, use TLS, and define backup/restore procedures.
 
+Key concepts:
+
+- **OAuth 2.0:** Authorization framework for delegated access.
+- **OIDC:** Identity layer on OAuth 2.0 that defines login and identity claims.
+- **JWT:** Signed token format used for SeniorMate access tokens.
+- **Realm:** Isolated Keycloak security domain; SeniorMate uses `seniormate`.
+- **Client:** Application registered with Keycloak.
+- **Roles:** Claims mapped to SeniorMate permissions.
+- **Groups:** Hierarchical user organization available for future org mapping.
+
+SeniorMate mapping:
+
+| SeniorMate concept | Identity concept |
+| --- | --- |
+| Login redirect | OIDC Authorization Code flow with PKCE |
+| `seniormate-frontend` | Public OIDC client |
+| `seniormate-api` | API audience/client |
+| admin/manager/nurse/caregiver/viewer | Realm/client roles and RBAC inputs |
+| Admin -> Users | Keycloak Admin API |
+| JWKS validation | JWT signature verification |
+
+### Why Keycloak instead of Auth0?
+
+Keycloak is self-hostable, open source, locally runnable, and gives SeniorMate
+control over realm configuration and identity data. Auth0 offers a managed
+identity platform with less operational burden, polished hosted experiences,
+and vendor support, but introduces external tenancy, pricing, and provider
+dependency.
+
+Tradeoff: Keycloak reduces vendor lock-in and improves local parity, while the
+SeniorMate operator becomes responsible for upgrades, availability, backup,
+TLS, and security hardening.
+
+### Keycloak Learning Resources
+
+**Beginner**
+
+- [Keycloak Getting Started Guides](https://www.keycloak.org/guides#getting-started)
+- [OpenID Connect Introduction](https://openid.net/connect/)
+
+**Intermediate**
+
+- [Keycloak Server Administration Guide](https://www.keycloak.org/docs/latest/server_admin/)
+- [Keycloak Securing Applications Guide](https://www.keycloak.org/docs/latest/securing_apps/)
+- [OAuth 2.0 Overview](https://oauth.net/2/)
+- [JWT Introduction](https://jwt.io/introduction)
+
+**Official**
+
+- [Keycloak Documentation](https://www.keycloak.org/documentation)
+
+**Suggested experiments**
+
+1. Decode a development access token and locate issuer, audience, expiry, and
+   roles without sharing the token.
+2. Change a demo user's role, log in again, and compare UI/API access.
+3. Temporarily shorten token lifetime in a disposable realm and observe
+   refresh behavior.
+4. Add a learning-only realm group and inspect the resulting token claims.
+
 ## GitHub Actions CI/CD
+
+### What Is GitHub Actions?
+
+GitHub Actions is a workflow automation service integrated with GitHub.
+Workflow YAML files react to events and run jobs on hosted or self-hosted
+runners.
+
+Core concepts:
+
+- **Workflow:** One YAML automation definition.
+- **Event:** Pull request, push, manual dispatch, or another trigger.
+- **Job:** Group of steps executed on one runner.
+- **Runner:** Machine that performs a job.
+- **Action:** Reusable packaged workflow step.
+- **Artifact:** File bundle passed between jobs or retained after a run.
+- **Environment/deployment:** Protected deployment target and recorded release.
 
 Current workflows validate:
 
@@ -134,6 +313,41 @@ Current: source -> test -> build
 Future:  source -> test -> scan -> package -> attest -> deploy -> verify
 ```
 
+SeniorMate mapping:
+
+| SeniorMate concept | GitHub Actions concept |
+| --- | --- |
+| Backend CI | Workflow with lint/test job |
+| Frontend CI | Workflow with npm build job |
+| Docker validation | Workflow using runner Docker |
+| GitHub Pages | Build artifact plus deployment job/environment |
+| PR checks | Pull-request workflow events |
+
+### GitHub Actions Learning Resources
+
+**Beginner**
+
+- [Understanding GitHub Actions](https://docs.github.com/en/actions/about-github-actions/understanding-github-actions)
+- [Quickstart for GitHub Actions](https://docs.github.com/en/actions/writing-workflows/quickstart)
+
+**Intermediate**
+
+- [Workflow Syntax](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions)
+- [Store and Share Data with Artifacts](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts)
+- [Deployments and Environments](https://docs.github.com/en/actions/deployment)
+- [Security Hardening](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions)
+
+**Official**
+
+- [GitHub Actions Documentation](https://docs.github.com/actions)
+
+**Suggested experiments**
+
+1. Add a manual `workflow_dispatch` input to a throwaway branch workflow.
+2. Upload a small generated test report as an artifact.
+3. Add a job dependency and observe execution order.
+4. Compare a failed step, failed job, and skipped dependent job.
+
 ## GitHub Pages
 
 The public site lives in `docs-site/`. Its VitePress base is `/SeniorMate/`
@@ -150,6 +364,9 @@ The workflow:
 
 Repository Pages settings must use GitHub Actions as the source.
 
+GitHub Pages is a deployment example: the build job creates a static artifact,
+and the deploy job publishes it to the `github-pages` environment.
+
 ## Release and Versioning
 
 SeniorMate uses Semantic Versioning. Version `1.0.0` appears in:
@@ -162,6 +379,33 @@ SeniorMate uses Semantic Versioning. Version `1.0.0` appears in:
 
 A release process should keep code version, documentation, tag, and GitHub
 Release aligned.
+
+## Docker Learning Resources
+
+### Beginner
+
+- [Docker Get Started](https://docs.docker.com/get-started/)
+- [Docker Compose Quickstart](https://docs.docker.com/compose/gettingstarted/)
+
+### Intermediate
+
+- [Dockerfile Reference](https://docs.docker.com/reference/dockerfile/)
+- [Compose Networking](https://docs.docker.com/compose/how-tos/networking/)
+- [Volumes](https://docs.docker.com/engine/storage/volumes/)
+- [Build Best Practices](https://docs.docker.com/build/building/best-practices/)
+
+### Official Documentation
+
+- [Docker Documentation](https://docs.docker.com/)
+- [Docker Compose Documentation](https://docs.docker.com/compose/)
+
+### Suggested Docker Experiments
+
+1. Run `docker compose config` and trace one resolved variable.
+2. Enter the backend container and resolve `postgres`, `minio`, and `keycloak`.
+3. Stop/recreate PostgreSQL and prove named-volume persistence.
+4. Rebuild the backend after a requirements change and compare image layers.
+5. Use `docker compose down` versus `down -v` in a disposable environment.
 
 ## Observability Gaps
 

--- a/docs/learning/seniormate-developer-guide.md
+++ b/docs/learning/seniormate-developer-guide.md
@@ -280,12 +280,26 @@ When something fails:
 Use the detailed [Troubleshooting Guide](troubleshooting.md) for symptom-based
 diagnosis.
 
+## Technology Learning Index
+
+Every major technology guide follows the same questions: what it is, why
+SeniorMate uses it, where it lives, what to study, and what to experiment with.
+
+| Technology | Learning section |
+| --- | --- |
+| Flask, SQLAlchemy, Alembic, Flasgger | [Flask Backend Guide](flask-backend-guide.md) |
+| Vue, Vue Router, Vuetify, Vite | [Vue Frontend Guide](vue-frontend-guide.md) |
+| PostgreSQL and relational modeling | [Data Model Walkthrough](data-model-walkthrough.md) |
+| Docker, Compose, MinIO, Keycloak, GitHub Actions | [Platform Engineering Guide](platform-engineering-guide.md) |
+| REST/OpenAPI request behavior | [Request Flows](request-flows.md) and backend guide |
+
 ## Recommended Learning Path
 
-1. Follow the [Code Reading Roadmap](code-reading-roadmap.md).
-2. Read the backend and frontend guides side by side.
-3. Trace one workflow in [Request Flows](request-flows.md).
-4. Run the app and compare logs with the sequence diagram.
-5. Complete a small task in [Learning Exercises](exercises.md).
-6. Write down which boundary surprised you. That is usually the best next
+1. Use the [Eight-Week Study Plan](study-plan.md).
+2. Follow the [Code Reading Roadmap](code-reading-roadmap.md).
+3. Read the backend and frontend guides side by side.
+4. Trace one workflow in [Request Flows](request-flows.md).
+5. Run the app and compare logs with the sequence diagram.
+6. Complete a small task in [Learning Exercises](exercises.md).
+7. Write down which boundary surprised you. That is usually the best next
    topic to study.

--- a/docs/learning/study-plan.md
+++ b/docs/learning/study-plan.md
@@ -1,0 +1,219 @@
+# SeniorMate Eight-Week Study Plan
+
+This plan is designed for a developer with limited Flask and Vue experience.
+Aim for four to six focused hours each week. Keep a learning journal with:
+
+- New terms.
+- Commands used.
+- Request paths traced.
+- Questions and failures.
+- One small artifact or code experiment.
+
+Use fictional/local data only and keep experiments on feature branches.
+
+## Week 1: Docker and Flask Basics
+
+**Study**
+
+- Containers, images, volumes, networks, and Compose.
+- Flask routes, requests, responses, contexts, and blueprints.
+- SeniorMate's app factory and local service graph.
+
+**Read**
+
+- [Docker Get Started](https://docs.docker.com/get-started/)
+- [Docker Compose](https://docs.docker.com/compose/)
+- [Flask Tutorial](https://flask.palletsprojects.com/en/stable/tutorial/)
+- [Flask Backend Guide](flask-backend-guide.md)
+
+**Hands-on**
+
+1. Start the stack and inspect all five services.
+2. Trace `/api/health` from Compose port to Flask route.
+3. Add and test a temporary learning endpoint, then remove it.
+
+**Outcome**
+
+Explain the difference between image/container and host/container addressing.
+
+## Week 2: SQLAlchemy and PostgreSQL
+
+**Study**
+
+- Tables, keys, relationships, indexes, constraints, and transactions.
+- SQLAlchemy model/relationship mapping.
+- Alembic migration history.
+
+**Read**
+
+- [PostgreSQL Tutorial](https://www.postgresql.org/docs/current/tutorial.html)
+- [SQLAlchemy ORM Quick Start](https://docs.sqlalchemy.org/en/20/orm/quickstart.html)
+- [Data Model Walkthrough](data-model-walkthrough.md)
+
+**Hands-on**
+
+1. Inspect the patient and visit tables in `psql`.
+2. Trace model relationships and deletion behavior.
+3. Generate a disposable migration for a nullable learning field.
+
+**Outcome**
+
+Explain how model code, migration code, and the live database differ.
+
+## Week 3: Vue Basics and Vuetify
+
+**Study**
+
+- Components, props, refs, computed state, Composition API, and lifecycle.
+- Vue Router and Vuetify forms/layout.
+
+**Read**
+
+- [Vue Tutorial](https://vuejs.org/tutorial/)
+- [Vue Guide](https://vuejs.org/guide/introduction.html)
+- [Vuetify Documentation](https://vuetifyjs.com/)
+- [Vue Frontend Guide](vue-frontend-guide.md)
+
+**Hands-on**
+
+1. Add a computed display value to a local view.
+2. Build a small Vuetify card and form from static data.
+3. Trace route metadata and a permission guard.
+
+**Outcome**
+
+Explain how reactive state causes the rendered UI to update.
+
+## Week 4: REST APIs and Swagger
+
+**Study**
+
+- HTTP methods and status codes.
+- JSON request/response design.
+- Validation, pagination, and multipart requests.
+- OpenAPI and Swagger UI.
+
+**Read**
+
+- [MDN HTTP Overview](https://developer.mozilla.org/en-US/docs/Web/HTTP/Overview)
+- [OpenAPI Specification](https://spec.openapis.org/oas/latest.html)
+- [Swagger OpenAPI Guide](https://swagger.io/docs/specification/v3_0/about/)
+- [Request Flows](request-flows.md)
+
+**Hands-on**
+
+1. Create a patient in Swagger.
+2. Trigger and inspect a validation error.
+3. Compare one runtime parser with its `app/swagger.py` schema.
+
+**Outcome**
+
+Trace an HTTP request from browser/service to route, model, and response.
+
+## Week 5: Keycloak, OAuth 2.0, OIDC, and JWT
+
+**Study**
+
+- OAuth 2.0 authorization.
+- OIDC identity.
+- Authorization Code with PKCE.
+- JWT claims, signatures, issuer, audience, and expiry.
+- Keycloak realms, clients, roles, and groups.
+
+**Read**
+
+- [Keycloak Getting Started](https://www.keycloak.org/guides#getting-started)
+- [OpenID Connect](https://openid.net/connect/)
+- [OAuth 2.0](https://oauth.net/2/)
+- Platform guide Keycloak section.
+
+**Hands-on**
+
+1. Inspect development realm clients and roles.
+2. Decode a local token safely.
+3. Compare viewer and manager access after fresh login.
+
+**Outcome**
+
+Explain why frontend route guards are not the security boundary.
+
+## Week 6: Reporting and Architecture Review
+
+**Study**
+
+- Aggregation queries.
+- Filters and CSV output.
+- Service boundaries and cross-system workflows.
+- PostgreSQL metadata plus MinIO object storage.
+
+**Read**
+
+- `backend/app/routes/reports.py`
+- [Architecture Overview](../architecture/overview.md)
+- [Request Flows](request-flows.md)
+
+**Hands-on**
+
+1. Trace one report filter into SQLAlchemy conditions.
+2. Compare JSON and CSV report output.
+3. Upload a medical record and map database/object-store state.
+
+**Outcome**
+
+Draw SeniorMate's architecture from memory and explain each boundary.
+
+## Week 7: CI/CD and GitHub Actions
+
+**Study**
+
+- Workflow triggers, jobs, runners, actions, artifacts, and environments.
+- Pull-request validation and GitHub Pages deployment.
+
+**Read**
+
+- [GitHub Actions Documentation](https://docs.github.com/actions)
+- [Understanding GitHub Actions](https://docs.github.com/en/actions/about-github-actions/understanding-github-actions)
+- `.github/workflows/`
+
+**Hands-on**
+
+1. Match every CI step to a local command.
+2. Inspect a workflow run and its job logs.
+3. Add an artifact step on a temporary branch.
+
+**Outcome**
+
+Explain the path from commit to required checks and Pages deployment.
+
+## Week 8: Production Readiness and Platform Engineering
+
+**Study**
+
+- Secrets, TLS, backups, migrations, immutable images, observability, security,
+  deployment safety, and rollback.
+- Platform engineering as a paved path for developers.
+
+**Read**
+
+- [Platform Engineering Guide](platform-engineering-guide.md)
+- [Deployment Guide](../technical/deployment-guide.md)
+- [Backup and Restore](../admin-guide/backup-restore.md)
+
+**Hands-on**
+
+1. Perform a gap assessment using the production-readiness checklist.
+2. Design a staging pipeline without implementing production credentials.
+3. Propose logs, metrics, traces, dashboards, and alerts for one workflow.
+
+**Outcome**
+
+Produce a prioritized production-readiness backlog with risks and owners.
+
+## Continuing After Week 8
+
+Choose one [learning exercise](exercises.md), implement it through a pull
+request, and write a short retrospective:
+
+- What changed across layers?
+- Which test caught the most useful issue?
+- Which boundary should be improved next?

--- a/docs/learning/vue-frontend-guide.md
+++ b/docs/learning/vue-frontend-guide.md
@@ -3,6 +3,46 @@
 This guide explains how the SeniorMate Vue 3 frontend is assembled and how a
 user action becomes an authenticated API request and a UI update.
 
+## What Is Vue?
+
+Vue is a progressive JavaScript framework for building reactive user
+interfaces. It organizes UI into components and automatically updates rendered
+output when reactive state changes.
+
+SeniorMate uses Vue because it supports an approachable component model,
+incremental composition, a mature router, and a strong ecosystem without
+requiring a large frontend framework.
+
+Vue appears throughout `frontend/src/`:
+
+- `main.js` creates and mounts the application.
+- `views/` contains route-level page components.
+- `components/` contains reusable UI components.
+- `router.js` maps URLs to views.
+- `auth.js` and `branding.js` provide reactive shared state.
+
+## What Is Vite?
+
+Vite is the frontend development server and production build tool. It serves
+Vue modules quickly during development and bundles optimized static assets for
+deployment.
+
+SeniorMate uses Vite through `frontend/package.json`, `frontend/vite.config.js`,
+and `VITE_*` environment variables. The local frontend container runs the Vite
+development server, while CI runs the production build.
+
+Compared with the older Vue CLI/Webpack approach, Vite offers faster startup
+and a simpler modern configuration. The tradeoff is that environment variables
+and browser-compatible code must follow Vite conventions.
+
+Resources and experiments:
+
+- [Vite Guide](https://vite.dev/guide/)
+- [Vite Environment Variables](https://vite.dev/guide/env-and-mode)
+- Change a non-secret `VITE_*` value locally and inspect it through
+  `import.meta.env`.
+- Run `npm run build` and inspect the generated `dist/` assets.
+
 ## Application Bootstrap
 
 [`frontend/src/main.js`](../../frontend/src/main.js) is the entry point.
@@ -33,6 +73,17 @@ objects:
 
 Components use JavaScript template strings rather than `.vue` single-file
 components. A view exports an object with `setup()` and `template`.
+
+### Core Vue Concepts in SeniorMate
+
+- **Component architecture:** App, views, and reusable components compose the
+  interface.
+- **Reactive state:** `ref` and `reactive` hold mutable UI/auth data.
+- **Composition API:** `setup()` groups state, computed values, and actions.
+- **Computed state:** Navigation and display values derive from other state.
+- **Lifecycle hooks:** `onMounted()` loads route data after mounting.
+- **Routing:** Vue Router selects views and applies permission guards.
+- **Services pattern:** Plain modules isolate API paths and HTTP details.
 
 ## Router
 
@@ -79,6 +130,33 @@ Reusable UI components standardize common patterns:
 
 Views should reuse these before inventing another local pattern.
 
+## What Is Vuetify?
+
+Vuetify is a Vue component framework implementing Material Design-inspired
+components and layout utilities. SeniorMate uses it to provide accessible,
+consistent tables, forms, dialogs, navigation, cards, grids, and feedback
+states without hand-building every interaction.
+
+Why use a component framework:
+
+- Shared visual and interaction conventions.
+- Responsive grid and spacing utilities.
+- Accessible component behavior as a starting point.
+- Faster delivery for data-heavy administration screens.
+- Central theme/default configuration.
+
+SeniorMate examples:
+
+| SeniorMate UI | Vuetify concept |
+| --- | --- |
+| Patient list | `v-data-table` |
+| Patient form | `v-form`, `v-text-field`, `v-select`, `v-textarea` |
+| Dashboard metrics | Cards and responsive grid |
+| Sidebar | Navigation drawer and lists |
+| Delete confirmation | Dialog and buttons |
+| Status display | Chips |
+| Loading/empty/error states | Skeletons, alerts, progress, reusable wrappers |
+
 ## Views and Components
 
 Views under `src/views/` correspond to router destinations. They own page-level
@@ -111,6 +189,24 @@ A useful split is:
 
 Domain service files such as `patients.js`, `visits.js`, and
 `medicalRecords.js` keep paths and HTTP verbs out of views.
+
+## SeniorMate-to-Vue Map
+
+The repository uses JavaScript filenames rather than the illustrative `.vue`
+or TypeScript names commonly seen in tutorials.
+
+| SeniorMate component | Vue concept |
+| --- | --- |
+| `PatientListView.js` | Routed component/page |
+| `DashboardView.js` | Routed component/page |
+| `PatientAvatar.js` | Reusable component |
+| `router.js` | Vue Router route table and guard |
+| `services/patients.js` | Service/API client module |
+| `auth.js` | Reactive module-level state |
+| `onMounted(loadPatients)` | Lifecycle hook |
+| `computed(...)` rows/navigation | Derived reactive state |
+| `v-if="canCreatePatient()"` | Conditional rendering |
+| `v-model="form.first_name"` | Two-way form binding |
 
 ## State Management
 
@@ -231,3 +327,58 @@ The current frontend has limited unit coverage. Also verify:
 - Desktop and narrow browser widths.
 - No raw API stack traces are shown.
 - No broken image or logo states.
+
+## Understanding the Design
+
+### Why Vue instead of React or Angular?
+
+Vue gives SeniorMate a concise reactive model and component system with less
+framework ceremony than Angular and fewer architectural choices to assemble
+than a typical React stack. The tradeoff is a smaller hiring ecosystem than
+React and fewer enforced application conventions than Angular.
+
+### Why Vuetify instead of PrimeVue?
+
+This is a comparison, not a documented historical selection process.
+
+Vuetify fits because SeniorMate already uses Material Design icons, layout
+utilities, data tables, forms, dialogs, and a centrally customized theme.
+PrimeVue offers a broad component catalog and different theming model, but
+switching would replace nearly every template and visual convention.
+
+Tradeoff: Vuetify accelerates consistent administration UI, but contributes a
+large CSS/JavaScript bundle and makes the product's components closely tied to
+its APIs.
+
+## Learning Resources
+
+### Vue Beginner
+
+- [Vue Interactive Tutorial](https://vuejs.org/tutorial/)
+- [Vue Guide Introduction](https://vuejs.org/guide/introduction.html)
+- [Essentials: Reactivity Fundamentals](https://vuejs.org/guide/essentials/reactivity-fundamentals.html)
+
+### Vue Intermediate
+
+- [Composition API FAQ](https://vuejs.org/guide/extras/composition-api-faq.html)
+- [Reusable Composables](https://vuejs.org/guide/reusability/composables.html)
+- [Vue Router Guide](https://router.vuejs.org/guide/)
+- [Vue Testing Guide](https://vuejs.org/guide/scaling-up/testing.html)
+
+### Official Documentation
+
+- [Vue Documentation](https://vuejs.org/)
+- [Vue Router](https://router.vuejs.org/)
+- [Vuetify Documentation](https://vuetifyjs.com/)
+- [Vite Documentation](https://vite.dev/)
+
+## Suggested Vue and Vuetify Experiments
+
+1. Add a computed patient display name and observe automatic UI updates.
+2. Extract repeated loading/error logic into a small composable.
+3. Add route metadata to a temporary learning route and test the guard.
+4. Build a small Vuetify data table from static data before connecting an API.
+5. Add a form field with `v-model`, local validation, and backend error
+   display.
+6. Change one Vuetify theme color in development and identify every surface it
+   affects.


### PR DESCRIPTION
# Summary

- Expand the Feature 31 learning guides with learning-first explanations for Flask, Vue, Vuetify, Vite, PostgreSQL, MinIO, Keycloak, Docker, GitHub Actions, REST, and OpenAPI.
- Add SeniorMate concept mappings, architecture tradeoffs, staged learning resources, and repository-based experiments.
- Add an eight-week personal study plan and enrich every practical exercise with prerequisite reading and expected skills.

## Related Issue / Task

- Enhancement to Feature 31: developer learning guide

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Documentation
- [ ] Chore / maintenance
- [ ] Refactor

## Testing Performed

- `cd backend && .venv/bin/ruff check app tests`
- `cd backend && .venv/bin/pytest -q` (147 passed)
- `cd frontend && npm run test:permissions` (5 passed)
- `cd frontend && npm run build`
- `cd docs-site && npm run build`
- `docker-compose config -q`
- Validated all relative Markdown links in the learning suite, README, and documentation index.
- Confirmed all 10 exercises include reading resources and expected skills.

## Screenshots

N/A - documentation-only change.

## Checklist

- [x] Changelog updated
- [x] Documentation updated
- [x] Tests or manual validation completed
- [x] No secrets, credentials, or sensitive data included
- [x] PR is ready for maintainer review

## Maintainer Merge Reminder

Only the maintainer merges pull requests into `main`.
